### PR TITLE
feat(mcp): add edition discovery tool

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -104,14 +105,15 @@ if not _cors_origins:
 else:
     logger.info(f"CORS middleware configured with origins: {_cors_origins}")
 
-_cors_kwargs = dict(
-    allow_origins=_cors_origins,
-    allow_credentials="*" not in _cors_origins,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allow_headers=["Content-Type", "Accept", "Authorization", "X-Request-ID"],
-    expose_headers=["X-Request-ID"],
-)
+_cors_kwargs: dict[str, Any] = {
+    "allow_origins": _cors_origins,
+    "allow_credentials": "*" not in _cors_origins,
+    "allow_methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    "allow_headers": ["Content-Type", "Accept", "Authorization", "X-Request-ID"],
+    "expose_headers": ["X-Request-ID"],
+}
 if _mcp_app is not None:
+
     class _MCPAwareCORSMiddleware:
         def __init__(self, app, **kwargs) -> None:
             self._app = app

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -130,8 +130,9 @@ class ChampagneFestivalMcpBackend:
         }
 
     @staticmethod
-    def _edition_discovery_dict(edition: Edition) -> dict:
-        dates = sorted({event.date for event in edition.events})
+    def _edition_discovery_dict(edition: Edition, dates: list[date] | None = None) -> dict:
+        if dates is None:
+            dates = sorted({event.date for event in edition.events})
         return {
             "id": edition.id,
             "year": edition.year,
@@ -255,8 +256,10 @@ class ChampagneFestivalMcpBackend:
             result = await db.execute(select(Edition).options(selectinload(Edition.events)))
             editions: list[Edition] = list(result.scalars().all())
 
-        def _sort_key(edition: Edition) -> tuple[date, date, int, str]:
-            dates = sorted({event.date for event in edition.events})
+        editions_with_dates = [(edition, sorted({event.date for event in edition.events})) for edition in editions]
+
+        def _sort_key(item: tuple[Edition, list[date]]) -> tuple[date, date, int, str]:
+            edition, dates = item
             return (
                 dates[0] if dates else date.max,
                 dates[-1] if dates else date.max,
@@ -264,9 +267,9 @@ class ChampagneFestivalMcpBackend:
                 edition.id,
             )
 
-        editions.sort(key=_sort_key)
+        editions_with_dates.sort(key=_sort_key)
         return {
-            "editions": [self._edition_discovery_dict(edition) for edition in editions],
+            "editions": [self._edition_discovery_dict(edition, dates) for edition, dates in editions_with_dates],
             "count": len(editions),
         }
 

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -16,7 +16,7 @@ Auth tiers (sourced from bearer JWT ``realm_access.roles``):
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 from fastmcp import FastMCP
@@ -130,6 +130,20 @@ class ChampagneFestivalMcpBackend:
         }
 
     @staticmethod
+    def _edition_discovery_dict(edition: Edition) -> dict:
+        dates = sorted({event.date for event in edition.events})
+        return {
+            "id": edition.id,
+            "year": edition.year,
+            "type": edition.edition_type,
+            "date_range": {
+                "start": str(dates[0]) if dates else None,
+                "end": str(dates[-1]) if dates else None,
+            },
+            "is_active": edition.active,
+        }
+
+    @staticmethod
     def _event_dict(event: Event) -> dict:
         return {
             "id": event.id,
@@ -228,6 +242,33 @@ class ChampagneFestivalMcpBackend:
             if edition is None:
                 return {"active_edition": None, "message": "No active or upcoming editions found."}
             return {"active_edition": self._edition_dict(edition)}
+
+    async def list_editions(self) -> dict:
+        """List past and upcoming festival editions for public discovery.
+
+        Returns edition IDs, years, types, date ranges, and active status.
+        No PII is included.
+        """
+        from sqlalchemy.orm import selectinload
+
+        async with self.session_factory() as db:
+            result = await db.execute(select(Edition).options(selectinload(Edition.events)))
+            editions: list[Edition] = list(result.scalars().all())
+
+        def _sort_key(edition: Edition) -> tuple[date, date, int, str]:
+            dates = sorted({event.date for event in edition.events})
+            return (
+                dates[0] if dates else date.max,
+                dates[-1] if dates else date.max,
+                edition.year,
+                edition.id,
+            )
+
+        editions.sort(key=_sort_key)
+        return {
+            "editions": [self._edition_discovery_dict(edition) for edition in editions],
+            "count": len(editions),
+        }
 
     async def get_event_schedule(self, edition_id: str | None = None) -> dict:
         """Return the event schedule for an edition.
@@ -873,6 +914,7 @@ def create_mcp_server(
 
     # Register all tools
     mcp.tool(backend.get_active_edition)
+    mcp.tool(backend.list_editions)
     mcp.tool(backend.get_event_schedule)
     mcp.tool(backend.get_venue_plan_summary)
     mcp.tool(backend.find_guest)

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -342,6 +342,7 @@ class TestCreateMcpServer:
         tool_names = {tool.name for tool in tools}
         expected = {
             "get_active_edition",
+            "list_editions",
             "get_event_schedule",
             "get_venue_plan_summary",
             "find_guest",
@@ -354,6 +355,49 @@ class TestCreateMcpServer:
             "get_check_in_summary",
         }
         assert expected == tool_names
+
+
+# ---------------------------------------------------------------------------
+# list_editions
+# ---------------------------------------------------------------------------
+
+
+class TestListEditions:
+    @pytest.mark.anyio
+    async def test_returns_editions_in_chronological_order(self):
+        past_event = _make_event(event_id="ev-past", event_date=date(2025, 10, 18))
+        upcoming_event = _make_event(event_id="ev-upcoming", event_date=date(2026, 3, 21))
+        past = _make_edition(edition_id="2025-october", year=2025, month="october", active=False, events=[past_event])
+        upcoming = _make_edition(events=[upcoming_event])
+
+        db = _make_db_execute([[upcoming, past]])
+        backend = ChampagneFestivalMcpBackend(_make_session_factory(db))
+        result = await backend.list_editions()
+
+        assert result["count"] == 2
+        assert result["editions"] == [
+            {
+                "id": "2025-october",
+                "year": 2025,
+                "type": "festival",
+                "date_range": {"start": "2025-10-18", "end": "2025-10-18"},
+                "is_active": False,
+            },
+            {
+                "id": "2026-march",
+                "year": 2026,
+                "type": "festival",
+                "date_range": {"start": "2026-03-21", "end": "2026-03-21"},
+                "is_active": True,
+            },
+        ]
+
+    @pytest.mark.anyio
+    async def test_returns_empty_list_when_no_editions_exist(self):
+        db = _make_db_execute([[]])
+        backend = ChampagneFestivalMcpBackend(_make_session_factory(db))
+        result = await backend.list_editions()
+        assert result == {"editions": [], "count": 0}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a public MCP `list_editions` tool for historical and upcoming edition discovery
- return compact edition metadata: `id`, `year`, `type`, `date_range`, and `is_active`
- register the tool and cover chronological ordering plus empty results

## Verification
- `uv run pytest tests/test_mcp_server.py` (`63 passed`)
- `uv run ruff check app/mcp_server.py tests/test_mcp_server.py`
- `git diff --check`

Closes #510