### PR TITLE
Update docs for SuperTokens-based admin auth

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -67,7 +67,7 @@ docker compose run --rm champagnefestival-api alembic upgrade head
 - `WEBSITE_BASE_PATH` controls the website sign-in path on the website domain.
   With the current defaults, that path is `/admin`.
 - `API_BASE_PATH` controls the SuperTokens backend auth/session routes.
-  With the current defaults, those routes live under `/auth/*`, and the dashboard
-  is served at `${API_BASE_PATH}/dashboard` (currently `/auth/dashboard`).
+  With the current defaults, those routes live under `/api/auth/*`, and the dashboard
+  is served at `${API_BASE_PATH}/dashboard` (currently `/api/auth/dashboard`).
 - Backend admin API routes still live under `/api/*` and require a valid
   SuperTokens session with the `admin` role.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -64,6 +64,10 @@ docker compose run --rm champagnefestival-api alembic upgrade head
 
 ## Admin access
 
-- `/admin` uses SuperTokens email/password sign-in on the website domain.
-- Backend admin API routes require a valid session with the SuperTokens `admin` role.
-- The backend also serves the SuperTokens dashboard at `/auth/dashboard`.
+- `WEBSITE_BASE_PATH` controls the website sign-in path on the website domain.
+  With the current defaults, that path is `/admin`.
+- `API_BASE_PATH` controls the SuperTokens backend auth/session routes.
+  With the current defaults, those routes live under `/auth/*`, and the dashboard
+  is served at `${API_BASE_PATH}/dashboard` (currently `/auth/dashboard`).
+- Backend admin API routes still live under `/api/*` and require a valid
+  SuperTokens session with the `admin` role.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -66,4 +66,4 @@ docker compose run --rm champagnefestival-api alembic upgrade head
 
 - `/admin` uses SuperTokens email/password sign-in on the website domain.
 - Backend admin API routes require a valid session with the SuperTokens `admin` role.
-- The shared SuperTokens operator dashboard is exposed separately by the infra stack on `auth.tjor.im`, not by this app.
+- The backend also serves the SuperTokens dashboard at `/auth/dashboard`.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -44,8 +44,13 @@ Key variables:
 | `SUPERTOKENS_API_KEY` | Shared secret between backend SDK and SuperTokens core |
 | `API_DOMAIN` | Public backend origin, e.g. `https://champagnefestival.tjor.im` |
 | `WEBSITE_DOMAIN` | Public frontend origin, e.g. `https://champagnefestival.tjor.im` |
+| `API_BASE_PATH` | SuperTokens API path, default `/api/auth` |
+| `WEBSITE_BASE_PATH` | SuperTokens frontend auth path, default `/admin` |
 | `CORS_ORIGINS` | Comma-separated allowed origins, e.g. `https://champagnefestival.be` |
 | `SMTP_*` | Optional — reservation confirmation emails |
+
+> **Note:** In `production` mode the server validates these at startup and **refuses to start**
+> if `SUPERTOKENS_CONNECTION_URI` or `SUPERTOKENS_API_KEY` is missing.
 
 ## Database migrations
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -39,8 +39,11 @@ Key variables:
 | Variable | Description |
 |---|---|
 | `ENVIRONMENT` | Set to `production` |
-| `ADMIN_TOKEN` | Long random string for admin bearer auth |
-| `DATABASE_URL` | e.g. `sqlite+aiosqlite:////var/data/champagne/champagne.db` |
+| `DATABASE_URL` | e.g. `postgresql+asyncpg://user:password@postgres:5432/champagnefestival` |
+| `SUPERTOKENS_CONNECTION_URI` | e.g. `http://supertokens:3567` |
+| `SUPERTOKENS_API_KEY` | Shared secret between backend SDK and SuperTokens core |
+| `API_DOMAIN` | Public backend origin, e.g. `https://champagnefestival.tjor.im` |
+| `WEBSITE_DOMAIN` | Public frontend origin, e.g. `https://champagnefestival.tjor.im` |
 | `CORS_ORIGINS` | Comma-separated allowed origins, e.g. `https://champagnefestival.be` |
 | `SMTP_*` | Optional — reservation confirmation emails |
 
@@ -58,3 +61,9 @@ docker compose run --rm champagnefestival-api alembic upgrade head
 > docker compose build champagnefestival-api
 > docker compose run --rm champagnefestival-api alembic upgrade head
 > ```
+
+## Admin access
+
+- `/admin` uses SuperTokens email/password sign-in on the website domain.
+- Backend admin API routes require a valid session with the SuperTokens `admin` role.
+- The shared SuperTokens operator dashboard is exposed separately by the infra stack on `auth.tjor.im`, not by this app.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ champagnefestival/
 ```bash
 # Backend (Terminal 1)
 cd backend
-cp .env.example .env          # configure — at minimum set ADMIN_TOKEN
+cp .env.example .env          # configure DATABASE_URL + SuperTokens settings
 uv sync                       # install dependencies
 uv run alembic upgrade head   # run database migrations
 uv run uvicorn app.main:app --reload

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,9 +26,9 @@ API_DOMAIN=http://localhost:8000
 # Default: http://localhost:5173
 WEBSITE_DOMAIN=http://localhost:5173
 
-# Base path for SuperTokens API routes (e.g. /auth/signin, /auth/signout).
-# Default: /auth
-API_BASE_PATH=/auth
+# Base path for SuperTokens API routes (e.g. /api/auth/signin, /api/auth/signout).
+# Default: /api/auth
+API_BASE_PATH=/api/auth
 
 # Base path for SuperTokens frontend routes on the website domain.
 # Default: /admin

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,8 +31,8 @@ WEBSITE_DOMAIN=http://localhost:5173
 API_BASE_PATH=/auth
 
 # Base path for SuperTokens frontend routes on the website domain.
-# Default: /auth
-WEBSITE_BASE_PATH=/auth
+# Default: /admin
+WEBSITE_BASE_PATH=/admin
 
 # ─── Database ────────────────────────────────────────────────────────────────
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -199,7 +199,7 @@ location /api/ {
 | `SUPERTOKENS_API_KEY` | yes in production | `""` | Shared secret for SuperTokens core and dashboard |
 | `API_DOMAIN` | yes in production | `http://localhost:8000` | Public backend origin used by SuperTokens; must be set to the real public API origin in production |
 | `WEBSITE_DOMAIN` | yes in production | `http://localhost:5173` | Public frontend origin used by SuperTokens; must be set to the real public website origin in production |
-| `API_BASE_PATH` | no | `/auth` | SuperTokens API path on the backend |
+| `API_BASE_PATH` | no | `/api/auth` | SuperTokens API path on the backend |
 | `WEBSITE_BASE_PATH` | no | `/admin` | SuperTokens frontend auth path on the website |
 | `CORS_ORIGINS`     | no       | `""`                                                   | Comma-separated allowed origins, e.g. `https://champagnefestival.be` |
 | `MIN_FORM_SECONDS` | no       | `3`                                                    | Anti-spam: min seconds to fill the form                              |
@@ -224,8 +224,8 @@ See `.env.example` for a template.
 - `WEBSITE_BASE_PATH` is the website auth UI path on the website domain.
   With the current defaults, that is `/admin`.
 - `API_BASE_PATH` is the SuperTokens backend auth/session path.
-  With the current defaults, those routes live under `/auth/*`, and the dashboard
-  is served at `${API_BASE_PATH}/dashboard` (currently `/auth/dashboard`).
+  With the current defaults, those routes live under `/api/auth/*`, and the dashboard
+  is served at `${API_BASE_PATH}/dashboard` (currently `/api/auth/dashboard`).
 - Admin API endpoints still live under `/api/*` and require a valid SuperTokens
   session containing the `admin` role.
 - Public endpoints (reservation creation, check-in) do not require admin auth.

--- a/backend/README.md
+++ b/backend/README.md
@@ -183,10 +183,10 @@ location /api/ {
 | ------------------ | -------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
 | `ENVIRONMENT`      | no       | `development`                                          | `development` or `production` — gates startup safety checks          |
 | `DATABASE_URL`     | no       | `postgresql+asyncpg://localhost/champagne`             | Async SQLAlchemy URL                                                 |
-| `SUPERTOKENS_CONNECTION_URI` | no | `""` | SuperTokens core URL; required in production |
-| `SUPERTOKENS_API_KEY` | no | `""` | Shared secret for SuperTokens core and dashboard; required in production |
-| `API_DOMAIN` | no | `http://localhost:8000` | Public backend origin used by SuperTokens |
-| `WEBSITE_DOMAIN` | no | `http://localhost:5173` | Public frontend origin used by SuperTokens |
+| `SUPERTOKENS_CONNECTION_URI` | yes in production | `""` | SuperTokens core URL |
+| `SUPERTOKENS_API_KEY` | yes in production | `""` | Shared secret for SuperTokens core and dashboard |
+| `API_DOMAIN` | yes in production | `http://localhost:8000` | Public backend origin used by SuperTokens; must be set to the real public API origin in production |
+| `WEBSITE_DOMAIN` | yes in production | `http://localhost:5173` | Public frontend origin used by SuperTokens; must be set to the real public website origin in production |
 | `API_BASE_PATH` | no | `/auth` | SuperTokens API path on the backend |
 | `WEBSITE_BASE_PATH` | no | `/admin` | SuperTokens frontend auth path on the website |
 | `CORS_ORIGINS`     | no       | `""`                                                   | Comma-separated allowed origins, e.g. `https://champagnefestival.be` |

--- a/backend/README.md
+++ b/backend/README.md
@@ -211,7 +211,7 @@ See `.env.example` for a template.
 
 - `/admin` uses SuperTokens email/password auth on the website domain.
 - Admin API endpoints require a valid SuperTokens session containing the `admin` role.
-- The shared SuperTokens operator dashboard is exposed separately by the infra stack on `auth.tjor.im`, not by this backend.
+- The backend also serves the SuperTokens dashboard at `/auth/dashboard`.
 - Public endpoints (reservation creation, check-in) do not require admin auth.
 
 ### Endpoints

--- a/backend/README.md
+++ b/backend/README.md
@@ -68,7 +68,7 @@ uv sync
 
 # 3. Configure environment
 cp .env.example .env
-# Edit .env — at minimum set ADMIN_TOKEN and DATABASE_URL
+# Edit .env — at minimum set DATABASE_URL and the SuperTokens settings
 
 # 4. Run database migrations
 uv run alembic upgrade head
@@ -181,9 +181,14 @@ location /api/ {
 
 | Variable           | Required | Default                                                | Description                                                          |
 | ------------------ | -------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
-| `ADMIN_TOKEN`      | **yes**  | —                                                      | Bearer token for admin endpoints (required in production)            |
 | `ENVIRONMENT`      | no       | `development`                                          | `development` or `production` — gates startup safety checks          |
 | `DATABASE_URL`     | no       | `postgresql+asyncpg://localhost/champagne`             | Async SQLAlchemy URL                                                 |
+| `SUPERTOKENS_CONNECTION_URI` | no | `""` | SuperTokens core URL; required in production |
+| `SUPERTOKENS_API_KEY` | no | `""` | Shared secret for SuperTokens core and dashboard; required in production |
+| `API_DOMAIN` | no | `http://localhost:8000` | Public backend origin used by SuperTokens |
+| `WEBSITE_DOMAIN` | no | `http://localhost:5173` | Public frontend origin used by SuperTokens |
+| `API_BASE_PATH` | no | `/auth` | SuperTokens API path on the backend |
+| `WEBSITE_BASE_PATH` | no | `/admin` | SuperTokens frontend auth path on the website |
 | `CORS_ORIGINS`     | no       | `""`                                                   | Comma-separated allowed origins, e.g. `https://champagnefestival.be` |
 | `MIN_FORM_SECONDS` | no       | `3`                                                    | Anti-spam: min seconds to fill the form                              |
 | `GUEST_ACCESS_TOKEN_TTL_MINUTES` | no | `30` | TTL in minutes for short-lived guest access tokens used by `/api/reservations/my/request` and `/api/reservations/my/access` |
@@ -204,8 +209,10 @@ See `.env.example` for a template.
 
 ### Authentication
 
-Admin endpoints require an `Authorization: Bearer <ADMIN_TOKEN>` header.
-Public endpoints (reservation creation, check-in) do not require a token.
+- `/admin` uses SuperTokens email/password auth on the website domain.
+- Admin API endpoints require a valid SuperTokens session containing the `admin` role.
+- The shared SuperTokens operator dashboard is exposed separately by the infra stack on `auth.tjor.im`, not by this backend.
+- Public endpoints (reservation creation, check-in) do not require admin auth.
 
 ### Endpoints
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -84,6 +84,9 @@ uv run uvicorn app.main:app --reload
 
 The interactive API docs are available at <http://localhost:8000/docs>.
 
+On Linux, the backend container relies on Docker's `host-gateway` support so
+`host.docker.internal` resolves correctly for `SUPERTOKENS_CONNECTION_URI`.
+
 ---
 
 ## Development tools
@@ -106,6 +109,15 @@ uv run ty check .
 # Run tests
 uv run pytest
 ```
+
+Tests use a separate database by default:
+
+```bash
+psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE test_champagne;"
+```
+
+They connect to `postgresql+asyncpg://postgres:postgres@localhost:5432/test_champagne`
+unless `TEST_DATABASE_URL` overrides it.
 
 ---
 
@@ -209,9 +221,13 @@ See `.env.example` for a template.
 
 ### Authentication
 
-- `/admin` uses SuperTokens email/password auth on the website domain.
-- Admin API endpoints require a valid SuperTokens session containing the `admin` role.
-- The backend also serves the SuperTokens dashboard at `/auth/dashboard`.
+- `WEBSITE_BASE_PATH` is the website auth UI path on the website domain.
+  With the current defaults, that is `/admin`.
+- `API_BASE_PATH` is the SuperTokens backend auth/session path.
+  With the current defaults, those routes live under `/auth/*`, and the dashboard
+  is served at `${API_BASE_PATH}/dashboard` (currently `/auth/dashboard`).
+- Admin API endpoints still live under `/api/*` and require a valid SuperTokens
+  session containing the `admin` role.
 - Public endpoints (reservation creation, check-in) do not require admin auth.
 
 ### Endpoints

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -16,7 +16,7 @@ async def require_admin(request: Request) -> None:
     ``UserRoleClaim``).
 
     All admin routers use this dependency to gate access.  A valid session is
-    created when the user signs in via the ``/auth/signin`` endpoint provided
+    created when the user signs in via the ``/api/auth/signin`` endpoint provided
     by the SuperTokens middleware.  The ``admin`` role must be assigned to the
     user via the SuperTokens UserRoles recipe.
     """

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -16,7 +16,7 @@ async def require_admin(request: Request) -> None:
     ``UserRoleClaim``).
 
     All admin routers use this dependency to gate access.  A valid session is
-    created when the user signs in via the ``/api/auth/signin`` endpoint provided
+    created when the user signs in via the ``{API_BASE_PATH}/signin`` endpoint provided
     by the SuperTokens middleware.  The ``admin`` role must be assigned to the
     user via the SuperTokens UserRoles recipe.
     """

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,8 +37,8 @@ class Settings(BaseSettings):
     website_domain: str = "http://localhost:5173"
     """Public URL where the frontend is reachable (used by SuperTokens for cookies)."""
 
-    api_base_path: str = "/auth"
-    """Base path for SuperTokens API routes (e.g. /auth/signin, /auth/signout)."""
+    api_base_path: str = "/api/auth"
+    """Base path for SuperTokens API routes (e.g. /api/auth/signin, /api/auth/signout)."""
 
     website_base_path: str = "/admin"
     """Base path for SuperTokens frontend routes on the website domain."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -89,14 +89,14 @@ else:
 
 _supertokens_cors_headers = get_all_cors_headers() if settings.supertokens_connection_uri else []
 
-# SuperTokens middleware handles /api/auth/* routes and session management.
+# SuperTokens middleware handles {api_base_path}/* routes and session management.
 # Added first so it is innermost in the stack.
 # Only added when SuperTokens is configured (has a connection URI).
 if settings.supertokens_connection_uri:
     app.add_middleware(get_middleware())
 
 # CORSMiddleware is added after SuperTokens so it runs outermost, ensuring
-# CORS headers are present on /api/auth/* responses that SuperTokens handles directly.
+# CORS headers are present on {api_base_path}/* responses that SuperTokens handles directly.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -89,14 +89,14 @@ else:
 
 _supertokens_cors_headers = get_all_cors_headers() if settings.supertokens_connection_uri else []
 
-# SuperTokens middleware handles /auth/* routes and session management.
+# SuperTokens middleware handles /api/auth/* routes and session management.
 # Added first so it is innermost in the stack.
 # Only added when SuperTokens is configured (has a connection URI).
 if settings.supertokens_connection_uri:
     app.add_middleware(get_middleware())
 
 # CORSMiddleware is added after SuperTokens so it runs outermost, ensuring
-# CORS headers are present on /auth/* responses that SuperTokens handles directly.
+# CORS headers are present on /api/auth/* responses that SuperTokens handles directly.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,

--- a/backend/app/supertokens_config.py
+++ b/backend/app/supertokens_config.py
@@ -3,7 +3,7 @@
 import logging
 
 from supertokens_python import InputAppInfo, SupertokensConfig, init
-from supertokens_python.recipe import emailpassword, session, userroles
+from supertokens_python.recipe import dashboard, emailpassword, session, userroles
 
 from app.config import settings
 
@@ -41,6 +41,7 @@ def init_supertokens() -> None:
             emailpassword.init(),
             session.init(),
             userroles.init(),
+            dashboard.init(api_key=settings.supertokens_api_key or None),
         ],
     )
-    logger.info("SuperTokens initialized (emailpassword + session + userroles)")
+    logger.info("SuperTokens initialized (emailpassword + session + userroles + dashboard)")

--- a/backend/app/supertokens_config.py
+++ b/backend/app/supertokens_config.py
@@ -37,6 +37,7 @@ def init_supertokens() -> None:
             api_key=settings.supertokens_api_key or None,
         ),
         framework="fastapi",
+        mode="asgi",
         recipe_list=[
             emailpassword.init(),
             session.init(),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,10 @@ packages = ["app"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
+addopts = "-p no:anyio"
+markers = ["anyio: marks tests as anyio-compatible (no-op under asyncio_mode=auto)"]
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=8", "pytest-asyncio>=0.24", "httpx>=0.28", "anyio>=4", "ruff>=0.15.11", "ty>=0.0.31"]
+dev = ["pytest>=8", "pytest-asyncio>=0.26.0", "httpx>=0.28", "anyio>=4", "ruff>=0.15.11", "ty>=0.0.31"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,6 +25,12 @@ TEST_DATABASE_URL = os.environ.get(
 )
 
 
+@pytest.fixture(scope="session")
+def anyio_backend():
+    # Session scope matches the session-scoped `engine` fixture below.
+    return "asyncio"
+
+
 @pytest.fixture(autouse=True)
 def reset_rate_limiter(monkeypatch):
     """Reset the in-memory rate limiter before every test for isolation."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,12 +25,6 @@ TEST_DATABASE_URL = os.environ.get(
 )
 
 
-@pytest.fixture(scope="session")
-def anyio_backend():
-    # Session scope matches the session-scoped `engine` fixture below.
-    return "asyncio"
-
-
 @pytest.fixture(autouse=True)
 def reset_rate_limiter(monkeypatch):
     """Reset the in-memory rate limiter before every test for isolation."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,7 +18,8 @@ TEST_DATABASE_URL = os.environ.get(
     "TEST_DATABASE_URL",
     # Default targets a *separate* test database (test_champagne) so the dev
     # database (champagne, provisioned by docker-compose) is never touched.
-    # Create it once with: psql -U postgres -c "CREATE DATABASE test_champagne;"
+    # Create it once with:
+    #   psql -h localhost -p 5432 -U postgres -c "CREATE DATABASE test_champagne;"
     # Override via TEST_DATABASE_URL env var in CI or custom environments.
     "postgresql+asyncpg://postgres:postgres@localhost:5432/test_champagne",
 )

--- a/backend/tests/test_supertokens_config.py
+++ b/backend/tests/test_supertokens_config.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from app import supertokens_config as st_config
+
+
+def test_init_supertokens_registers_dashboard_recipe(monkeypatch) -> None:
+    recorded: dict[str, object] = {}
+    dashboard_recipe = object()
+    emailpassword_recipe = object()
+    session_recipe = object()
+    userroles_recipe = object()
+
+    monkeypatch.setattr(st_config.settings, "supertokens_connection_uri", "http://supertokens-champagnefestival:3567")
+    monkeypatch.setattr(st_config.settings, "supertokens_api_key", "champagnefestival-api-key")
+    monkeypatch.setattr(st_config.settings, "api_domain", "https://champagnefestival.tjor.im")
+    monkeypatch.setattr(st_config.settings, "website_domain", "https://champagnefestival.tjor.im")
+    monkeypatch.setattr(st_config.settings, "api_base_path", "/auth")
+    monkeypatch.setattr(st_config.settings, "website_base_path", "/admin")
+
+    def fake_init(**kwargs):
+        recorded.update(kwargs)
+
+    monkeypatch.setattr(st_config, "init", fake_init)
+    monkeypatch.setattr(st_config.emailpassword, "init", lambda: emailpassword_recipe)
+    monkeypatch.setattr(st_config.session, "init", lambda: session_recipe)
+    monkeypatch.setattr(st_config.userroles, "init", lambda: userroles_recipe)
+
+    def fake_dashboard_init(*, api_key):
+        recorded["dashboard_api_key"] = api_key
+        return dashboard_recipe
+
+    monkeypatch.setattr(st_config.dashboard, "init", fake_dashboard_init)
+
+    st_config.init_supertokens()
+
+    assert recorded["framework"] == "fastapi"
+    assert recorded["dashboard_api_key"] == "champagnefestival-api-key"
+    assert recorded["recipe_list"] == [
+        emailpassword_recipe,
+        session_recipe,
+        userroles_recipe,
+        dashboard_recipe,
+    ]

--- a/backend/tests/test_supertokens_config.py
+++ b/backend/tests/test_supertokens_config.py
@@ -14,7 +14,7 @@ def test_init_supertokens_registers_dashboard_recipe(monkeypatch) -> None:
     monkeypatch.setattr(st_config.settings, "supertokens_api_key", "champagnefestival-api-key")
     monkeypatch.setattr(st_config.settings, "api_domain", "https://champagnefestival.tjor.im")
     monkeypatch.setattr(st_config.settings, "website_domain", "https://champagnefestival.tjor.im")
-    monkeypatch.setattr(st_config.settings, "api_base_path", "/auth")
+    monkeypatch.setattr(st_config.settings, "api_base_path", "/api/auth")
     monkeypatch.setattr(st_config.settings, "website_base_path", "/admin")
 
     def fake_init(**kwargs):

--- a/backend/tests/test_supertokens_config.py
+++ b/backend/tests/test_supertokens_config.py
@@ -34,6 +34,7 @@ def test_init_supertokens_registers_dashboard_recipe(monkeypatch) -> None:
     st_config.init_supertokens()
 
     assert recorded["framework"] == "fastapi"
+    assert recorded["mode"] == "asgi"
     assert recorded["app_info"].api_domain == "https://champagnefestival.tjor.im"
     assert recorded["app_info"].website_domain == "https://champagnefestival.tjor.im"
     assert recorded["app_info"].api_base_path == "/api/auth"

--- a/backend/tests/test_supertokens_config.py
+++ b/backend/tests/test_supertokens_config.py
@@ -34,6 +34,10 @@ def test_init_supertokens_registers_dashboard_recipe(monkeypatch) -> None:
     st_config.init_supertokens()
 
     assert recorded["framework"] == "fastapi"
+    assert recorded["app_info"].api_domain == "https://champagnefestival.tjor.im"
+    assert recorded["app_info"].website_domain == "https://champagnefestival.tjor.im"
+    assert recorded["app_info"].api_base_path == "/api/auth"
+    assert recorded["app_info"].website_base_path == "/admin"
     assert recorded["dashboard_api_key"] == "champagnefestival-api-key"
     assert recorded["recipe_list"] == [
         emailpassword_recipe,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/champagne
       ENVIRONMENT: development
-      ADMIN_TOKEN: changeme
+      SUPERTOKENS_CONNECTION_URI: http://host.docker.internal:3567
+      SUPERTOKENS_API_KEY: changeme
+      API_DOMAIN: http://localhost:8000
+      WEBSITE_DOMAIN: http://localhost:5173
       CORS_ORIGINS: http://localhost:5173
     depends_on:
       db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
     build: ./backend
     ports:
       - "8000:8000"
+    # Ensure host.docker.internal resolves on Linux too (requires host-gateway support).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/champagne
       ENVIRONMENT: development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/champagne
       ENVIRONMENT: development
       SUPERTOKENS_CONNECTION_URI: http://host.docker.internal:3567
-      SUPERTOKENS_API_KEY: changeme
+      SUPERTOKENS_API_KEY: changeme  # Must match the api_key set in your local SuperTokens core config
       API_DOMAIN: http://localhost:8000
       WEBSITE_DOMAIN: http://localhost:5173
       CORS_ORIGINS: http://localhost:5173

--- a/frontend/src/config/supertokens.ts
+++ b/frontend/src/config/supertokens.ts
@@ -11,7 +11,7 @@ export function initSuperTokens(): void {
       appName: "Champagne Festival",
       apiDomain,
       websiteDomain: window.location.origin,
-      apiBasePath: "/auth",
+      apiBasePath: "/api/auth",
       websiteBasePath: "/admin",
     },
     recipeList: [EmailPassword.init(), Session.init()],

--- a/infra/champagnefestival.env.example
+++ b/infra/champagnefestival.env.example
@@ -15,8 +15,8 @@ API_DOMAIN=https://champagnefestival.tjor.im
 # Public URL where the frontend is reachable.
 WEBSITE_DOMAIN=https://champagnefestival.tjor.im
 
-# Base path for SuperTokens API routes (e.g. /auth/signin, /auth/signout).
-API_BASE_PATH=/auth
+# Base path for SuperTokens API routes (e.g. /api/auth/signin, /api/auth/signout).
+API_BASE_PATH=/api/auth
 
 # Base path for SuperTokens frontend routes on the website domain.
 WEBSITE_BASE_PATH=/admin


### PR DESCRIPTION
## Summary
- remove stale `ADMIN_TOKEN` references from docs and local compose config
- document the current SuperTokens-based admin auth model
- fix the frontend auth path default in the backend env example

## Context
The app now uses SuperTokens sessions and the `admin` role for admin access. The shared operator dashboard is exposed separately by the infra stack on `auth.tjor.im`.
