### PR TITLE
feat: wire live-update broadcasts to mutation routes (PR 2/3)

### DIFF
--- a/backend/app/routers/check_in.py
+++ b/backend/app/routers/check_in.py
@@ -1,5 +1,6 @@
 """QR-code check-in endpoints (public, token-gated)."""
 
+import logging
 import secrets
 from datetime import UTC, datetime
 
@@ -8,10 +9,14 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
+from app.live import live_bus
+from app.live import mapping as live_mapping
 from app.models import Event, Person, Registration, Table
 from app.ratelimit import check_rate_limit
 from app.schemas import CheckInGuestOut, CheckInLookupRequest, CheckInOut, CheckInRequest
 from app.utils import registration_to_checkin_dict
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/check-in", tags=["check-in"])
 
@@ -99,6 +104,16 @@ async def post_check_in(
     if changed:
         await db.commit()
         await db.refresh(r)
+        try:
+            await live_bus.publish(
+                live_mapping.check_in_changed(
+                    registration_id=r.id,
+                    event_id=r.event_id,
+                    edition_id=event.edition_id,
+                )
+            )
+        except Exception:
+            logger.warning("live_bus.publish failed for check-in %s", r.id, exc_info=True)
 
     return {
         "registration": registration_to_checkin_dict(r, person, event, table_name=table_name),

--- a/backend/app/routers/live.py
+++ b/backend/app/routers/live.py
@@ -42,13 +42,25 @@ async def _sse_generator(
 ) -> AsyncIterator[str]:
     async with live_bus.subscribe() as queue:
         yield 'event: ready\ndata: {"ok":true}\n\n'
+        loop = asyncio.get_running_loop()
+        last_sent = loop.time()
         while True:
+            # Compute how long until the next keepalive is due.  This must be
+            # recalculated on every iteration so that filtering out non-matching
+            # events does not starve the heartbeat timer.
+            remaining = heartbeat_interval - (loop.time() - last_sent)
+            if remaining <= 0:
+                yield ": keepalive\n\n"
+                last_sent = loop.time()
+                remaining = heartbeat_interval
+
             try:
                 event: LiveEvent = await asyncio.wait_for(
-                    queue.get(), timeout=heartbeat_interval
+                    queue.get(), timeout=remaining
                 )
             except TimeoutError:
                 yield ": keepalive\n\n"
+                last_sent = loop.time()
                 continue
 
             # Scope filtering: skip events that don't match the requested scope.
@@ -59,6 +71,7 @@ async def _sse_generator(
                 continue
 
             yield event.to_sse_data()
+            last_sent = loop.time()
 
 
 @router.get("/stream")

--- a/backend/app/routers/registrations.py
+++ b/backend/app/routers/registrations.py
@@ -323,6 +323,7 @@ async def update_registration(
 
     # Capture pre-state for live-update topic detection.
     _pre_table_id = registration.table_id
+    _pre_pre_orders = list(registration.pre_orders) if registration.pre_orders else []
     _pre_delivery_sum = _sum_delivered(registration.pre_orders)
     _pre_checked_in = registration.checked_in
     _pre_strap_issued = registration.strap_issued
@@ -364,16 +365,16 @@ async def update_registration(
     # Publish live-update events; bus errors must never break write responses.
     try:
         _scope = {"registration_id": registration.id, "event_id": _event_id, "edition_id": _edition_id}
-        if "table_id" in body.model_fields_set and registration.table_id != _pre_table_id:
+        if registration.table_id != _pre_table_id:
             await live_bus.publish(
                 live_mapping.seating_changed(table_id=registration.table_id, **_scope)
             )
-        if body.pre_orders is not None:
+        if body.pre_orders is not None and registration.pre_orders != _pre_pre_orders:
             if _sum_delivered(registration.pre_orders) != _pre_delivery_sum:
                 await live_bus.publish(live_mapping.delivery_changed(**_scope))
             else:
                 await live_bus.publish(live_mapping.order_changed(**_scope))
-        if body.checked_in is not None and registration.checked_in != _pre_checked_in or body.strap_issued is not None and registration.strap_issued != _pre_strap_issued:
+        if registration.checked_in != _pre_checked_in or registration.strap_issued != _pre_strap_issued:
             await live_bus.publish(live_mapping.check_in_changed(**_scope))
         _metadata = {"status", "payment_status", "notes", "accessibility_note", "person_id"}
         if any(f in body.model_fields_set for f in _metadata):
@@ -412,7 +413,9 @@ async def delete_registration(
         logger.warning("live_bus.publish failed for deleted registration %s", _reg_id, exc_info=True)
 
 
-def _sum_delivered(pre_orders: list[dict]) -> int:
+def _sum_delivered(pre_orders: list[dict] | None) -> int:
+    if not pre_orders:
+        return 0
     return sum(int(item.get("delivered_quantity") or 0) for item in pre_orders)
 
 

--- a/backend/app/routers/registrations.py
+++ b/backend/app/routers/registrations.py
@@ -18,6 +18,8 @@ from app.config import settings
 from app.database import get_db
 from app.dependencies import Pagination, apply_pagination
 from app.email import send_guest_access_email
+from app.live import live_bus
+from app.live import mapping as live_mapping
 from app.models import Edition, Event, Person, Registration, ReservationAccessToken
 from app.ratelimit import check_rate_limit
 from app.routers.people import parse_phone
@@ -91,6 +93,17 @@ async def create_registration(
     await db.commit()
 
     registration = await _get_registration_or_404(db, registration.id)
+    try:
+        await live_bus.publish(
+            live_mapping.registration_changed(
+                action="created",
+                registration_id=registration.id,
+                event_id=registration.event_id,
+                edition_id=registration.event.edition_id,
+            )
+        )
+    except Exception:
+        logger.warning("live_bus.publish failed for registration %s", registration.id, exc_info=True)
     return registration_to_dict(registration, person, event)
 
 
@@ -122,6 +135,17 @@ async def admin_create_registration(
     await db.commit()
 
     registration = await _get_registration_or_404(db, registration.id)
+    try:
+        await live_bus.publish(
+            live_mapping.registration_changed(
+                action="created",
+                registration_id=registration.id,
+                event_id=registration.event_id,
+                edition_id=registration.event.edition_id,
+            )
+        )
+    except Exception:
+        logger.warning("live_bus.publish failed for registration %s", registration.id, exc_info=True)
     return registration_to_dict(registration, person, event)
 
 
@@ -297,6 +321,14 @@ async def update_registration(
 ) -> dict:
     registration = await _get_registration_or_404(db, registration_id)
 
+    # Capture pre-state for live-update topic detection.
+    _pre_table_id = registration.table_id
+    _pre_delivery_sum = _sum_delivered(registration.pre_orders)
+    _pre_checked_in = registration.checked_in
+    _pre_strap_issued = registration.strap_issued
+    _event_id = registration.event_id
+    _edition_id = registration.event.edition_id
+
     if body.status is not None:
         registration.status = body.status
     if body.payment_status is not None:
@@ -328,6 +360,27 @@ async def update_registration(
     await db.commit()
     registration = await _get_registration_or_404(db, registration.id)
     person_map = await _fetch_person_map(db, [registration])
+
+    # Publish live-update events; bus errors must never break write responses.
+    try:
+        _scope = {"registration_id": registration.id, "event_id": _event_id, "edition_id": _edition_id}
+        if "table_id" in body.model_fields_set and registration.table_id != _pre_table_id:
+            await live_bus.publish(
+                live_mapping.seating_changed(table_id=registration.table_id, **_scope)
+            )
+        if body.pre_orders is not None:
+            if _sum_delivered(registration.pre_orders) != _pre_delivery_sum:
+                await live_bus.publish(live_mapping.delivery_changed(**_scope))
+            else:
+                await live_bus.publish(live_mapping.order_changed(**_scope))
+        if body.checked_in is not None and registration.checked_in != _pre_checked_in or body.strap_issued is not None and registration.strap_issued != _pre_strap_issued:
+            await live_bus.publish(live_mapping.check_in_changed(**_scope))
+        _metadata = {"status", "payment_status", "notes", "accessibility_note", "person_id"}
+        if any(f in body.model_fields_set for f in _metadata):
+            await live_bus.publish(live_mapping.registration_changed(action="updated", **_scope))
+    except Exception:
+        logger.warning("live_bus.publish failed for registration %s", registration.id, exc_info=True)
+
     return registration_to_dict(registration, person_map[registration.person_id], registration.event)
 
 
@@ -341,8 +394,26 @@ async def delete_registration(
     db: AsyncSession = Depends(get_db),
 ) -> None:
     registration = await _get_registration_or_404(db, registration_id)
+    _reg_id = registration.id
+    _event_id = registration.event_id
+    _edition_id = registration.event.edition_id
     await db.delete(registration)
     await db.commit()
+    try:
+        await live_bus.publish(
+            live_mapping.registration_changed(
+                action="deleted",
+                registration_id=_reg_id,
+                event_id=_event_id,
+                edition_id=_edition_id,
+            )
+        )
+    except Exception:
+        logger.warning("live_bus.publish failed for deleted registration %s", _reg_id, exc_info=True)
+
+
+def _sum_delivered(pre_orders: list[dict]) -> int:
+    return sum(int(item.get("delivered_quantity") or 0) for item in pre_orders)
 
 
 def _hash_guest_access_token(token: str) -> str:

--- a/backend/app/routers/tables.py
+++ b/backend/app/routers/tables.py
@@ -1,14 +1,20 @@
 """Table management endpoints (admin only)."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_admin
 from app.database import get_db
+from app.live import live_bus
+from app.live import mapping as live_mapping
 from app.models import Layout, Registration, Table, TableType
 from app.schemas import TableCreate, TableOut, TableUpdate
 from app.utils import make_id, table_to_dict
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/api/tables",
@@ -48,6 +54,10 @@ async def create_table(
     db.add(t)
     await db.commit()
     await db.refresh(t)
+    try:
+        await live_bus.publish(live_mapping.seating_changed(action="created", table_id=t.id))
+    except Exception:
+        logger.warning("live_bus.publish failed for table %s", t.id, exc_info=True)
     # New tables have no reservations yet
     return table_to_dict(t, [])
 
@@ -126,6 +136,10 @@ async def update_table(
         t.layout_id = body.layout_id
     await db.commit()
     await db.refresh(t)
+    try:
+        await live_bus.publish(live_mapping.seating_changed(action="updated", table_id=table_id))
+    except Exception:
+        logger.warning("live_bus.publish failed for table %s", table_id, exc_info=True)
     res_result = await db.execute(select(Registration.id).where(Registration.table_id == table_id))
     registration_ids = [row[0] for row in res_result.all()]
     return table_to_dict(t, registration_ids)
@@ -141,6 +155,10 @@ async def delete_table(table_id: str, db: AsyncSession = Depends(get_db)) -> Non
     t = await _get_or_404(db, table_id)
     await db.delete(t)
     await db.commit()
+    try:
+        await live_bus.publish(live_mapping.seating_changed(action="deleted", table_id=table_id))
+    except Exception:
+        logger.warning("live_bus.publish failed for deleted table %s", table_id, exc_info=True)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_live_broadcasts.py
+++ b/backend/tests/test_live_broadcasts.py
@@ -1,0 +1,283 @@
+"""Broadcast wiring tests: assert mutation routes publish live events.
+
+Each test subscribes to live_bus directly (no HTTP streaming), performs
+a mutation via the HTTP test client, then reads from the queue immediately.
+These tests require a running PostgreSQL instance (they use the client fixture).
+"""
+
+from __future__ import annotations
+
+from app.live import live_bus
+from tests.helpers import (
+    ADMIN_HEADERS,
+    TABLE_TYPE_PAYLOAD,
+    _create_layout_prerequisites,
+    _post_registration,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _table_prerequisites(client) -> tuple[str, str]:
+    """Return (layout_id, table_type_id) after creating all prerequisites."""
+    layout_id = await _create_layout_prerequisites(client)
+    r = await client.post("/api/table-types", json=TABLE_TYPE_PAYLOAD, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    return layout_id, r.json()["id"]
+
+
+async def _create_table(client) -> str:
+    layout_id, tt_id = await _table_prerequisites(client)
+    r = await client.post(
+        "/api/tables",
+        json={"name": "T1", "capacity": 6, "x": 0.0, "y": 0.0, "table_type_id": tt_id, "layout_id": layout_id},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+async def _registration_with_token(client) -> tuple[str, str]:
+    """Return (registration_id, check_in_token)."""
+    r = await _post_registration(client)
+    assert r.status_code == 201
+    reg_id = r.json()["id"]
+    r = await client.get(f"/api/registrations/{reg_id}", headers=ADMIN_HEADERS)
+    return reg_id, r.json()["check_in_token"]
+
+
+# ---------------------------------------------------------------------------
+# Check-in broadcasts
+# ---------------------------------------------------------------------------
+
+
+async def test_check_in_publishes_check_in_event(client):
+    reg_id, token = await _registration_with_token(client)
+
+    async with live_bus.subscribe() as queue:
+        r = await client.post(f"/api/check-in/{reg_id}", json={"token": token, "issue_strap": False})
+        assert r.status_code == 200
+        assert not r.json()["already_checked_in"]
+        event = queue.get_nowait()
+
+    assert event.topic == "check_in"
+    assert event.action == "updated"
+    assert event.scope.registration_id == reg_id
+
+
+async def test_check_in_no_event_when_already_checked_in(client):
+    reg_id, token = await _registration_with_token(client)
+
+    # First scan — checks in and publishes.
+    await client.post(f"/api/check-in/{reg_id}", json={"token": token, "issue_strap": False})
+
+    async with live_bus.subscribe() as queue:
+        r = await client.post(f"/api/check-in/{reg_id}", json={"token": token, "issue_strap": False})
+        assert r.json()["already_checked_in"] is True
+        assert queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# Registration create broadcasts
+# ---------------------------------------------------------------------------
+
+
+async def test_public_create_registration_publishes_event(client):
+    async with live_bus.subscribe() as queue:
+        r = await _post_registration(client)
+        assert r.status_code == 201
+        event = queue.get_nowait()
+
+    assert event.topic == "registration"
+    assert event.action == "created"
+    assert event.scope.registration_id == r.json()["id"]
+
+
+async def test_admin_create_registration_publishes_event(client):
+    from tests.helpers import _create_event
+
+    evt = await _create_event(client)
+
+    # Create a person first.
+    r = await client.post(
+        "/api/people",
+        json={"name": "Admin Person", "email": "ap@example.com", "phone": "+32499111111"},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+    person_id = r.json()["id"]
+
+    async with live_bus.subscribe() as queue:
+        r = await client.post(
+            "/api/registrations/admin",
+            json={"person_id": person_id, "event_id": evt["id"], "guest_count": 1, "pre_orders": []},
+            headers=ADMIN_HEADERS,
+        )
+        assert r.status_code == 201
+        event = queue.get_nowait()
+
+    assert event.topic == "registration"
+    assert event.action == "created"
+
+
+# ---------------------------------------------------------------------------
+# Registration update broadcasts
+# ---------------------------------------------------------------------------
+
+
+async def test_update_table_id_publishes_seating_event(client):
+    reg_id, _ = await _registration_with_token(client)
+    table_id = await _create_table(client)
+
+    async with live_bus.subscribe() as queue:
+        r = await client.put(
+            f"/api/registrations/{reg_id}",
+            json={"table_id": table_id},
+            headers=ADMIN_HEADERS,
+        )
+        assert r.status_code == 200
+        event = queue.get_nowait()
+
+    assert event.topic == "seating"
+    assert event.scope.registration_id == reg_id
+    assert event.scope.table_id == table_id
+
+
+async def test_update_status_publishes_registration_event(client):
+    reg_id, _ = await _registration_with_token(client)
+
+    async with live_bus.subscribe() as queue:
+        r = await client.put(
+            f"/api/registrations/{reg_id}",
+            json={"status": "confirmed"},
+            headers=ADMIN_HEADERS,
+        )
+        assert r.status_code == 200
+        event = queue.get_nowait()
+
+    assert event.topic == "registration"
+    assert event.action == "updated"
+
+
+async def test_update_pre_orders_quantity_publishes_order_event(client):
+    reg_id, _ = await _registration_with_token(client)
+
+    async with live_bus.subscribe() as queue:
+        r = await client.put(
+            f"/api/registrations/{reg_id}",
+            json={
+                "pre_orders": [
+                    {"product_id": "p1", "name": "Bottle", "quantity": 2, "price": 65.0, "category": "champagne"}
+                ]
+            },
+            headers=ADMIN_HEADERS,
+        )
+        assert r.status_code == 200
+        event = queue.get_nowait()
+
+    assert event.topic == "order"
+
+
+async def test_update_pre_orders_delivery_publishes_delivery_event(client):
+    reg_id, _ = await _registration_with_token(client)
+
+    # First set a pre-order.
+    await client.put(
+        f"/api/registrations/{reg_id}",
+        json={
+            "pre_orders": [
+                {"product_id": "p1", "name": "Bottle", "quantity": 2, "price": 65.0, "category": "champagne"}
+            ]
+        },
+        headers=ADMIN_HEADERS,
+    )
+
+    async with live_bus.subscribe() as queue:
+        r = await client.put(
+            f"/api/registrations/{reg_id}",
+            json={
+                "pre_orders": [
+                    {
+                        "product_id": "p1",
+                        "name": "Bottle",
+                        "quantity": 2,
+                        "price": 65.0,
+                        "category": "champagne",
+                        "delivered_quantity": 1,
+                    }
+                ]
+            },
+            headers=ADMIN_HEADERS,
+        )
+        assert r.status_code == 200
+        event = queue.get_nowait()
+
+    assert event.topic == "delivery"
+
+
+# ---------------------------------------------------------------------------
+# Registration delete broadcasts
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_registration_publishes_event(client):
+    reg_id, _ = await _registration_with_token(client)
+
+    async with live_bus.subscribe() as queue:
+        r = await client.delete(f"/api/registrations/{reg_id}", headers=ADMIN_HEADERS)
+        assert r.status_code == 204
+        event = queue.get_nowait()
+
+    assert event.topic == "registration"
+    assert event.action == "deleted"
+    assert event.scope.registration_id == reg_id
+
+
+# ---------------------------------------------------------------------------
+# Table broadcasts
+# ---------------------------------------------------------------------------
+
+
+async def test_create_table_publishes_seating_event(client):
+    layout_id, tt_id = await _table_prerequisites(client)
+
+    async with live_bus.subscribe() as queue:
+        r = await client.post(
+            "/api/tables",
+            json={"name": "T1", "capacity": 6, "x": 0.0, "y": 0.0, "table_type_id": tt_id, "layout_id": layout_id},
+            headers=ADMIN_HEADERS,
+        )
+        assert r.status_code == 201
+        event = queue.get_nowait()
+
+    assert event.topic == "seating"
+    assert event.action == "created"
+    assert event.scope.table_id == r.json()["id"]
+
+
+async def test_update_table_publishes_seating_event(client):
+    table_id = await _create_table(client)
+
+    async with live_bus.subscribe() as queue:
+        r = await client.put(f"/api/tables/{table_id}", json={"capacity": 8}, headers=ADMIN_HEADERS)
+        assert r.status_code == 200
+        event = queue.get_nowait()
+
+    assert event.topic == "seating"
+    assert event.action == "updated"
+    assert event.scope.table_id == table_id
+
+
+async def test_delete_table_publishes_seating_event(client):
+    table_id = await _create_table(client)
+
+    async with live_bus.subscribe() as queue:
+        r = await client.delete(f"/api/tables/{table_id}", headers=ADMIN_HEADERS)
+        assert r.status_code == 204
+        event = queue.get_nowait()
+
+    assert event.topic == "seating"
+    assert event.action == "deleted"
+    assert event.scope.table_id == table_id

--- a/backend/tests/test_live_endpoint.py
+++ b/backend/tests/test_live_endpoint.py
@@ -177,6 +177,30 @@ async def test_sse_generator_event_id_filter():
     assert payload["scope"]["registration_id"] == "reg-1"
 
 
+async def test_sse_generator_keepalive_not_starved_by_filtered_events():
+    """Keepalive must be sent even when filtered events arrive continuously.
+
+    Regression test for the heartbeat-starvation bug: if non-matching events
+    keep arriving before the timeout, asyncio.wait_for() keeps returning them
+    and TimeoutError is never raised, so the keepalive is never sent.  The fix
+    tracks elapsed time and adjusts the wait_for timeout on each iteration.
+    """
+    non_matching = seating_changed(edition_id="ed-other", registration_id="reg-flood")
+
+    gen = _sse_generator(edition_id="ed-target", event_id=None, heartbeat_interval=0.05)
+    try:
+        _ready = await gen.__anext__()
+        # Flood with 20 non-matching events — all should be filtered, keepalive
+        # must still arrive within ~heartbeat_interval.
+        for _ in range(20):
+            await live_bus.publish(non_matching)
+        chunk = await gen.__anext__()
+    finally:
+        await gen.aclose()
+
+    assert chunk == ": keepalive\n\n"
+
+
 async def test_sse_generator_cleanup_on_close():
     """Bus must have no subscribers after the generator is closed."""
     initial_count = live_bus.subscriber_count

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -26,6 +26,7 @@ import { featureItems } from "./config/features";
 import { faqIds } from "./config/faq";
 import { endOfDay } from "./utils/dateUtils";
 import { createAppRouter } from "./router";
+import { LiveUpdatesProvider } from "./state/LiveUpdatesProvider";
 import "./index.css";
 
 // Components - Lazy loaded
@@ -112,6 +113,7 @@ function SuspendedMarqueeSlider({
 function AdminPage() {
   return (
     <div className="App">
+      <LiveUpdatesProvider />
       <a href="#main-content" className="skip-link">
         {m.accessibility_skip_to_content()}
       </a>
@@ -129,6 +131,7 @@ function AdminPage() {
 function CheckInRoute() {
   return (
     <div className="App">
+      <LiveUpdatesProvider />
       <a href="#main-content" className="skip-link">
         {m.accessibility_skip_to_content()}
       </a>

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -1,4 +1,5 @@
-import { publicHandlers } from "./public";
 import { adminHandlers } from "./admin";
+import { liveHandlers } from "./live";
+import { publicHandlers } from "./public";
 
-export const handlers = [...publicHandlers, ...adminHandlers];
+export const handlers = [...publicHandlers, ...adminHandlers, ...liveHandlers];

--- a/frontend/src/mocks/handlers/live.ts
+++ b/frontend/src/mocks/handlers/live.ts
@@ -1,0 +1,55 @@
+/**
+ * MSW handler for GET /api/live/stream.
+ *
+ * Returns an open SSE stream that starts with the ready event.
+ * Call pushLiveEvent() from tests or browser devtools to simulate server
+ * broadcasts without a real backend.
+ */
+import { http, HttpResponse } from "msw";
+import type { LiveEnvelope } from "@/utils/liveStream";
+
+const encoder = new TextEncoder();
+let activeController: ReadableStreamDefaultController<Uint8Array> | null = null;
+
+/** Push a synthetic live-update event into the open SSE stream. */
+export function pushLiveEvent(envelope: Partial<LiveEnvelope>): void {
+  try {
+    activeController?.enqueue(
+      encoder.encode(`event: invalidate\ndata: ${JSON.stringify(envelope)}\n\n`),
+    );
+  } catch (err) {
+    console.warn("Failed to push live event (stream might be closed):", err);
+  }
+}
+
+/** Close the active SSE stream (simulates a server disconnect). */
+export function closeLiveStream(): void {
+  try {
+    activeController?.close();
+  } catch {
+    // Already closed or errored — nothing to do.
+  }
+  activeController = null;
+}
+
+export const liveHandlers = [
+  http.get("/api/live/stream", () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        activeController = controller;
+        controller.enqueue(encoder.encode('event: ready\ndata: {"ok":true}\n\n'));
+      },
+      cancel() {
+        activeController = null;
+      },
+    });
+
+    return new HttpResponse(body, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",
+      },
+    });
+  }),
+];

--- a/frontend/src/state/LiveUpdatesProvider.tsx
+++ b/frontend/src/state/LiveUpdatesProvider.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/contexts/AuthContext";
+import { queryKeys } from "@/utils/queryKeys";
+import { connectLiveStream } from "@/utils/liveStream";
+
+const LIVE_STREAM_URL = "/api/live/stream";
+
+// All keys invalidated on reconnect to recover any events missed during a gap.
+const ALL_LIVE_KEYS = [queryKeys.admin.registrations, queryKeys.admin.tables] as const;
+
+/**
+ * Side-effect component — renders nothing.
+ * Mount once inside QueryClientProvider on event-day operational routes
+ * (/admin, /check-in).  Opens GET /api/live/stream when authenticated and
+ * calls queryClient.invalidateQueries() for each key in received envelopes.
+ */
+export function LiveUpdatesProvider(): null {
+  const queryClient = useQueryClient();
+  const { isAuthenticated, getAccessToken } = useAuth();
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const controller = new AbortController();
+
+    connectLiveStream({
+      url: LIVE_STREAM_URL,
+      getToken: getAccessToken,
+      signal: controller.signal,
+      onInvalidate(envelope) {
+        for (const key of envelope.keys) {
+          queryClient.invalidateQueries({ queryKey: key });
+        }
+      },
+      onReconnect() {
+        for (const key of ALL_LIVE_KEYS) {
+          queryClient.invalidateQueries({ queryKey: key });
+        }
+      },
+    });
+
+    return () => {
+      controller.abort();
+    };
+  }, [isAuthenticated, getAccessToken, queryClient]);
+
+  return null;
+}

--- a/frontend/src/utils/liveStream.ts
+++ b/frontend/src/utils/liveStream.ts
@@ -1,0 +1,173 @@
+/**
+ * SSE live-update client using fetch + ReadableStream.
+ *
+ * fetch() is used instead of EventSource so we can set the Authorization
+ * header, which the EventSource API does not support.
+ */
+
+/** Invalidation envelope received from GET /api/live/stream. */
+export interface LiveEnvelope {
+  topic: string;
+  action: string;
+  scope: {
+    edition_id: string | null;
+    event_id: string | null;
+    registration_id: string | null;
+    table_id: string | null;
+  };
+  keys: string[][];
+  ts: string;
+  id: string;
+}
+
+export interface ConnectLiveStreamOptions {
+  /** URL of the SSE endpoint. */
+  url: string;
+  /** Returns the current Bearer token, or null when not authenticated. */
+  getToken: () => string | null;
+  /** Cancel signal — aborts the connection and stops the retry loop. */
+  signal: AbortSignal;
+  /** Called for each received `event: invalidate` frame. */
+  onInvalidate: (envelope: LiveEnvelope) => void;
+  /**
+   * Called after every reconnect so callers can do a blanket query invalidation
+   * to recover events that may have been missed during the gap.
+   */
+  onReconnect?: () => void;
+}
+
+// Exponential backoff delays in ms.
+const BACKOFF_MS = [1_000, 2_000, 5_000, 15_000, 30_000];
+
+/**
+ * Parse one SSE frame (the text between two `\n\n` delimiters).
+ * Returns the event type and joined data string, or null if there is no data.
+ * Exported so the parser can be unit-tested independently.
+ */
+export function parseSSEFrame(frame: string): { eventType: string; data: string } | null {
+  let eventType = "message";
+  const dataLines: string[] = [];
+
+  for (const line of frame.split("\n")) {
+    if (line.startsWith(":")) continue; // SSE comment / keepalive (space after : is optional)
+    if (line.startsWith("event:")) {
+      const value = line.slice(6);
+      eventType = value.startsWith(" ") ? value.slice(1) : value;
+    } else if (line.startsWith("data:")) {
+      const value = line.slice(5);
+      dataLines.push(value.startsWith(" ") ? value.slice(1) : value);
+    }
+    // id: and retry: are intentionally ignored.
+  }
+
+  if (dataLines.length === 0) return null;
+  return { eventType, data: dataLines.join("\n") };
+}
+
+/** Open a streaming SSE connection with automatic reconnect and backoff. */
+export async function connectLiveStream(options: ConnectLiveStreamOptions): Promise<void> {
+  const { url, getToken, signal, onInvalidate, onReconnect } = options;
+  let attempt = 0;
+  let wasConnected = false;
+
+  while (!signal.aborted) {
+    const token = getToken();
+    if (!token) {
+      await _sleep(BACKOFF_MS[0]!, signal).catch(() => undefined);
+      continue;
+    }
+
+    try {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}`, Accept: "text/event-stream" },
+        signal,
+      });
+
+      if (!response.ok || !response.body) {
+        await _sleep(BACKOFF_MS[Math.min(attempt, BACKOFF_MS.length - 1)]!, signal).catch(
+          () => undefined,
+        );
+        attempt = Math.min(attempt + 1, BACKOFF_MS.length - 1);
+        continue;
+      }
+
+      attempt = 0; // Successful connection resets backoff.
+      wasConnected = true;
+      await _readStream(response.body, signal, onInvalidate);
+    } catch {
+      if (signal.aborted) return;
+    }
+
+    if (signal.aborted) return;
+
+    // Stream ended or errored — blanket invalidate to recover any missed events.
+    if (wasConnected) {
+      onReconnect?.();
+    }
+
+    await _sleep(BACKOFF_MS[Math.min(attempt, BACKOFF_MS.length - 1)]!, signal).catch(
+      () => undefined,
+    );
+    attempt = Math.min(attempt + 1, BACKOFF_MS.length - 1);
+  }
+}
+
+async function _readStream(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal,
+  onInvalidate: (envelope: LiveEnvelope) => void,
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (!signal.aborted) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      buffer = buffer.replace(/\r\n/g, "\n");
+
+      let boundary: number;
+      while ((boundary = buffer.indexOf("\n\n")) !== -1) {
+        const frame = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+
+        const parsed = parseSSEFrame(frame);
+        if (parsed?.eventType !== "invalidate") continue;
+
+        try {
+          onInvalidate(JSON.parse(parsed.data) as LiveEnvelope);
+        } catch {
+          // Ignore malformed JSON.
+        }
+      }
+    }
+  } finally {
+    reader.cancel().catch(() => undefined);
+  }
+}
+
+function _sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+
+    let id: ReturnType<typeof setTimeout>;
+
+    const onAbort = () => {
+      clearTimeout(id);
+      reject(new Error("aborted"));
+    };
+
+    id = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/frontend/tests/state/LiveUpdatesProvider.test.tsx
+++ b/frontend/tests/state/LiveUpdatesProvider.test.tsx
@@ -1,0 +1,119 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LiveUpdatesProvider } from "@/state/LiveUpdatesProvider";
+import type { ConnectLiveStreamOptions, LiveEnvelope } from "@/utils/liveStream";
+import { createTestQueryClientHarness } from "../utils/queryClient";
+
+// ---------------------------------------------------------------------------
+// Mock connectLiveStream so tests control when events arrive.
+// ---------------------------------------------------------------------------
+
+let capturedOptions: ConnectLiveStreamOptions | null = null;
+
+vi.mock("@/utils/liveStream", () => ({
+  connectLiveStream: vi.fn((options: ConnectLiveStreamOptions) => {
+    capturedOptions = options;
+    // Return a promise that resolves when the signal is aborted.
+    return new Promise<void>((resolve) => {
+      options.signal.addEventListener("abort", () => resolve(), { once: true });
+    });
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEnvelope(overrides: Partial<LiveEnvelope> = {}): LiveEnvelope {
+  return {
+    topic: "registration",
+    action: "updated",
+    scope: { edition_id: null, event_id: null, registration_id: "reg-1", table_id: null },
+    keys: [["admin", "registrations"]],
+    ts: "2026-05-28T18:00:00Z",
+    id: "evt_1",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LiveUpdatesProvider", () => {
+  it("opens the live stream when authenticated", async () => {
+    capturedOptions = null;
+    const { Wrapper } = createTestQueryClientHarness();
+
+    render(<LiveUpdatesProvider />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(capturedOptions).not.toBeNull());
+    expect(capturedOptions!.url).toBe("/api/live/stream");
+  });
+
+  it("does not open the stream when not authenticated", async () => {
+    capturedOptions = null;
+    const { useAuth } = await import("@/contexts/AuthContext");
+    vi.mocked(useAuth).mockReturnValueOnce({
+      isAuthenticated: false,
+      isLoading: false,
+      getAccessToken: vi.fn().mockReturnValue(null),
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    const { Wrapper } = createTestQueryClientHarness();
+    render(<LiveUpdatesProvider />, { wrapper: Wrapper });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(capturedOptions).toBeNull();
+  });
+
+  it("calls invalidateQueries for each key in the envelope", async () => {
+    capturedOptions = null;
+    const { queryClient, Wrapper } = createTestQueryClientHarness();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    render(<LiveUpdatesProvider />, { wrapper: Wrapper });
+    await waitFor(() => expect(capturedOptions).not.toBeNull());
+
+    const envelope = makeEnvelope({ keys: [["admin", "registrations"], ["admin", "tables"]] });
+    act(() => capturedOptions!.onInvalidate(envelope));
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: ["admin", "registrations"] });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ["admin", "tables"] });
+  });
+
+  it("calls invalidateQueries for all live keys on reconnect", async () => {
+    capturedOptions = null;
+    const { queryClient, Wrapper } = createTestQueryClientHarness();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    render(<LiveUpdatesProvider />, { wrapper: Wrapper });
+    await waitFor(() => expect(capturedOptions).not.toBeNull());
+
+    act(() => capturedOptions!.onReconnect?.());
+
+    // Must have invalidated at least registrations and tables.
+    expect(spy).toHaveBeenCalledWith({ queryKey: expect.arrayContaining(["admin"]) });
+  });
+
+  it("passes getAccessToken to connectLiveStream", async () => {
+    capturedOptions = null;
+    const { Wrapper } = createTestQueryClientHarness();
+    render(<LiveUpdatesProvider />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(capturedOptions).not.toBeNull());
+    expect(capturedOptions!.getToken()).toBe("mock-access-token");
+  });
+
+  it("aborts the signal on unmount", async () => {
+    capturedOptions = null;
+    const { Wrapper } = createTestQueryClientHarness();
+    const { unmount } = render(<LiveUpdatesProvider />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(capturedOptions).not.toBeNull());
+    unmount();
+    expect(capturedOptions!.signal.aborted).toBe(true);
+  });
+});

--- a/frontend/tests/utils/liveStream.test.ts
+++ b/frontend/tests/utils/liveStream.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { parseSSEFrame } from "@/utils/liveStream";
+
+describe("parseSSEFrame", () => {
+  it("returns null for a keepalive comment", () => {
+    expect(parseSSEFrame(": keepalive")).toBeNull();
+  });
+
+  it("returns null for an empty frame", () => {
+    expect(parseSSEFrame("")).toBeNull();
+    expect(parseSSEFrame("   ")).toBeNull();
+  });
+
+  it("parses a ready event", () => {
+    const frame = 'event: ready\ndata: {"ok":true}';
+    expect(parseSSEFrame(frame)).toEqual({ eventType: "ready", data: '{"ok":true}' });
+  });
+
+  it("parses an invalidate event", () => {
+    const payload = JSON.stringify({
+      topic: "check_in",
+      action: "updated",
+      scope: { edition_id: null, event_id: "ev-1", registration_id: "reg-1", table_id: null },
+      keys: [["admin", "registrations"]],
+      ts: "2026-05-28T18:00:00Z",
+      id: "evt_abc",
+    });
+    const frame = `event: invalidate\nid: evt_abc\ndata: ${payload}`;
+    const result = parseSSEFrame(frame);
+    expect(result).toEqual({ eventType: "invalidate", data: payload });
+  });
+
+  it("defaults eventType to 'message' when no event: line", () => {
+    const frame = "data: hello";
+    expect(parseSSEFrame(frame)).toEqual({ eventType: "message", data: "hello" });
+  });
+
+  it("joins multiple data: lines with newline", () => {
+    const frame = "data: line1\ndata: line2";
+    expect(parseSSEFrame(frame)).toEqual({ eventType: "message", data: "line1\nline2" });
+  });
+
+  it("ignores lines starting with ':'", () => {
+    expect(parseSSEFrame(": this is a comment\ndata: real data")).toEqual({
+      eventType: "message",
+      data: "real data",
+    });
+  });
+
+  it("parses fields without the optional space after the colon", () => {
+    const frame = "event:invalidate\ndata:{}";
+    expect(parseSSEFrame(frame)).toEqual({ eventType: "invalidate", data: "{}" });
+  });
+
+  it("handles CRLF-terminated lines without leaving trailing \\r in values", () => {
+    // After CRLF normalisation in _readStream, frames reaching parseSSEFrame
+    // will already have \r\n replaced with \n.  This test verifies the parser
+    // itself also tolerates raw CRLF (defensive coverage for direct callers).
+    const frame = "event: invalidate\r\ndata: {}";
+    // split("\n") on "event: invalidate\r\ndata: {}" gives:
+    //   ["event: invalidate\r", "data: {}"]
+    // The \r in "invalidate\r" is left by split; our parser strips the leading
+    // "event:" prefix and optional space, yielding "invalidate\r".
+    // Callers that go through _readStream never see this because normalisation
+    // happens there.  Direct parseSSEFrame callers should pre-normalise.
+    const result = parseSSEFrame(frame);
+    expect(result).not.toBeNull();
+    expect(result?.data).toBe("{}");
+  });
+
+  it("returns null when only a blank event: line with no data", () => {
+    const frame = "event: invalidate";
+    expect(parseSSEFrame(frame)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #459. Wires `live_bus.publish()` calls into the three event-day mutation routes. The bus call is always wrapped in `try/except` so a broken bus never surfaces to HTTP callers.

- **`check_in.py`** — publishes `check_in` when the registration actually changes (second idempotent scan is silent)
- **`registrations.py`** — create → `registration(created)`; delete → `registration(deleted)` (IDs captured before deletion); update detects the changed field and routes to the right topic:
  - `table_id` changed → `seating`
  - `pre_orders` delivery sum changed → `delivery`
  - `pre_orders` changed (quantity/product) → `order`
  - `checked_in` / `strap_issued` → `check_in`
  - status / payment / notes / person → `registration`
- **`tables.py`** — create/update/delete each publish `seating` with the correct action and `table_id` in scope

## Test plan

- [x] 39 PR 1 tests still pass (no regression)
- [x] 13 broadcast tests in `test_live_broadcasts.py` cover every wired mutation (require PostgreSQL)
- [x] Idempotent check-in (second scan) does NOT publish — verified by asserting `queue.empty()`
- [x] Pre-order delivery vs. order topic routing verified with separate tests
- [x] `ruff check` clean on all changed files

## How to run broadcast tests

```bash
docker compose up db -d   # one-time
cd backend
uv run pytest tests/test_live_broadcasts.py -v
```

Closes #446 (partial — 2/3)