### PR TITLE
fix(mcp): validate guest search parameters

### DIFF
--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -401,6 +401,8 @@ class ChampagneFestivalMcpBackend:
         """
         role = self._require_volunteer()
 
+        name = name.strip() if name else None
+        email = email.strip() if email else None
         if not name and not email:
             raise ValueError("Provide at least one of 'name' or 'email' to search.")
 
@@ -410,7 +412,7 @@ class ChampagneFestivalMcpBackend:
             if name:
                 filters.append(Person.name.ilike(f"%{name}%"))
             if email:
-                filters.append(Person.email == email.lower().strip())
+                filters.append(Person.email == email.lower())
 
             stmt = stmt.where(or_(*filters)).order_by(Person.name).limit(50)
             result = await db.execute(stmt)

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -402,7 +402,7 @@ class ChampagneFestivalMcpBackend:
         role = self._require_volunteer()
 
         if not name and not email:
-            return {"guests": [], "message": "Provide at least one of 'name' or 'email' to search."}
+            raise ValueError("Provide at least one of 'name' or 'email' to search.")
 
         async with self.session_factory() as db:
             stmt = select(Person)

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -506,13 +506,13 @@ class TestFindGuest:
             await backend.find_guest(name="Jean")
 
     @pytest.mark.anyio
-    async def test_find_guest_without_params_returns_empty(self):
+    async def test_find_guest_without_params_raises_validation_error(self):
         backend = ChampagneFestivalMcpBackend(MagicMock())
-        token = _make_access_token(["volunteer"])
-        with patch.object(mcp_module, "get_access_token", return_value=token):
-            result = await backend.find_guest()
-        assert result["guests"] == []
-        assert "message" in result
+        with (
+            patch.object(backend, "_require_volunteer", return_value="volunteer"),
+            pytest.raises(ValueError, match="Provide at least one of 'name' or 'email' to search"),
+        ):
+            await backend.find_guest()
 
     @pytest.mark.anyio
     async def test_find_guest_returns_results_for_volunteer(self):

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -515,6 +515,15 @@ class TestFindGuest:
             await backend.find_guest()
 
     @pytest.mark.anyio
+    async def test_find_guest_with_whitespace_only_params_raises_validation_error(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        with (
+            patch.object(backend, "_require_volunteer", return_value="volunteer"),
+            pytest.raises(ValueError, match="Provide at least one of 'name' or 'email' to search"),
+        ):
+            await backend.find_guest(name="  ", email="  ")
+
+    @pytest.mark.anyio
     async def test_find_guest_returns_results_for_volunteer(self):
         person = _make_person(name="Jean Dupont", email="jean@example.com")
         db = _make_db_execute([[person]])


### PR DESCRIPTION
## Summary
- reject `find_guest` calls that provide neither `name` nor `email`
- raise a descriptive validation error instead of returning an empty result
- cover the validation path with an auth-independent regression test

## Test plan
- `uv run pytest tests/test_mcp_server.py::TestFindGuest -q`

Closes #511