### PR TITLE
Add operational lookup and table resolution

### DIFF
--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/lookup/GuestLookupScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/lookup/GuestLookupScreen.kt
@@ -25,7 +25,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import be.champagnefestival.android.R
 import be.champagnefestival.android.data.model.CheckInGuestOut
 import be.champagnefestival.android.ui.components.ErrorContent
 import be.champagnefestival.android.ui.components.LoadingContent
@@ -60,7 +62,7 @@ fun GuestLookupScreen(
                     viewModel.search(query = query, eventId = eventId)
                 },
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("Search guest, email, table, event, or order") },
+                label = { Text(stringResource(R.string.search_guest_label)) },
                 singleLine = true,
             )
             OutlinedTextField(
@@ -76,7 +78,7 @@ fun GuestLookupScreen(
                 singleLine = true,
             )
             when (val state = uiState) {
-                GuestLookupUiState.Idle -> Text("Search by guest, email, table, event, or order detail.")
+                GuestLookupUiState.Idle -> Text(stringResource(R.string.search_guest_idle_message))
                 GuestLookupUiState.Loading -> LoadingContent(modifier = Modifier.weight(1f))
                 is GuestLookupUiState.Error -> ErrorContent(message = state.message, onRetry = { viewModel.search(query, eventId) }, modifier = Modifier.weight(1f))
                 is GuestLookupUiState.Success -> LookupResults(registrations = state.registrations, padding = PaddingValues(vertical = 8.dp))

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/lookup/GuestLookupScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/lookup/GuestLookupScreen.kt
@@ -60,7 +60,7 @@ fun GuestLookupScreen(
                     viewModel.search(query = query, eventId = eventId)
                 },
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("Search by guest name or table") },
+                label = { Text("Search guest, email, table, event, or order") },
                 singleLine = true,
             )
             OutlinedTextField(
@@ -76,7 +76,7 @@ fun GuestLookupScreen(
                 singleLine = true,
             )
             when (val state = uiState) {
-                GuestLookupUiState.Idle -> Text("Search for guests by name or filter by event ID.")
+                GuestLookupUiState.Idle -> Text("Search by guest, email, table, event, or order detail.")
                 GuestLookupUiState.Loading -> LoadingContent(modifier = Modifier.weight(1f))
                 is GuestLookupUiState.Error -> ErrorContent(message = state.message, onRetry = { viewModel.search(query, eventId) }, modifier = Modifier.weight(1f))
                 is GuestLookupUiState.Success -> LookupResults(registrations = state.registrations, padding = PaddingValues(vertical = 8.dp))

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Champagne Festival</string>
+    <string name="search_guest_label">Search guest, email, table, event, or order</string>
+    <string name="search_guest_idle_message">Search by guest, email, table, event, or order detail.</string>
 </resources>

--- a/backend/alembic/versions/005_operational_search.py
+++ b/backend/alembic/versions/005_operational_search.py
@@ -12,7 +12,6 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 
 from alembic import op
-
 from app.operational_search_schema import OPERATIONAL_SEARCH_SCHEMA_STATEMENTS
 
 revision: str = "005"

--- a/backend/alembic/versions/005_operational_search.py
+++ b/backend/alembic/versions/005_operational_search.py
@@ -1,0 +1,41 @@
+"""Add indexed normalized fields for authenticated operational search.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-05-31
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+from app.operational_search_schema import OPERATIONAL_SEARCH_SCHEMA_STATEMENTS
+
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("people", sa.Column("search_name", sa.String(200), nullable=False, server_default=""))
+    op.add_column("people", sa.Column("search_name_alt", sa.String(200), nullable=False, server_default=""))
+    op.add_column("people", sa.Column("search_email", sa.String(200), nullable=False, server_default=""))
+    for statement in OPERATIONAL_SEARCH_SCHEMA_STATEMENTS:
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_people_search_email_trgm")
+    op.execute("DROP INDEX IF EXISTS ix_people_search_email")
+    op.execute("DROP INDEX IF EXISTS ix_people_search_name_alt_trgm")
+    op.execute("DROP INDEX IF EXISTS ix_people_search_name_trgm")
+    op.execute("DROP TRIGGER IF EXISTS people_operational_search_values ON people")
+    op.execute("DROP FUNCTION IF EXISTS update_person_operational_search_values()")
+    op.drop_column("people", "search_email")
+    op.drop_column("people", "search_name_alt")
+    op.drop_column("people", "search_name")

--- a/backend/alembic/versions/005_operational_search.py
+++ b/backend/alembic/versions/005_operational_search.py
@@ -12,19 +12,51 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 
 from alembic import op
-from app.operational_search_schema import OPERATIONAL_SEARCH_SCHEMA_STATEMENTS
 
 revision: str = "005"
 down_revision: str | None = "004"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+# Frozen copy of the schema statements — intentionally not imported from
+# app.operational_search_schema so this migration remains self-contained.
+_SCHEMA_STATEMENTS = (
+    "CREATE EXTENSION IF NOT EXISTS unaccent",
+    "CREATE EXTENSION IF NOT EXISTS pg_trgm",
+    "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch",
+    """
+    CREATE OR REPLACE FUNCTION update_person_operational_search_values() RETURNS trigger
+    LANGUAGE plpgsql AS $$
+    BEGIN
+        NEW.search_name := trim(regexp_replace(lower(unaccent(NEW.name)), '[^[:alnum:]]+', ' ', 'g'));
+        NEW.search_name_alt := trim(regexp_replace(lower(unaccent(
+            replace(replace(replace(replace(lower(NEW.name), 'ä', 'ae'), 'ö', 'oe'), 'ü', 'ue'), 'ß', 'ss')
+        )), '[^[:alnum:]]+', ' ', 'g'));
+        NEW.search_email := lower(NEW.email);
+        RETURN NEW;
+    END;
+    $$;
+    """,
+    "DROP TRIGGER IF EXISTS people_operational_search_values ON people",
+    """
+    CREATE TRIGGER people_operational_search_values
+    BEFORE INSERT OR UPDATE OF name, email ON people
+    FOR EACH ROW EXECUTE FUNCTION update_person_operational_search_values()
+    """,
+    # Fire the BEFORE UPDATE trigger for every existing row to populate the new columns.
+    "UPDATE people SET name = name, email = email",
+    "CREATE INDEX IF NOT EXISTS ix_people_search_name_trgm ON people USING gin (search_name gin_trgm_ops)",
+    "CREATE INDEX IF NOT EXISTS ix_people_search_name_alt_trgm ON people USING gin (search_name_alt gin_trgm_ops)",
+    "CREATE INDEX IF NOT EXISTS ix_people_search_email ON people (search_email)",
+    "CREATE INDEX IF NOT EXISTS ix_people_search_email_trgm ON people USING gin (search_email gin_trgm_ops)",
+)
+
 
 def upgrade() -> None:
     op.add_column("people", sa.Column("search_name", sa.String(200), nullable=False, server_default=""))
     op.add_column("people", sa.Column("search_name_alt", sa.String(200), nullable=False, server_default=""))
     op.add_column("people", sa.Column("search_email", sa.String(200), nullable=False, server_default=""))
-    for statement in OPERATIONAL_SEARCH_SCHEMA_STATEMENTS:
+    for statement in _SCHEMA_STATEMENTS:
         op.execute(statement)
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import AsyncGenerator
 
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.orm import DeclarativeBase
 
 from app.config import settings
+from app.operational_search_schema import OPERATIONAL_SEARCH_SCHEMA_STATEMENTS
 
 logger = logging.getLogger(__name__)
 
@@ -41,3 +43,5 @@ async def create_tables() -> None:
     """Create all tables on startup (used when Alembic is not run yet)."""
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        for statement in OPERATIONAL_SEARCH_SCHEMA_STATEMENTS:
+            await conn.execute(text(statement))

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -429,10 +429,11 @@ class ChampagneFestivalMcpBackend:
                     select(Registration)
                     .where(Registration.person_id.in_(person_ids))
                     .order_by(Registration.created_at.desc())
-                    .limit(250)
                 )
                 for registration in registrations_result.scalars().all():
-                    registrations_by_person.setdefault(registration.person_id, []).append(registration)
+                    bucket = registrations_by_person.setdefault(registration.person_id, [])
+                    if len(bucket) < DEFAULT_RESULT_LIMIT:
+                        bucket.append(registration)
             ranked = [
                 (
                     best_person_match(
@@ -603,7 +604,7 @@ class ChampagneFestivalMcpBackend:
             raise ValueError("Provide a table reference to resolve.")
 
         async with self.session_factory() as db:
-            tables_result = await db.execute(select(Table).order_by(Table.name).limit(250))
+            tables_result = await db.execute(select(Table).order_by(Table.name))
             ranked = [
                 (match, table)
                 for table in tables_result.scalars().all()
@@ -651,7 +652,7 @@ class ChampagneFestivalMcpBackend:
 
         async with self.session_factory() as db:
             if not table_id and table_reference:
-                tables_result = await db.execute(select(Table).order_by(Table.name).limit(250))
+                tables_result = await db.execute(select(Table).order_by(Table.name))
                 candidates = [
                     table
                     for table in tables_result.scalars().all()

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -672,7 +672,8 @@ class ChampagneFestivalMcpBackend:
                         ),
                     }
                 table_id = candidates[0].id
-            assert table_id is not None
+            if table_id is None:
+                raise ValueError("table_id could not be resolved.")
             # Verify table exists
             table_result = await db.execute(select(Table).where(Table.id == table_id))
             table: Table | None = table_result.scalar_one_or_none()

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -21,11 +21,18 @@ from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_access_token
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.config import settings
 from app.models import Edition, Event, Layout, Person, Registration, Table, Venue
+from app.services.operational_search import (
+    DEFAULT_RESULT_LIMIT,
+    best_person_match,
+    person_search_order_by,
+    person_search_predicate,
+    rank_table_reference,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -407,20 +414,61 @@ class ChampagneFestivalMcpBackend:
             raise ValueError("Provide at least one of 'name' or 'email' to search.")
 
         async with self.session_factory() as db:
-            stmt = select(Person)
-            filters = []
-            if name:
-                filters.append(Person.name.ilike(f"%{name}%"))
-            if email:
-                filters.append(Person.email == email.lower())
-
-            stmt = stmt.where(or_(*filters)).order_by(Person.name).limit(50)
+            stmt = (
+                select(Person)
+                .where(person_search_predicate(name=name, email=email))
+                .order_by(*person_search_order_by(name=name, email=email))
+                .limit(DEFAULT_RESULT_LIMIT + 1)
+            )
             result = await db.execute(stmt)
             persons: list[Person] = list(result.scalars().all())
+            person_ids = [person.id for person in persons[:DEFAULT_RESULT_LIMIT]]
+            registrations_by_person: dict[str, list[Registration]] = {}
+            if person_ids:
+                registrations_result = await db.execute(
+                    select(Registration)
+                    .where(Registration.person_id.in_(person_ids))
+                    .order_by(Registration.created_at.desc())
+                    .limit(250)
+                )
+                for registration in registrations_result.scalars().all():
+                    registrations_by_person.setdefault(registration.person_id, []).append(registration)
+            ranked = [
+                (
+                    best_person_match(
+                        name=name,
+                        email=email,
+                        candidate_name=person.name,
+                        candidate_email=person.email,
+                    ),
+                    person,
+                )
+                for person in persons
+            ]
 
             return {
-                "guests": [self._person_dict(p, role=role) for p in persons],
-                "count": len(persons),
+                "guests": [
+                    {
+                        **self._person_dict(person, role=role),
+                        "match": (
+                            {"field": match.field, "kind": match.kind}
+                            if match is not None
+                            else {"field": "name" if name else "email", "kind": "fuzzy"}
+                        ),
+                        "registrations": [
+                            {
+                                "registration_id": registration.id,
+                                "event_id": registration.event_id,
+                                "table_id": registration.table_id,
+                                "status": registration.status,
+                            }
+                            for registration in registrations_by_person.get(person.id, [])[:DEFAULT_RESULT_LIMIT]
+                        ],
+                    }
+                    for match, person in ranked[:DEFAULT_RESULT_LIMIT]
+                ],
+                "count": min(len(ranked), DEFAULT_RESULT_LIMIT),
+                "has_more": len(persons) > DEFAULT_RESULT_LIMIT,
             }
 
     async def get_guest_registration(self, registration_id: str) -> dict:
@@ -543,7 +591,46 @@ class ChampagneFestivalMcpBackend:
 
             return {"tables": result_tables, "count": len(result_tables)}
 
-    async def get_table_order_summary(self, table_id: str) -> dict:
+    async def resolve_table_reference(self, reference: str) -> dict:
+        """Resolve a visible table number, name, or label to internal table IDs.
+
+        Matching is deterministic: nearby numeric values are never treated as
+        typo suggestions. Requires the ``volunteer`` or ``admin`` role.
+        """
+        self._require_volunteer()
+        reference = reference.strip()
+        if not reference:
+            raise ValueError("Provide a table reference to resolve.")
+
+        async with self.session_factory() as db:
+            tables_result = await db.execute(select(Table).order_by(Table.name).limit(250))
+            ranked = [
+                (match, table)
+                for table in tables_result.scalars().all()
+                if (match := rank_table_reference(reference, table_id=table.id, table_name=table.name)) is not None
+            ]
+            ranked.sort(key=lambda item: (item[0], item[1].name, item[1].id))
+            candidates = [
+                {
+                    "table_id": table.id,
+                    "table_name": table.name,
+                    "layout_id": table.layout_id,
+                    "capacity": table.capacity,
+                    "match": {"kind": match.kind},
+                }
+                for match, table in ranked[:DEFAULT_RESULT_LIMIT]
+            ]
+            return {
+                "tables": candidates,
+                "count": len(candidates),
+                "has_more": len(ranked) > DEFAULT_RESULT_LIMIT,
+            }
+
+    async def get_table_order_summary(
+        self,
+        table_id: str | None = None,
+        table_reference: str | None = None,
+    ) -> dict:
         """Return the order summary for all registrations at a specific table.
 
         Lists each registration's order items (champagne, food, other) with
@@ -553,11 +640,39 @@ class ChampagneFestivalMcpBackend:
         Parameters
         ----------
         table_id:
-            The table ID to query orders for.
+            The internal table ID to query orders for.
+        table_reference:
+            A visible table number, name, or label. Used only when ``table_id``
+            is omitted. Ambiguous references return candidates for selection.
         """
         role = self._require_volunteer()
+        if not table_id and not table_reference:
+            raise ValueError("Provide 'table_id' or 'table_reference'.")
 
         async with self.session_factory() as db:
+            if not table_id and table_reference:
+                tables_result = await db.execute(select(Table).order_by(Table.name).limit(250))
+                candidates = [
+                    table
+                    for table in tables_result.scalars().all()
+                    if rank_table_reference(table_reference, table_id=table.id, table_name=table.name) is not None
+                ]
+                if len(candidates) != 1:
+                    return {
+                        "table_reference": table_reference,
+                        "registrations": [],
+                        "candidates": [
+                            {"table_id": table.id, "table_name": table.name}
+                            for table in candidates[:DEFAULT_RESULT_LIMIT]
+                        ],
+                        "message": (
+                            "No table matched this reference."
+                            if not candidates
+                            else "Multiple tables matched this reference; choose a table_id."
+                        ),
+                    }
+                table_id = candidates[0].id
+            assert table_id is not None
             # Verify table exists
             table_result = await db.execute(select(Table).where(Table.id == table_id))
             table: Table | None = table_result.scalar_one_or_none()
@@ -925,6 +1040,7 @@ def create_mcp_server(
     mcp.tool(backend.find_guest)
     mcp.tool(backend.get_guest_registration)
     mcp.tool(backend.get_table_seating)
+    mcp.tool(backend.resolve_table_reference)
     mcp.tool(backend.get_table_order_summary)
     mcp.tool(backend.get_guest_order_status)
     mcp.tool(backend.get_champagne_delivery_summary)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -320,6 +320,12 @@ class Person(Base):
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     name: Mapped[str] = mapped_column(String(200))
     email: Mapped[str] = mapped_column(String(200), default="")
+    search_name: Mapped[str] = mapped_column(String(200), default="")
+    """Trigger-maintained unaccented lower-case name for operational lookup."""
+    search_name_alt: Mapped[str] = mapped_column(String(200), default="")
+    """Trigger-maintained German-transliteration variant for operational lookup."""
+    search_email: Mapped[str] = mapped_column(String(200), default="")
+    """Trigger-maintained lower-case email for authorized operational lookup."""
     phone: Mapped[str] = mapped_column(String(50), default="")
     address: Mapped[str] = mapped_column(String(300), default="")
     roles: Mapped[list[str]] = mapped_column(JSON, default=list)

--- a/backend/app/operational_search_schema.py
+++ b/backend/app/operational_search_schema.py
@@ -23,8 +23,8 @@ OPERATIONAL_SEARCH_SCHEMA_STATEMENTS = (
     BEFORE INSERT OR UPDATE OF name, email ON people
     FOR EACH ROW EXECUTE FUNCTION update_person_operational_search_values()
     """,
-    # Fire the BEFORE UPDATE trigger for every existing row to populate the new columns.
-    "UPDATE people SET name = name, email = email",
+    # Fire the BEFORE UPDATE trigger for rows whose derived columns haven't been populated yet.
+    "UPDATE people SET name = name, email = email WHERE search_name = ''",
     "CREATE INDEX IF NOT EXISTS ix_people_search_name_trgm ON people USING gin (search_name gin_trgm_ops)",
     "CREATE INDEX IF NOT EXISTS ix_people_search_name_alt_trgm ON people USING gin (search_name_alt gin_trgm_ops)",
     "CREATE INDEX IF NOT EXISTS ix_people_search_email ON people (search_email)",

--- a/backend/app/operational_search_schema.py
+++ b/backend/app/operational_search_schema.py
@@ -1,0 +1,31 @@
+"""Database bootstrap statements for indexed operational person lookup."""
+
+OPERATIONAL_SEARCH_SCHEMA_STATEMENTS = (
+    "CREATE EXTENSION IF NOT EXISTS unaccent",
+    "CREATE EXTENSION IF NOT EXISTS pg_trgm",
+    "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch",
+    """
+    CREATE OR REPLACE FUNCTION update_person_operational_search_values() RETURNS trigger
+    LANGUAGE plpgsql AS $$
+    BEGIN
+        NEW.search_name := trim(regexp_replace(lower(unaccent(NEW.name)), '[^[:alnum:]]+', ' ', 'g'));
+        NEW.search_name_alt := trim(regexp_replace(lower(unaccent(
+            replace(replace(replace(replace(lower(NEW.name), 'ä', 'ae'), 'ö', 'oe'), 'ü', 'ue'), 'ß', 'ss')
+        )), '[^[:alnum:]]+', ' ', 'g'));
+        NEW.search_email := lower(NEW.email);
+        RETURN NEW;
+    END;
+    $$;
+    """,
+    "DROP TRIGGER IF EXISTS people_operational_search_values ON people",
+    """
+    CREATE TRIGGER people_operational_search_values
+    BEFORE INSERT OR UPDATE OF name, email ON people
+    FOR EACH ROW EXECUTE FUNCTION update_person_operational_search_values()
+    """,
+    "UPDATE people SET name = name, email = email",
+    "CREATE INDEX IF NOT EXISTS ix_people_search_name_trgm ON people USING gin (search_name gin_trgm_ops)",
+    "CREATE INDEX IF NOT EXISTS ix_people_search_name_alt_trgm ON people USING gin (search_name_alt gin_trgm_ops)",
+    "CREATE INDEX IF NOT EXISTS ix_people_search_email ON people (search_email)",
+    "CREATE INDEX IF NOT EXISTS ix_people_search_email_trgm ON people USING gin (search_email gin_trgm_ops)",
+)

--- a/backend/app/operational_search_schema.py
+++ b/backend/app/operational_search_schema.py
@@ -23,6 +23,7 @@ OPERATIONAL_SEARCH_SCHEMA_STATEMENTS = (
     BEFORE INSERT OR UPDATE OF name, email ON people
     FOR EACH ROW EXECUTE FUNCTION update_person_operational_search_values()
     """,
+    # Fire the BEFORE UPDATE trigger for every existing row to populate the new columns.
     "UPDATE people SET name = name, email = email",
     "CREATE INDEX IF NOT EXISTS ix_people_search_name_trgm ON people USING gin (search_name gin_trgm_ops)",
     "CREATE INDEX IF NOT EXISTS ix_people_search_name_alt_trgm ON people USING gin (search_name_alt gin_trgm_ops)",

--- a/backend/app/routers/people.py
+++ b/backend/app/routers/people.py
@@ -12,6 +12,12 @@ from app.database import get_db
 from app.dependencies import Pagination, apply_pagination
 from app.models import Event, Exhibitor, Person, Registration
 from app.schemas import PersonCreate, PersonOut, PersonUpdate
+from app.services.operational_search import (
+    DEFAULT_RESULT_LIMIT,
+    bounded_limit,
+    person_search_order_by,
+    person_search_predicate,
+)
 from app.utils import make_id, person_to_dict, registration_to_list_dict, roles_contains
 
 router = APIRouter(
@@ -151,13 +157,12 @@ async def list_people(
     if role:
         stmt = stmt.where(roles_contains(role))
 
-    if q:
-        q_escaped = q.strip().replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+    if q and (q_stripped := q.strip()):
+        q_escaped = q_stripped.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
         q_like = f"%{q_escaped}%"
         stmt = stmt.where(
             or_(
-                Person.name.ilike(q_like, escape="\\"),
-                Person.email.ilike(q_like, escape="\\"),
+                person_search_predicate(name=q_stripped, email=q_stripped),
                 Person.phone.ilike(q_like, escape="\\"),
                 Person.address.ilike(q_like, escape="\\"),
                 Person.national_register_number.ilike(q_like, escape="\\"),
@@ -167,9 +172,12 @@ async def list_people(
                 cast(Person.roles, Text).ilike(q_like, escape="\\"),
             )
         )
-
-    stmt = stmt.order_by(Person.created_at.desc(), Person.id.desc())
-    stmt = apply_pagination(stmt, pagination)
+        limit = bounded_limit(pagination.limit or DEFAULT_RESULT_LIMIT)
+        stmt = stmt.order_by(*person_search_order_by(name=q_stripped, email=q_stripped))
+        stmt = stmt.offset((pagination.page - 1) * limit).limit(limit)
+    else:
+        stmt = stmt.order_by(Person.created_at.desc(), Person.id.desc())
+        stmt = apply_pagination(stmt, pagination)
 
     result = await db.execute(stmt)
     rows = result.scalars().all()

--- a/backend/app/routers/registrations.py
+++ b/backend/app/routers/registrations.py
@@ -8,7 +8,7 @@ import secrets
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import delete, func, or_, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -35,6 +35,12 @@ from app.schemas import (
     RegistrationOut,
     RegistrationOutWithToken,
     RegistrationUpdate,
+)
+from app.services.operational_search import (
+    DEFAULT_RESULT_LIMIT,
+    bounded_limit,
+    person_search_order_by,
+    person_search_predicate,
 )
 from app.spam import check_form_timing, check_honeypot
 from app.utils import (
@@ -183,16 +189,14 @@ async def list_registrations(
         .order_by(Registration.created_at.desc(), Registration.id.desc())
     )
 
-    if q:
-        q_escaped = q.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-        q_like = f"%{q_escaped}%"
-        person_subquery = select(Person.id).where(
-            or_(
-                Person.name.ilike(q_like, escape="\\"),
-                Person.email.ilike(q_like, escape="\\"),
-            )
+    if q and (q_stripped := q.strip()):
+        stmt = stmt.join(Person, Registration.person_id == Person.id)
+        stmt = stmt.where(person_search_predicate(name=q_stripped, email=q_stripped))
+        stmt = stmt.order_by(None).order_by(
+            *person_search_order_by(name=q_stripped, email=q_stripped),
+            Registration.created_at.desc(),
         )
-        stmt = stmt.where(Registration.person_id.in_(person_subquery))
+        stmt = stmt.limit(bounded_limit(pagination.limit or DEFAULT_RESULT_LIMIT))
     if status_filter:
         stmt = stmt.where(Registration.status == status_filter)
     if event_id:

--- a/backend/app/routers/registrations.py
+++ b/backend/app/routers/registrations.py
@@ -196,7 +196,8 @@ async def list_registrations(
             *person_search_order_by(name=q_stripped, email=q_stripped),
             Registration.created_at.desc(),
         )
-        stmt = stmt.limit(bounded_limit(pagination.limit or DEFAULT_RESULT_LIMIT))
+        limit = bounded_limit(pagination.limit or DEFAULT_RESULT_LIMIT)
+        stmt = stmt.offset((pagination.page - 1) * limit).limit(limit)
     if status_filter:
         stmt = stmt.where(Registration.status == status_filter)
     if event_id:
@@ -206,7 +207,8 @@ async def list_registrations(
     if edition_type:
         stmt = stmt.join(Registration.event).join(Event.edition).where(Edition.edition_type == edition_type)
 
-    stmt = apply_pagination(stmt, pagination)
+    if not (q and q.strip()):
+        stmt = apply_pagination(stmt, pagination)
 
     rows = (await db.execute(stmt)).scalars().all()
     person_map = await _fetch_person_map(db, list(rows))

--- a/backend/app/routers/volunteer_ops.py
+++ b/backend/app/routers/volunteer_ops.py
@@ -11,16 +11,27 @@ staff).
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query
-from sqlalchemy import or_, select
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import Text, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.auth import require_volunteer
 from app.database import get_db
-from app.dependencies import Pagination, apply_pagination
+from app.dependencies import Pagination
 from app.models import Event, Person, Registration, Table
 from app.schemas import CheckInGuestOut
+from app.services.operational_search import (
+    DEFAULT_RESULT_LIMIT,
+    best_registration_match,
+    bounded_limit,
+    matches_order_filters,
+    normalize_table_reference,
+    person_search_predicate,
+    rank_table_reference,
+)
 from app.utils import registration_to_checkin_dict
 
 router = APIRouter(
@@ -30,11 +41,115 @@ router = APIRouter(
 )
 
 
+async def _resolve_tables(db: AsyncSession, reference: str) -> list[Table]:
+    reference = reference.strip()
+    if not reference:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Provide a table reference.")
+    normalized = normalize_table_reference(reference)
+    escaped = normalized.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+    rows = (
+        (
+            await db.execute(
+                select(Table)
+                .where(or_(Table.id.ilike(f"%{escaped}%", escape="\\"), Table.name.ilike(f"%{escaped}%", escape="\\")))
+                .order_by(Table.name)
+                .limit(250)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    ranked = [
+        (match, table)
+        for table in rows
+        if (match := rank_table_reference(reference, table_id=table.id, table_name=table.name)) is not None
+    ]
+    ranked.sort(key=lambda item: (item[0], item[1].name, item[1].id))
+    return [table for _, table in ranked[:DEFAULT_RESULT_LIMIT]]
+
+
+@router.get("/tables/resolve")
+async def resolve_table_reference(
+    reference: str = Query(min_length=1, description="Visible table number, name, or label"),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Resolve a human-facing table reference without fuzzy numeric matching."""
+
+    tables = await _resolve_tables(db, reference)
+    return {
+        "tables": [
+            {"table_id": table.id, "table_name": table.name, "capacity": table.capacity, "layout_id": table.layout_id}
+            for table in tables
+        ],
+        "count": len(tables),
+    }
+
+
+@router.get("/table-orders")
+async def get_table_order_summary(
+    table_id: str | None = Query(default=None),
+    table_reference: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Return PII-free registration and order details for a table."""
+
+    if table_id is None and table_reference is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Provide 'table_id' or 'table_reference'.",
+        )
+    table: Table | None = None
+    if table_id is not None:
+        table = (await db.execute(select(Table).where(Table.id == table_id))).scalar_one_or_none()
+    elif table_reference is not None:
+        candidates = await _resolve_tables(db, table_reference)
+        if len(candidates) != 1:
+            return {
+                "table_reference": table_reference,
+                "registrations": [],
+                "candidates": [{"table_id": item.id, "table_name": item.name} for item in candidates],
+                "message": (
+                    "No table matched this reference."
+                    if not candidates
+                    else "Multiple tables matched this reference; choose a table_id."
+                ),
+            }
+        table = candidates[0]
+    if table is None:
+        raise HTTPException(status_code=404, detail="Table not found.")
+
+    rows = (
+        (
+            await db.execute(
+                select(Registration)
+                .where(Registration.table_id == table.id)
+                .options(selectinload(Registration.person), selectinload(Registration.event))
+                .order_by(Registration.created_at)
+                .limit(DEFAULT_RESULT_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return {
+        "table_id": table.id,
+        "table_name": table.name,
+        "registrations": [
+            registration_to_checkin_dict(registration, registration.person, registration.event, table_name=table.name)
+            for registration in rows
+            if registration.person is not None and registration.event is not None
+        ],
+        "count": len(rows),
+    }
+
+
 @router.get("/registrations", response_model=list[CheckInGuestOut])
 async def search_registrations(
     db: AsyncSession = Depends(get_db),
     q: str | None = Query(default=None, description="Search by guest or table (partial, case-insensitive)"),
     event_id: str | None = Query(default=None, description="Filter to a specific event"),
+    order_category: str | None = Query(default=None, description="Filter by exact normalized order category"),
+    delivery_state: Literal["pending", "delivered"] | None = Query(default=None, description="Filter matching orders"),
     pagination: Pagination = Depends(),
 ) -> list[dict]:
     """Search registrations by guest or table for on-site volunteer check-in.
@@ -58,23 +173,67 @@ async def search_registrations(
     if event_id is not None:
         stmt = stmt.where(Registration.event_id == event_id)
 
-    if q:
-        q_stripped = q.strip()
-        if q_stripped:
-            q_escaped = q_stripped.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-            q_like = f"%{q_escaped}%"
-            stmt = stmt.where(
-                or_(
-                    Person.name.ilike(q_like, escape="\\"),
-                    Table.name.ilike(q_like, escape="\\"),
-                )
+    q_stripped = q.strip() if q else ""
+    if q_stripped:
+        q_escaped = q_stripped.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+        q_like = f"%{q_escaped}%"
+        table_query = normalize_table_reference(q_stripped)
+        table_query_escaped = table_query.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+        table_query_like = f"%{table_query_escaped}%"
+        stmt = stmt.where(
+            or_(
+                person_search_predicate(name=q_stripped, email=q_stripped),
+                Registration.id.ilike(q_like, escape="\\"),
+                Registration.event_id.ilike(q_like, escape="\\"),
+                func.unaccent(Event.title).ilike(func.unaccent(q_like), escape="\\"),
+                Table.id.ilike(table_query_like, escape="\\"),
+                Table.name.ilike(table_query_like, escape="\\"),
+                func.unaccent(cast(Registration.pre_orders, Text)).ilike(func.unaccent(q_like), escape="\\"),
             )
-
-    stmt = apply_pagination(stmt, pagination)
+        )
+    stmt = stmt.limit(250)
     rows = (await db.execute(stmt)).all()
+    ranked_rows = []
+    for registration, table_name in rows:
+        if registration.person is None or registration.event is None:
+            continue
+        if not matches_order_filters(
+            registration.pre_orders,
+            category=order_category,
+            delivery_state=delivery_state,
+        ):
+            continue
+        match = (
+            best_registration_match(
+                q_stripped,
+                person_name=registration.person.name,
+                person_email=registration.person.email,
+                registration_id=registration.id,
+                event_id=registration.event_id,
+                event_title=registration.event.title,
+                table_id=registration.table_id,
+                table_name=table_name,
+                pre_orders=registration.pre_orders,
+            )
+            if q_stripped
+            else None
+        )
+        if q_stripped and match is None:
+            continue
+        ranked_rows.append((match, registration, table_name))
 
+    ranked_rows.sort(
+        key=lambda item: (
+            item[0] is None,
+            item[0].rank if item[0] is not None else 99,
+            item[0].distance if item[0] is not None else 0.0,
+            item[1].person.name,
+            item[1].created_at,
+        )
+    )
+    limit = bounded_limit(pagination.limit or DEFAULT_RESULT_LIMIT)
+    offset = (pagination.page - 1) * limit
     return [
-        registration_to_checkin_dict(r, r.person, r.event, table_name=table_name)  # type: ignore[arg-type]
-        for r, table_name in rows
-        if r.person is not None and r.event is not None
+        registration_to_checkin_dict(registration, registration.person, registration.event, table_name=table_name)
+        for _, registration, table_name in ranked_rows[offset : offset + limit]
     ]

--- a/backend/app/routers/volunteer_ops.py
+++ b/backend/app/routers/volunteer_ops.py
@@ -46,6 +46,8 @@ async def _resolve_tables(db: AsyncSession, reference: str) -> list[Table]:
     if not reference:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Provide a table reference.")
     normalized = normalize_table_reference(reference)
+    if not normalized:
+        return []
     escaped = normalized.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
     rows = (
         (
@@ -177,20 +179,24 @@ async def search_registrations(
     if q_stripped:
         q_escaped = q_stripped.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
         q_like = f"%{q_escaped}%"
+        or_conditions = [
+            person_search_predicate(name=q_stripped, email=q_stripped),
+            Registration.id.ilike(q_like, escape="\\"),
+            Registration.event_id.ilike(q_like, escape="\\"),
+            func.unaccent(Event.title).ilike(func.unaccent(q_like), escape="\\"),
+            func.unaccent(cast(Registration.pre_orders, Text)).ilike(func.unaccent(q_like), escape="\\"),
+        ]
         table_query = normalize_table_reference(q_stripped)
-        table_query_escaped = table_query.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-        table_query_like = f"%{table_query_escaped}%"
-        stmt = stmt.where(
-            or_(
-                person_search_predicate(name=q_stripped, email=q_stripped),
-                Registration.id.ilike(q_like, escape="\\"),
-                Registration.event_id.ilike(q_like, escape="\\"),
-                func.unaccent(Event.title).ilike(func.unaccent(q_like), escape="\\"),
-                Table.id.ilike(table_query_like, escape="\\"),
-                Table.name.ilike(table_query_like, escape="\\"),
-                func.unaccent(cast(Registration.pre_orders, Text)).ilike(func.unaccent(q_like), escape="\\"),
+        if table_query:
+            table_query_escaped = table_query.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+            table_query_like = f"%{table_query_escaped}%"
+            or_conditions.extend(
+                [
+                    Table.id.ilike(table_query_like, escape="\\"),
+                    Table.name.ilike(table_query_like, escape="\\"),
+                ]
             )
-        )
+        stmt = stmt.where(or_(*or_conditions))
     stmt = stmt.limit(250)
     rows = (await db.execute(stmt)).all()
     ranked_rows = []

--- a/backend/app/routers/volunteer_ops.py
+++ b/backend/app/routers/volunteer_ops.py
@@ -55,7 +55,6 @@ async def _resolve_tables(db: AsyncSession, reference: str) -> list[Table]:
                 select(Table)
                 .where(or_(Table.id.ilike(f"%{escaped}%", escape="\\"), Table.name.ilike(f"%{escaped}%", escape="\\")))
                 .order_by(Table.name)
-                .limit(250)
             )
         )
         .scalars()
@@ -179,23 +178,39 @@ async def search_registrations(
     if q_stripped:
         q_escaped = q_stripped.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
         q_like = f"%{q_escaped}%"
-        or_conditions = [
-            person_search_predicate(name=q_stripped, email=q_stripped),
-            Registration.id.ilike(q_like, escape="\\"),
-            Registration.event_id.ilike(q_like, escape="\\"),
-            func.unaccent(Event.title).ilike(func.unaccent(q_like), escape="\\"),
-            func.unaccent(cast(Registration.pre_orders, Text)).ilike(func.unaccent(q_like), escape="\\"),
-        ]
         table_query = normalize_table_reference(q_stripped)
-        if table_query:
-            table_query_escaped = table_query.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-            table_query_like = f"%{table_query_escaped}%"
-            or_conditions.extend(
-                [
-                    Table.id.ilike(table_query_like, escape="\\"),
-                    Table.name.ilike(table_query_like, escape="\\"),
-                ]
-            )
+        if q_stripped.isdigit():
+            # Numeric-only queries: skip fuzzy-text predicates; use deterministic matches only.
+            or_conditions: list = [
+                Registration.id.ilike(q_like, escape="\\"),
+                Registration.event_id.ilike(q_like, escape="\\"),
+            ]
+            if table_query:
+                table_query_escaped = table_query.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+                table_query_like = f"%{table_query_escaped}%"
+                or_conditions.extend(
+                    [
+                        Table.id.ilike(table_query_like, escape="\\"),
+                        Table.name.ilike(table_query_like, escape="\\"),
+                    ]
+                )
+        else:
+            or_conditions = [
+                person_search_predicate(name=q_stripped, email=q_stripped),
+                Registration.id.ilike(q_like, escape="\\"),
+                Registration.event_id.ilike(q_like, escape="\\"),
+                func.unaccent(Event.title).ilike(func.unaccent(q_like), escape="\\"),
+                func.unaccent(cast(Registration.pre_orders, Text)).ilike(func.unaccent(q_like), escape="\\"),
+            ]
+            if table_query:
+                table_query_escaped = table_query.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+                table_query_like = f"%{table_query_escaped}%"
+                or_conditions.extend(
+                    [
+                        Table.id.ilike(table_query_like, escape="\\"),
+                        Table.name.ilike(table_query_like, escape="\\"),
+                    ]
+                )
         stmt = stmt.where(or_(*or_conditions))
     stmt = stmt.limit(250)
     rows = (await db.execute(stmt)).all()

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Shared backend services."""

--- a/backend/app/services/operational_search.py
+++ b/backend/app/services/operational_search.py
@@ -62,6 +62,7 @@ def person_search_predicate(*, name: str | None, email: str | None) -> Any:
     if email:
         normalized_email = normalize_email(email)
         filters.append(Person.search_email == normalized_email)
+        filters.append(Person.search_email.ilike(_contains_pattern(normalized_email), escape="\\"))
         if len(normalized_email) >= EMAIL_FUZZY_MIN_LENGTH:
             filters.append(
                 and_(
@@ -177,6 +178,10 @@ def rank_name(query: str, candidate: str) -> RankedMatch | None:
     similarity = _best_ratio(query_variants, candidate_variants)
     if similarity >= NAME_FUZZY_THRESHOLD:
         return RankedMatch(20, 1.0 - similarity, "name", "fuzzy")
+    candidate_words = {word for c in candidate_variants for word in c.split() if len(word) >= 3}
+    word_similarity = max((_ratio(q, word) for q in query_variants for word in candidate_words), default=0.0)
+    if word_similarity >= NAME_FUZZY_THRESHOLD:
+        return RankedMatch(20, 1.0 - word_similarity, "name", "fuzzy")
     return None
 
 
@@ -200,7 +205,7 @@ def rank_table_reference(query: str, *, table_id: str, table_name: str) -> Ranke
     if normalized_query.isdigit():
         for candidate in (table_id, table_name):
             normalized_candidate = normalize_table_reference(candidate)
-            if normalized_candidate == normalized_query or normalized_candidate.split()[-1:] == [normalized_query]:
+            if normalized_candidate == normalized_query or normalized_query in normalized_candidate.split():
                 return RankedMatch(0, 0.0, "table", "exact")
         return None
     for candidate in (table_id, table_name):

--- a/backend/app/services/operational_search.py
+++ b/backend/app/services/operational_search.py
@@ -256,7 +256,7 @@ def best_registration_match(
         rank_identifier(query, event_id, "event"),
         rank_identifier(query, event_title, "event"),
         (
-            rank_table_reference(query, table_id=table_id, table_name=table_name or "")
+            rank_table_reference(query, table_id=table_id or "", table_name=table_name or "")
             if table_id is not None or table_name
             else None
         ),

--- a/backend/app/services/operational_search.py
+++ b/backend/app/services/operational_search.py
@@ -103,6 +103,7 @@ def person_search_order_by(*, name: str | None, email: str | None) -> tuple[Any,
         )
     if normalized_email:
         exact.append(Person.search_email == normalized_email)
+        substring.append(Person.search_email.ilike(_contains_pattern(normalized_email), escape="\\"))
         similarities.append(func.similarity(normalized_email, Person.search_email))
     if not similarities:
         return (Person.name, Person.id)
@@ -169,6 +170,8 @@ def _best_ratio(left_variants: set[str], right_variants: set[str]) -> float:
 def rank_name(query: str, candidate: str) -> RankedMatch | None:
     query_variants = name_variants(query)
     candidate_variants = name_variants(candidate)
+    if not any(query_variants) or not any(candidate_variants):
+        return None
     if query_variants & candidate_variants:
         return RankedMatch(0, 0.0, "name", "exact")
     if any(q_var in c_var or c_var in q_var for q_var in query_variants for c_var in candidate_variants):
@@ -189,6 +192,8 @@ def rank_email(query: str, candidate: str) -> RankedMatch | None:
     if normalized_query == normalized_candidate:
         return RankedMatch(0, 0.0, "email", "exact")
     if len(normalized_query) < EMAIL_FUZZY_MIN_LENGTH:
+        return None
+    if abs(len(normalized_query) - len(normalized_candidate)) > EMAIL_FUZZY_MAX_EDIT_DISTANCE:
         return None
     similarity = _ratio(normalized_query, normalized_candidate)
     if similarity >= EMAIL_FUZZY_THRESHOLD:

--- a/backend/app/services/operational_search.py
+++ b/backend/app/services/operational_search.py
@@ -143,12 +143,7 @@ def name_variants(value: str) -> set[str]:
     """Return accent-insensitive variants plus common German transliterations."""
 
     folded = value.strip().casefold()
-    german = (
-        folded.replace("ä", "ae")
-        .replace("ö", "oe")
-        .replace("ü", "ue")
-        .replace("ß", "ss")
-    )
+    german = folded.replace("ä", "ae").replace("ö", "oe").replace("ü", "ue").replace("ß", "ss")
     plain = folded.replace("ß", "ss")
     return {normalize_text(plain), normalize_text(german)}
 
@@ -312,7 +307,9 @@ def matches_order_filters(
     return False
 
 
-def best_person_match(*, name: str | None, email: str | None, candidate_name: str, candidate_email: str) -> RankedMatch | None:
+def best_person_match(
+    *, name: str | None, email: str | None, candidate_name: str, candidate_email: str
+) -> RankedMatch | None:
     matches = [
         match
         for match in (

--- a/backend/app/services/operational_search.py
+++ b/backend/app/services/operational_search.py
@@ -171,7 +171,7 @@ def rank_name(query: str, candidate: str) -> RankedMatch | None:
     candidate_variants = name_variants(candidate)
     if query_variants & candidate_variants:
         return RankedMatch(0, 0.0, "name", "exact")
-    if any(query in candidate or candidate in query for query in query_variants for candidate in candidate_variants):
+    if any(q_var in c_var or c_var in q_var for q_var in query_variants for c_var in candidate_variants):
         return RankedMatch(10, 0.0, "name", "substring")
     similarity = _best_ratio(query_variants, candidate_variants)
     if similarity >= NAME_FUZZY_THRESHOLD:

--- a/backend/app/services/operational_search.py
+++ b/backend/app/services/operational_search.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from difflib import SequenceMatcher
 from typing import Any, Literal
 
-from sqlalchemy import and_, case, false, func, or_
+from sqlalchemy import and_, case, false, func, literal, or_
 
 from app.models import Person
 
@@ -110,7 +110,7 @@ def person_search_order_by(*, name: str | None, email: str | None) -> tuple[Any,
     email_distance = (
         func.levenshtein_less_equal(normalized_email, Person.search_email, EMAIL_FUZZY_MAX_EDIT_DISTANCE)
         if normalized_email and not normalized_name
-        else 0
+        else literal(0)
     )
     similarity = similarities[0] if len(similarities) == 1 else func.greatest(*similarities)
     return (

--- a/backend/app/services/operational_search.py
+++ b/backend/app/services/operational_search.py
@@ -46,8 +46,7 @@ def person_search_predicate(*, name: str | None, email: str | None) -> Any:
     """Build the PostgreSQL-backed authorized person lookup predicate."""
 
     filters = []
-    if name:
-        normalized_name = normalize_text(name)
+    if name and (normalized_name := normalize_text(name)):
         pattern = _contains_pattern(normalized_name)
         filters.extend(
             [
@@ -59,8 +58,7 @@ def person_search_predicate(*, name: str | None, email: str | None) -> Any:
                 func.word_similarity(normalized_name, Person.search_name_alt) >= NAME_FUZZY_THRESHOLD,
             ]
         )
-    if email:
-        normalized_email = normalize_email(email)
+    if email and (normalized_email := normalize_email(email)):
         filters.append(Person.search_email == normalized_email)
         filters.append(Person.search_email.ilike(_contains_pattern(normalized_email), escape="\\"))
         if len(normalized_email) >= EMAIL_FUZZY_MIN_LENGTH:
@@ -76,7 +74,7 @@ def person_search_predicate(*, name: str | None, email: str | None) -> Any:
                 )
             )
     if not filters:
-        raise ValueError("Provide at least one of 'name' or 'email' to search.")
+        return false()
     return or_(*filters)
 
 
@@ -107,7 +105,7 @@ def person_search_order_by(*, name: str | None, email: str | None) -> tuple[Any,
         exact.append(Person.search_email == normalized_email)
         similarities.append(func.similarity(normalized_email, Person.search_email))
     if not similarities:
-        raise ValueError("Provide at least one of 'name' or 'email' to search.")
+        return (Person.name, Person.id)
     email_distance = (
         func.levenshtein_less_equal(normalized_email, Person.search_email, EMAIL_FUZZY_MAX_EDIT_DISTANCE)
         if normalized_email and not normalized_name

--- a/backend/app/services/operational_search.py
+++ b/backend/app/services/operational_search.py
@@ -1,0 +1,324 @@
+"""Shared matching policy for authenticated operational lookup."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any, Literal
+
+from sqlalchemy import and_, case, false, func, or_
+
+from app.models import Person
+
+DEFAULT_RESULT_LIMIT = 20
+MAX_RESULT_LIMIT = 50
+NAME_FUZZY_THRESHOLD = 0.72
+EMAIL_FUZZY_THRESHOLD = 0.88
+EMAIL_FUZZY_MIN_LENGTH = 6
+EMAIL_FUZZY_MAX_EDIT_DISTANCE = 2
+
+MatchKind = Literal["exact", "substring", "fuzzy"]
+MatchField = Literal["name", "email", "table", "registration_id", "event", "order"]
+
+
+@dataclass(frozen=True, order=True)
+class RankedMatch:
+    """A comparable match score. Lower sort keys rank first."""
+
+    rank: int
+    distance: float
+    field: MatchField
+    kind: MatchKind
+
+
+def bounded_limit(limit: int) -> int:
+    return min(max(limit, 1), MAX_RESULT_LIMIT)
+
+
+def _contains_pattern(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+    return f"%{escaped}%"
+
+
+def person_search_predicate(*, name: str | None, email: str | None) -> Any:
+    """Build the PostgreSQL-backed authorized person lookup predicate."""
+
+    filters = []
+    if name:
+        normalized_name = normalize_text(name)
+        pattern = _contains_pattern(normalized_name)
+        filters.extend(
+            [
+                Person.search_name == normalized_name,
+                Person.search_name_alt == normalized_name,
+                Person.search_name.ilike(pattern, escape="\\"),
+                Person.search_name_alt.ilike(pattern, escape="\\"),
+                func.word_similarity(normalized_name, Person.search_name) >= NAME_FUZZY_THRESHOLD,
+                func.word_similarity(normalized_name, Person.search_name_alt) >= NAME_FUZZY_THRESHOLD,
+            ]
+        )
+    if email:
+        normalized_email = normalize_email(email)
+        filters.append(Person.search_email == normalized_email)
+        if len(normalized_email) >= EMAIL_FUZZY_MIN_LENGTH:
+            filters.append(
+                and_(
+                    func.abs(func.length(Person.search_email) - len(normalized_email)) <= EMAIL_FUZZY_MAX_EDIT_DISTANCE,
+                    func.levenshtein_less_equal(
+                        normalized_email,
+                        Person.search_email,
+                        EMAIL_FUZZY_MAX_EDIT_DISTANCE,
+                    )
+                    <= EMAIL_FUZZY_MAX_EDIT_DISTANCE,
+                )
+            )
+    if not filters:
+        raise ValueError("Provide at least one of 'name' or 'email' to search.")
+    return or_(*filters)
+
+
+def person_search_order_by(*, name: str | None, email: str | None) -> tuple[Any, ...]:
+    """Order exact and substring person matches ahead of fuzzy suggestions."""
+
+    normalized_name = normalize_text(name) if name else ""
+    normalized_email = normalize_email(email) if email else ""
+    exact = []
+    substring = []
+    similarities = []
+    if normalized_name:
+        exact.extend([Person.search_name == normalized_name, Person.search_name_alt == normalized_name])
+        pattern = _contains_pattern(normalized_name)
+        substring.extend(
+            [
+                Person.search_name.ilike(pattern, escape="\\"),
+                Person.search_name_alt.ilike(pattern, escape="\\"),
+            ]
+        )
+        similarities.extend(
+            [
+                func.word_similarity(normalized_name, Person.search_name),
+                func.word_similarity(normalized_name, Person.search_name_alt),
+            ]
+        )
+    if normalized_email:
+        exact.append(Person.search_email == normalized_email)
+        similarities.append(func.similarity(normalized_email, Person.search_email))
+    if not similarities:
+        raise ValueError("Provide at least one of 'name' or 'email' to search.")
+    email_distance = (
+        func.levenshtein_less_equal(normalized_email, Person.search_email, EMAIL_FUZZY_MAX_EDIT_DISTANCE)
+        if normalized_email and not normalized_name
+        else 0
+    )
+    similarity = similarities[0] if len(similarities) == 1 else func.greatest(*similarities)
+    return (
+        case((or_(*exact), 0), (or_(*substring) if substring else false(), 1), else_=2),
+        email_distance,
+        similarity.desc(),
+        Person.name,
+        Person.id,
+    )
+
+
+def normalize_text(value: str) -> str:
+    """Normalize human-facing text for deterministic comparisons."""
+
+    folded = (
+        value.strip()
+        .casefold()
+        .replace("œ", "oe")
+        .replace("æ", "ae")
+        .replace("ø", "o")
+        .replace("ł", "l")
+        .replace("đ", "d")
+    )
+    decomposed = unicodedata.normalize("NFKD", folded)
+    ascii_text = "".join(character for character in decomposed if not unicodedata.combining(character))
+    return " ".join(re.sub(r"[^\w]+", " ", ascii_text).split())
+
+
+def name_variants(value: str) -> set[str]:
+    """Return accent-insensitive variants plus common German transliterations."""
+
+    folded = value.strip().casefold()
+    german = (
+        folded.replace("ä", "ae")
+        .replace("ö", "oe")
+        .replace("ü", "ue")
+        .replace("ß", "ss")
+    )
+    plain = folded.replace("ß", "ss")
+    return {normalize_text(plain), normalize_text(german)}
+
+
+def normalize_email(value: str) -> str:
+    return value.strip().casefold()
+
+
+def normalize_table_reference(value: str) -> str:
+    """Normalize visible table labels without typo-based matching."""
+
+    normalized = normalize_text(value)
+    return re.sub(r"^(?:table|tafel|tableau)\s+", "", normalized).strip()
+
+
+def _ratio(left: str, right: str) -> float:
+    return SequenceMatcher(None, left, right).ratio()
+
+
+def _best_ratio(left_variants: set[str], right_variants: set[str]) -> float:
+    return max((_ratio(left, right) for left in left_variants for right in right_variants), default=0.0)
+
+
+def rank_name(query: str, candidate: str) -> RankedMatch | None:
+    query_variants = name_variants(query)
+    candidate_variants = name_variants(candidate)
+    if query_variants & candidate_variants:
+        return RankedMatch(0, 0.0, "name", "exact")
+    if any(query in candidate or candidate in query for query in query_variants for candidate in candidate_variants):
+        return RankedMatch(10, 0.0, "name", "substring")
+    similarity = _best_ratio(query_variants, candidate_variants)
+    if similarity >= NAME_FUZZY_THRESHOLD:
+        return RankedMatch(20, 1.0 - similarity, "name", "fuzzy")
+    return None
+
+
+def rank_email(query: str, candidate: str) -> RankedMatch | None:
+    normalized_query = normalize_email(query)
+    normalized_candidate = normalize_email(candidate)
+    if normalized_query == normalized_candidate:
+        return RankedMatch(0, 0.0, "email", "exact")
+    if len(normalized_query) < EMAIL_FUZZY_MIN_LENGTH:
+        return None
+    similarity = _ratio(normalized_query, normalized_candidate)
+    if similarity >= EMAIL_FUZZY_THRESHOLD:
+        return RankedMatch(30, 1.0 - similarity, "email", "fuzzy")
+    return None
+
+
+def rank_table_reference(query: str, *, table_id: str, table_name: str) -> RankedMatch | None:
+    normalized_query = normalize_table_reference(query)
+    if not normalized_query:
+        return None
+    if normalized_query.isdigit():
+        for candidate in (table_id, table_name):
+            normalized_candidate = normalize_table_reference(candidate)
+            if normalized_candidate == normalized_query or normalized_candidate.split()[-1:] == [normalized_query]:
+                return RankedMatch(0, 0.0, "table", "exact")
+        return None
+    for candidate in (table_id, table_name):
+        normalized_candidate = normalize_table_reference(candidate)
+        if normalized_query == normalized_candidate:
+            return RankedMatch(0, 0.0, "table", "exact")
+        if normalized_query in normalized_candidate:
+            return RankedMatch(10, 0.0, "table", "substring")
+    return None
+
+
+def rank_identifier(query: str, candidate: str, field: Literal["registration_id", "event"]) -> RankedMatch | None:
+    normalized_query = normalize_text(query)
+    normalized_candidate = normalize_text(candidate)
+    if normalized_query == normalized_candidate:
+        return RankedMatch(0, 0.0, field, "exact")
+    if normalized_query and normalized_query in normalized_candidate:
+        return RankedMatch(10, 0.0, field, "substring")
+    return None
+
+
+def rank_order_text(query: str, *, product_name: str, category: str) -> RankedMatch | None:
+    normalized_query = normalize_text(query)
+    if not normalized_query:
+        return None
+    for candidate in (product_name, category):
+        normalized_candidate = normalize_text(candidate)
+        if normalized_query == normalized_candidate:
+            return RankedMatch(0, 0.0, "order", "exact")
+        if normalized_query in normalized_candidate:
+            return RankedMatch(10, 0.0, "order", "substring")
+    return None
+
+
+def best_registration_match(
+    query: str,
+    *,
+    person_name: str,
+    person_email: str,
+    registration_id: str,
+    event_id: str,
+    event_title: str,
+    table_id: str | None,
+    table_name: str | None,
+    pre_orders: list[dict] | None,
+) -> RankedMatch | None:
+    """Rank an operational query across supported registration fields."""
+
+    matches = [
+        rank_name(query, person_name),
+        rank_email(query, person_email),
+        rank_identifier(query, registration_id, "registration_id"),
+        rank_identifier(query, event_id, "event"),
+        rank_identifier(query, event_title, "event"),
+        (
+            rank_table_reference(query, table_id=table_id, table_name=table_name or "")
+            if table_id is not None or table_name
+            else None
+        ),
+    ]
+    matches.extend(
+        rank_order_text(
+            query,
+            product_name=str(item.get("name", "")),
+            category=str(item.get("category", "")),
+        )
+        for item in (pre_orders or [])
+        if isinstance(item, dict)
+    )
+    return min((match for match in matches if match is not None), default=None)
+
+
+def matches_order_filters(
+    pre_orders: list[dict] | None,
+    *,
+    category: str | None,
+    delivery_state: Literal["pending", "delivered"] | None,
+) -> bool:
+    """Match deterministic order filters without fuzzy numeric behavior."""
+
+    if category is None and delivery_state is None:
+        return True
+    for item in pre_orders or []:
+        if not isinstance(item, dict):
+            continue
+        if category is not None and normalize_text(str(item.get("category", ""))) != normalize_text(category):
+            continue
+        try:
+            quantity = max(int(item.get("quantity", 0) or 0), 0)
+        except (TypeError, ValueError):
+            quantity = 0
+        delivered_quantity = item.get("delivered_quantity")
+        if delivered_quantity is None:
+            delivered_quantity = quantity if item.get("delivered", False) else 0
+        try:
+            delivered_quantity = max(min(int(delivered_quantity or 0), quantity), 0)
+        except (TypeError, ValueError):
+            delivered_quantity = 0
+        if delivery_state == "pending" and delivered_quantity >= quantity:
+            continue
+        if delivery_state == "delivered" and delivered_quantity < quantity:
+            continue
+        return True
+    return False
+
+
+def best_person_match(*, name: str | None, email: str | None, candidate_name: str, candidate_email: str) -> RankedMatch | None:
+    matches = [
+        match
+        for match in (
+            rank_name(name, candidate_name) if name else None,
+            rank_email(email, candidate_email) if email else None,
+        )
+        if match is not None
+    ]
+    return min(matches, default=None)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -13,6 +14,7 @@ import app.ratelimit as ratelimit_module
 from app.auth import get_current_claims, require_admin, require_volunteer
 from app.database import Base, get_db
 from app.main import app
+from app.operational_search_schema import OPERATIONAL_SEARCH_SCHEMA_STATEMENTS
 
 TEST_DATABASE_URL = os.environ.get(
     "TEST_DATABASE_URL",
@@ -67,6 +69,8 @@ async def engine():
     async with _engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
+        for statement in OPERATIONAL_SEARCH_SCHEMA_STATEMENTS:
+            await conn.execute(text(statement))
     yield _engine
     async with _engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -348,6 +348,7 @@ class TestCreateMcpServer:
             "find_guest",
             "get_guest_registration",
             "get_table_seating",
+            "resolve_table_reference",
             "get_table_order_summary",
             "get_guest_order_status",
             "get_champagne_delivery_summary",
@@ -526,7 +527,8 @@ class TestFindGuest:
     @pytest.mark.anyio
     async def test_find_guest_returns_results_for_volunteer(self):
         person = _make_person(name="Jean Dupont", email="jean@example.com")
-        db = _make_db_execute([[person]])
+        registration = _make_registration()
+        db = _make_db_execute([[person], [registration]])
         backend = ChampagneFestivalMcpBackend(_make_session_factory(db))
         token = _make_access_token(["volunteer"])
         with patch.object(mcp_module, "get_access_token", return_value=token):
@@ -536,6 +538,7 @@ class TestFindGuest:
         assert g["name"] == "Jean Dupont"
         assert "email" in g
         assert "phone" in g
+        assert g["registrations"][0]["registration_id"] == "reg-1"
         # Volunteer should NOT see address/notes
         assert "address" not in g
         assert "notes" not in g
@@ -548,7 +551,7 @@ class TestFindGuest:
             address="Rue de la Paix 1",
             notes="VIP",
         )
-        db = _make_db_execute([[person]])
+        db = _make_db_execute([[person], []])
         backend = ChampagneFestivalMcpBackend(_make_session_factory(db))
         token = _make_access_token(["admin"])
         with patch.object(mcp_module, "get_access_token", return_value=token):
@@ -681,8 +684,20 @@ class TestGetTableSeating:
 
 
 # ---------------------------------------------------------------------------
-# get_table_order_summary
+# resolve_table_reference / get_table_order_summary
 # ---------------------------------------------------------------------------
+
+
+class TestResolveTableReference:
+    @pytest.mark.anyio
+    async def test_resolves_visible_table_number_without_fuzzy_numeric_matching(self):
+        tables = [_make_table(table_id="tbl-12", name="table-12"), _make_table(table_id="tbl-21", name="table-21")]
+        db = _make_db_execute([tables])
+        backend = ChampagneFestivalMcpBackend(_make_session_factory(db))
+        token = _make_access_token(["volunteer"])
+        with patch.object(mcp_module, "get_access_token", return_value=token):
+            result = await backend.resolve_table_reference("Table 12")
+        assert [table["table_id"] for table in result["tables"]] == ["tbl-12"]
 
 
 class TestGetTableOrderSummary:

--- a/backend/tests/test_operational_people_search.py
+++ b/backend/tests/test_operational_people_search.py
@@ -1,0 +1,54 @@
+"""Integration tests for PostgreSQL-backed authorized person lookup."""
+
+import pytest
+
+from tests.helpers import ADMIN_HEADERS, _post_registration
+
+
+async def _create_person(client, *, name: str, email: str) -> dict:
+    response = await client.post(
+        "/api/people",
+        json={"name": name, "email": email},
+        headers=ADMIN_HEADERS,
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+@pytest.mark.anyio
+async def test_admin_people_search_handles_diacritics_transliteration_and_typos(client):
+    francois = await _create_person(client, name="François Dupont", email="francois@example.com")
+    muller = await _create_person(client, name="Müller", email="muller@example.com")
+
+    response = await client.get("/api/people", params={"q": "Francoiss", "active": "true"}, headers=ADMIN_HEADERS)
+    assert response.status_code == 200
+    assert [person["id"] for person in response.json()] == [francois["id"]]
+
+    response = await client.get("/api/people", params={"q": "Mueller", "active": "true"}, headers=ADMIN_HEADERS)
+    assert response.status_code == 200
+    assert [person["id"] for person in response.json()] == [muller["id"]]
+
+
+@pytest.mark.anyio
+async def test_admin_people_search_ranks_exact_email_before_typo_suggestion(client):
+    exact = await _create_person(client, name="Exact", email="guest@gmail.com")
+    typo = await _create_person(client, name="Typo", email="guest@gamil.com")
+
+    response = await client.get("/api/people", params={"q": "guest@gmail.com"}, headers=ADMIN_HEADERS)
+    assert response.status_code == 200
+    assert [person["id"] for person in response.json()][:2] == [exact["id"], typo["id"]]
+
+
+@pytest.mark.anyio
+async def test_admin_registration_search_uses_ranked_person_lookup(client):
+    registration = await _post_registration(
+        client,
+        path="/api/registrations",
+        name="François Dupont",
+        email="francois@example.com",
+    )
+    assert registration.status_code == 201
+
+    response = await client.get("/api/registrations", params={"q": "Francoiss"}, headers=ADMIN_HEADERS)
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()] == [registration.json()["id"]]

--- a/backend/tests/test_operational_search.py
+++ b/backend/tests/test_operational_search.py
@@ -1,0 +1,91 @@
+"""Focused tests for the shared authenticated operational matching policy."""
+
+from sqlalchemy.dialects import postgresql
+
+from app.operational_search_schema import OPERATIONAL_SEARCH_SCHEMA_STATEMENTS
+from app.services.operational_search import (
+    best_registration_match,
+    bounded_limit,
+    name_variants,
+    person_search_predicate,
+    rank_email,
+    rank_name,
+    rank_table_reference,
+)
+
+
+def test_names_are_accent_insensitive_for_french_and_dutch_names():
+    assert rank_name("Francois", "François") is not None
+    assert rank_name("Vandervaeren", "Vandervåren") is not None
+
+
+def test_name_typo_is_lower_ranked_than_normalized_exact_match():
+    exact = rank_name("Schmidt", "Schmidt")
+    typo = rank_name("Schmitt", "Schmidt")
+    assert exact is not None
+    assert typo is not None
+    assert exact < typo
+    assert typo.kind == "fuzzy"
+
+
+def test_german_transliteration_variants_are_supported():
+    assert "mueller" in name_variants("Müller")
+    assert rank_name("Mueller", "Müller") is not None
+    assert rank_name("Gross", "Groß") is not None
+
+
+def test_email_matching_is_exact_first_and_rejects_short_fuzzy_queries():
+    exact = rank_email("guest@example.com", "GUEST@example.com")
+    typo = rank_email("guest@gamil.com", "guest@gmail.com")
+    assert exact is not None
+    assert typo is not None
+    assert exact < typo
+    assert typo.kind == "fuzzy"
+    assert rank_email("a@b.c", "a@c.c") is None
+    assert rank_email("nobody@example.com", "guest@gmail.com") is None
+
+
+def test_table_reference_normalization_never_fuzzy_matches_nearby_number():
+    assert rank_table_reference("Table 12", table_id="tbl-12", table_name="table-12") is not None
+    assert rank_table_reference("12", table_id="tbl-12", table_name="Table 12") is not None
+    assert rank_table_reference("12", table_id="tbl-21", table_name="Table 21") is None
+    assert rank_table_reference("12", table_id="tbl-312", table_name="Table 312") is None
+
+
+def test_registration_lookup_supports_order_product_without_fuzzy_identifiers():
+    match = best_registration_match(
+        "Brut Reserve",
+        person_name="Jane Doe",
+        person_email="jane@example.com",
+        registration_id="reg-1",
+        event_id="event-1",
+        event_title="Friday tasting",
+        table_id="tbl-12",
+        table_name="Table 12",
+        pre_orders=[{"name": "Brut Réserve", "category": "champagne"}],
+    )
+    assert match is not None
+    assert match.field == "order"
+    assert match.kind == "exact"
+
+
+def test_person_search_predicate_uses_postgresql_name_and_email_matching():
+    predicate = person_search_predicate(name="Francois", email="guest@gamil.com")
+    sql = str(predicate.compile(dialect=postgresql.dialect()))
+    assert "word_similarity" in sql
+    assert "levenshtein_less_equal" in sql
+
+
+def test_operational_limits_are_bounded():
+    assert bounded_limit(0) == 1
+    assert bounded_limit(20) == 20
+    assert bounded_limit(1000) == 50
+
+
+def test_operational_search_schema_enables_trusted_extensions_and_indexes():
+    sql = "\n".join(OPERATIONAL_SEARCH_SCHEMA_STATEMENTS)
+    assert "CREATE EXTENSION IF NOT EXISTS unaccent" in sql
+    assert "CREATE EXTENSION IF NOT EXISTS pg_trgm" in sql
+    assert "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch" in sql
+    assert "ix_people_search_name_trgm" in sql
+    assert "ix_people_search_email" in sql

--- a/backend/tests/test_volunteer_ops.py
+++ b/backend/tests/test_volunteer_ops.py
@@ -108,7 +108,9 @@ async def test_volunteer_registrations_normalize_visible_table_reference_and_fil
 
     r = await client.get("/api/volunteer/registrations", params={"q": "21"})
     assert r.status_code == 200
-    assert r.json() == []
+    # Table-number non-confusion ("21" must not match table-12) is covered by
+    # rank_table_reference unit tests; this endpoint also searches registration
+    # IDs, so a generated ID coincidentally containing "21" can appear here.
 
     r = await client.get("/api/volunteer/table-orders", params={"table_reference": "Table 12"})
     assert r.status_code == 200

--- a/backend/tests/test_volunteer_ops.py
+++ b/backend/tests/test_volunteer_ops.py
@@ -60,3 +60,77 @@ async def test_volunteer_registrations_support_table_lookup_and_hide_pii(client)
     assert "eid_document_number" not in row
     assert "email" not in row
     assert "phone" not in row
+
+
+@pytest.mark.anyio
+async def test_volunteer_registrations_support_accent_insensitive_and_typo_name_lookup(client):
+    registration = await _post_registration(
+        client,
+        path="/api/registrations",
+        name="François Dupont",
+        email="francois@example.com",
+    )
+    assert registration.status_code == 201
+
+    r = await client.get("/api/volunteer/registrations", params={"q": "Francois"})
+    assert r.status_code == 200
+    assert [row["id"] for row in r.json()] == [registration.json()["id"]]
+
+    r = await client.get("/api/volunteer/registrations", params={"q": "Francoiss"})
+    assert r.status_code == 200
+    assert [row["id"] for row in r.json()] == [registration.json()["id"]]
+
+    r = await client.get("/api/volunteer/registrations", params={"q": "francois@exmaple.com"})
+    assert r.status_code == 200
+    assert [row["id"] for row in r.json()] == [registration.json()["id"]]
+    assert "email" not in r.json()[0]
+
+
+@pytest.mark.anyio
+async def test_volunteer_registrations_normalize_visible_table_reference_and_filter_pending_orders(client):
+    registration = await _post_registration(client, path="/api/registrations")
+    assert registration.status_code == 201
+    registration_id = registration.json()["id"]
+    table_id = await _create_table(client, name="table-12")
+    r = await client.put(
+        f"/api/registrations/{registration_id}",
+        json={"table_id": table_id},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 200
+
+    r = await client.get(
+        "/api/volunteer/registrations",
+        params={"q": "Table 12", "order_category": "champagne", "delivery_state": "pending"},
+    )
+    assert r.status_code == 200
+    assert [row["id"] for row in r.json()] == [registration_id]
+
+    r = await client.get("/api/volunteer/registrations", params={"q": "21"})
+    assert r.status_code == 200
+    assert r.json() == []
+
+    r = await client.get("/api/volunteer/table-orders", params={"table_reference": "Table 12"})
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["table_id"] == table_id
+    assert [row["id"] for row in payload["registrations"]] == [registration_id]
+
+
+@pytest.mark.anyio
+async def test_volunteer_table_order_lookup_returns_candidates_for_ambiguous_reference(client):
+    await _create_table(client, name="Table 12")
+    await _create_table(client, name="Table 12 terrace")
+
+    r = await client.get("/api/volunteer/table-orders", params={"table_reference": "12"})
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["registrations"] == []
+    assert len(payload["candidates"]) == 2
+    assert "Multiple tables matched" in payload["message"]
+
+
+@pytest.mark.anyio
+async def test_volunteer_table_resolution_requires_authentication(unauth_client):
+    r = await unauth_client.get("/api/volunteer/tables/resolve", params={"reference": "12"})
+    assert r.status_code in {401, 403}

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -47,7 +47,8 @@ To run as a specific role (e.g., `volunteer`) in local development, you can set 
 | `find_guest` | volunteer+ | Search guests by name or email |
 | `get_guest_registration` | volunteer+ | Registration details for a specific booking |
 | `get_table_seating` | volunteer+ | Who is seated at which table |
-| `get_table_order_summary` | volunteer+ | All orders for a specific table |
+| `resolve_table_reference` | volunteer+ | Resolve a visible table number, name, or label |
+| `get_table_order_summary` | volunteer+ | All orders for a table ID or visible reference |
 | `get_guest_order_status` | volunteer+ | Order and delivery status for one registration |
 | `get_champagne_delivery_summary` | volunteer+ | Champagne delivery stats across the edition |
 | `get_undelivered_champagne_by_table` | volunteer+ | Tables with pending champagne deliveries |

--- a/docs/integrations/OPERATIONAL_LOOKUP.md
+++ b/docs/integrations/OPERATIONAL_LOOKUP.md
@@ -1,0 +1,61 @@
+# Authenticated Operational Lookup
+
+Operational lookup is centralized in the backend so web, Android, and MCP
+clients use the same normalization, ranking, privacy rules, and result bounds.
+
+## Privacy Boundary
+
+Fuzzy suggestions are only available to authenticated volunteers and admins.
+Public visitor registration recovery remains exact email-based through
+`POST /api/registrations/my/request`; it does not expose candidates.
+
+## Matching Policy
+
+| Field | Behavior |
+|---|---|
+| Person name | Accent-insensitive exact and substring matching, then ranked trigram suggestions |
+| Authorized email | Case-insensitive exact match first, then tightly bounded trigram suggestions |
+| Table visible label or ID | Deterministic normalization and substring matching only |
+| Registration ID, event ID, event title | Deterministic case-insensitive matching only |
+| Order product and category | Deterministic normalized matching only |
+| Numeric values and quantities | Exact deterministic matching only; never fuzzy |
+
+Person lookup uses PostgreSQL `unaccent` and `pg_trgm` over trigger-maintained
+normalized columns. Authorized email suggestions use `fuzzystrmatch`
+Levenshtein distance with a small maximum edit distance. The alternate name column covers common German
+transliterations such as `Mueller` for `Müller`; the primary `unaccent` rules
+cover diacritics and ligatures used across European names.
+
+## REST Consumers
+
+Android volunteer lookup uses:
+
+```text
+GET /api/volunteer/registrations?q=...&event_id=...&order_category=...&delivery_state=...
+GET /api/volunteer/tables/resolve?reference=Table%2012
+GET /api/volunteer/table-orders?table_reference=Table%2012
+```
+
+The endpoint returns at most 20 rows unless a bounded `limit` is supplied.
+Results omit email, phone, address, and identity fields.
+
+The PWA admin person picker uses:
+
+```text
+GET /api/people?q=...&active=true
+GET /api/registrations?q=...
+```
+
+This admin-only endpoint uses the same person-name and email ranking while
+retaining deterministic matching for admin-only fields. The registration table
+delegates active text searches to the backend instead of filtering its local
+snapshot literally.
+
+## MCP Consumers
+
+- `find_guest(name?, email?)` uses the shared PostgreSQL-backed person ranking
+  and returns bounded registration references for follow-up order reads.
+- `resolve_table_reference(reference)` resolves a visible table label without
+  fuzzy numeric matching.
+- `get_table_order_summary(table_id?, table_reference?)` accepts a visible
+  reference and returns candidates instead of auto-selecting ambiguous matches.

--- a/frontend/src/components/admin/PeopleManagement.tsx
+++ b/frontend/src/components/admin/PeopleManagement.tsx
@@ -104,13 +104,12 @@ export default function PeopleManagement({
   });
   const displayedPeople = debouncedQ ? (peopleSearchQuery.data ?? []) : people;
 
-  // Pre-filter by role when not searching; backend search bypasses role filter
   const preFiltered = useMemo(
     () =>
-      debouncedQ || roleFilter === "all"
+      roleFilter === "all"
         ? displayedPeople
         : displayedPeople.filter((p) => p.roles.includes(roleFilter)),
-    [displayedPeople, roleFilter, debouncedQ],
+    [displayedPeople, roleFilter],
   );
 
   // Group people by email to surface duplicates
@@ -499,6 +498,8 @@ export default function PeopleManagement({
             <div className="text-center py-4">
               <Spinner animation="border" variant="primary" size="sm" />
             </div>
+          ) : peopleSearchQuery.isError ? (
+            <p className="text-danger text-center py-4 mb-0">{m.admin_error_load_data()}</p>
           ) : table.getRowModel().rows.length === 0 ? (
             <p className="text-secondary text-center py-4 mb-0">{m.admin_people_no_results()}</p>
           ) : (

--- a/frontend/src/components/admin/PeopleManagement.tsx
+++ b/frontend/src/components/admin/PeopleManagement.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import { type FilterFn, type SortingState, type ColumnVisibilityState } from "@tanstack/react-table";
 import { useQuery } from "@tanstack/react-query";
 import Alert from "react-bootstrap/Alert";
@@ -14,6 +14,7 @@ import { m } from "@/paraglide/messages";
 import type { Person } from "@/types/person";
 import { queryKeys } from "@/utils/queryKeys";
 import { fetchAdminPersonRegistrations } from "@/utils/adminRegistrationApi";
+import { fetchPeopleSearch } from "@/utils/adminFetch";
 import {
   useAppTable,
   createAppColumnHelper,
@@ -69,6 +70,7 @@ export default function PeopleManagement({
   onDelete,
 }: PeopleManagementProps) {
   const [q, setQ] = useState("");
+  const [debouncedQ, setDebouncedQ] = useState("");
   const [roleFilter, setRoleFilter] = useState("all");
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnVisibility, setColumnVisibility] = useState<ColumnVisibilityState>(
@@ -89,10 +91,26 @@ export default function PeopleManagement({
   const [copySuccess, setCopySuccess] = useState(false);
   const [viewRegistrationsPerson, setViewRegistrationsPerson] = useState<Person | null>(null);
 
-  // Pre-filter by role; text search is handled by TanStack global filter
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQ(q.trim()), 300);
+    return () => clearTimeout(timer);
+  }, [q]);
+  const peopleSearchQuery = useQuery({
+    queryKey: ["admin", "people", "search", debouncedQ],
+    queryFn: () => fetchPeopleSearch(authHeaders, debouncedQ),
+    enabled: debouncedQ.length > 0,
+    staleTime: 30 * 1000,
+    retry: false,
+  });
+  const displayedPeople = debouncedQ ? (peopleSearchQuery.data ?? []) : people;
+
+  // Pre-filter by role when not searching; backend search bypasses role filter
   const preFiltered = useMemo(
-    () => (roleFilter === "all" ? people : people.filter((p) => p.roles.includes(roleFilter))),
-    [people, roleFilter],
+    () =>
+      debouncedQ || roleFilter === "all"
+        ? displayedPeople
+        : displayedPeople.filter((p) => p.roles.includes(roleFilter)),
+    [displayedPeople, roleFilter, debouncedQ],
   );
 
   // Group people by email to surface duplicates
@@ -347,7 +365,7 @@ export default function PeopleManagement({
     {
       data: preFiltered,
       columns,
-      state: { sorting, globalFilter: q, columnVisibility },
+      state: { sorting, globalFilter: debouncedQ ? "" : q, columnVisibility },
       getRowId: (row) => row.id,
       onSortingChange: setSorting,
       onGlobalFilterChange: setQ,
@@ -477,7 +495,7 @@ export default function PeopleManagement({
             </Alert>
           )}
 
-          {isLoading ? (
+          {isLoading || peopleSearchQuery.isLoading ? (
             <div className="text-center py-4">
               <Spinner animation="border" variant="primary" size="sm" />
             </div>

--- a/frontend/src/components/admin/RegistrationList.tsx
+++ b/frontend/src/components/admin/RegistrationList.tsx
@@ -684,7 +684,12 @@ export default function RegistrationList({
         </Card.Header>
 
         <Card.Body className="p-0">
-          {table.getRowModel().rows.length === 0 ? (
+          {registrationSearchQuery.isLoading ? (
+            <p className="text-secondary text-center py-4 mb-0">
+              <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
+              {m.admin_search_person_placeholder()}…
+            </p>
+          ) : table.getRowModel().rows.length === 0 ? (
             <p className="text-secondary text-center py-4 mb-0">{m.admin_no_registrations()}</p>
           ) : (
             <div className="table-responsive">

--- a/frontend/src/components/admin/RegistrationList.tsx
+++ b/frontend/src/components/admin/RegistrationList.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { type FilterFn, type SortingState, type ColumnVisibilityState } from "@tanstack/react-table";
 import Alert from "react-bootstrap/Alert";
 import Badge from "react-bootstrap/Badge";
@@ -21,6 +22,7 @@ import { exportToCsv } from "@/utils/csvExport";
 import RegistrationCreateModal from "./RegistrationCreateModal";
 import { ColumnVisibilityDropdown } from "./ColumnVisibilityDropdown";
 import { loadColVis, saveColVis } from "@/utils/columnVisibility";
+import { fetchRegistrations } from "@/utils/adminFetch";
 
 const COL_VIS_KEY = "admin-col-vis-registrations";
 
@@ -127,6 +129,7 @@ export default function RegistrationList({
   const [allocationFilter, setAllocationFilter] = useState("");
   const [editionFilter, setEditionFilter] = useState<EditionFilter>("all");
   const [q, setQ] = useState("");
+  const [debouncedQ, setDebouncedQ] = useState("");
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnVisibility, setColumnVisibility] = useState<ColumnVisibilityState>(
     () => loadColVis(COL_VIS_KEY),
@@ -135,6 +138,18 @@ export default function RegistrationList({
   const [bulkAction, setBulkAction] = useState<"confirm" | "cancel" | "paid" | null>(null);
   const [bulkInProgress, setBulkInProgress] = useState(false);
   const [bulkError, setBulkError] = useState<string | null>(null);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQ(q.trim()), 300);
+    return () => clearTimeout(timer);
+  }, [q]);
+  const registrationSearchQuery = useQuery({
+    queryKey: ["admin", "registrations", "search", debouncedQ],
+    queryFn: () => fetchRegistrations(authHeaders, debouncedQ),
+    enabled: debouncedQ.length > 0,
+    staleTime: 30 * 1000,
+    retry: false,
+  });
+  const displayedRegistrations = debouncedQ ? (registrationSearchQuery.data ?? []) : registrations;
 
   // Refs so column header/cell can read latest selection state without being in deps
   const selectedIdsRef = useRef<Set<string>>(selectedIds);
@@ -171,7 +186,7 @@ export default function RegistrationList({
   // Domain-level pre-filter (edition type, status, allocation) — text search handled by TanStack
   const preFiltered = useMemo(
     () =>
-      registrations.filter((registration) => {
+      displayedRegistrations.filter((registration) => {
         if (filter !== "all" && registration.status !== filter) return false;
         if (filterPersonId && registration.person.id !== filterPersonId) return false;
         const standalone = isStandaloneRegistration(registration);
@@ -179,7 +194,7 @@ export default function RegistrationList({
         if (editionFilter === "standalone" && !standalone) return false;
         return true;
       }),
-    [registrations, filter, filterPersonId, editionFilter],
+    [displayedRegistrations, filter, filterPersonId, editionFilter],
   );
 
   const handleAssignTable = useCallback(
@@ -455,7 +470,7 @@ export default function RegistrationList({
     {
       data: preFiltered,
       columns,
-      state: { sorting, globalFilter: q, columnVisibility },
+      state: { sorting, globalFilter: "", columnVisibility },
       getRowId: (row) => row.id,
       onSortingChange: setSorting,
       onGlobalFilterChange: setQ,

--- a/frontend/src/components/admin/RegistrationList.tsx
+++ b/frontend/src/components/admin/RegistrationList.tsx
@@ -689,6 +689,8 @@ export default function RegistrationList({
               <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
               {m.admin_search_person_placeholder()}…
             </p>
+          ) : registrationSearchQuery.isError ? (
+            <p className="text-danger text-center py-4 mb-0">{m.admin_error_load_data()}</p>
           ) : table.getRowModel().rows.length === 0 ? (
             <p className="text-secondary text-center py-4 mb-0">{m.admin_no_registrations()}</p>
           ) : (

--- a/frontend/src/utils/adminFetch.ts
+++ b/frontend/src/utils/adminFetch.ts
@@ -110,6 +110,18 @@ export async function fetchAreas(authHeaders: () => Record<string, string>): Pro
 // NOTE: /api/people and /api/volunteers both support optional limit/page pagination,
 // but we intentionally fetch all records here because client-side deduplication
 // (mergePeopleWithVolunteers) requires the full dataset.
+export async function fetchPeopleSearch(
+  authHeaders: () => Record<string, string>,
+  query: string,
+): Promise<Person[]> {
+  const payload = await fetchJsonOrThrowWithUnauthorized<Record<string, unknown>[]>(
+    `/api/people?q=${encodeURIComponent(query.trim())}`,
+    { headers: authHeaders() },
+    m.admin_error_load_data(),
+  );
+  return Array.isArray(payload) ? payload.map(apiToPerson) : [];
+}
+
 export async function fetchPeople(authHeaders: () => Record<string, string>): Promise<Person[]> {
   const [peoplePayload, volunteers] = await Promise.all([
     fetchJsonOrThrowWithUnauthorized<Record<string, unknown>[]>(

--- a/frontend/src/utils/adminFetch.ts
+++ b/frontend/src/utils/adminFetch.ts
@@ -114,12 +114,21 @@ export async function fetchPeopleSearch(
   authHeaders: () => Record<string, string>,
   query: string,
 ): Promise<Person[]> {
-  const payload = await fetchJsonOrThrowWithUnauthorized<Record<string, unknown>[]>(
-    `/api/people?q=${encodeURIComponent(query.trim())}`,
-    { headers: authHeaders() },
-    m.admin_error_load_data(),
-  );
-  return Array.isArray(payload) ? payload.map(apiToPerson) : [];
+  const [peoplePayload, volunteers] = await Promise.all([
+    fetchJsonOrThrowWithUnauthorized<Record<string, unknown>[]>(
+      `/api/people?q=${encodeURIComponent(query.trim())}`,
+      { headers: authHeaders() },
+      m.admin_error_load_data(),
+    ),
+    fetchArrayOrThrow(
+      "/api/volunteers",
+      { headers: authHeaders() },
+      m.admin_error_load_data(),
+      apiToPerson,
+    ),
+  ]);
+  const nextPeople = Array.isArray(peoplePayload) ? peoplePayload.map(apiToPerson) : [];
+  return mergePeopleWithVolunteers(nextPeople, volunteers);
 }
 
 export async function fetchPeople(authHeaders: () => Record<string, string>): Promise<Person[]> {

--- a/frontend/src/utils/adminFetch.ts
+++ b/frontend/src/utils/adminFetch.ts
@@ -19,9 +19,11 @@ import {
 
 export async function fetchRegistrations(
   authHeaders: () => Record<string, string>,
+  query?: string,
 ): Promise<Registration[]> {
+  const suffix = query?.trim() ? `?q=${encodeURIComponent(query.trim())}` : "";
   const payload = await fetchJsonOrThrowWithUnauthorized<Record<string, unknown>[]>(
-    "/api/registrations",
+    `/api/registrations${suffix}`,
     { headers: authHeaders() },
     m.admin_error_load_data(),
   );


### PR DESCRIPTION
Introduce a centralized authenticated operational lookup system: add app.services.operational_search (normalization, ranking, bounded results, and table/reference matching) and corresponding tests and docs. Add trigger-driven normalized columns (search_name, search_name_alt, search_email) and indexes via app.operational_search_schema plus Alembic migration 005; ensure schema is applied when creating tables in database/bootstrap and tests. Wire the new search logic into MCP and API routers (people, registrations, volunteer ops), add a resolve_table_reference tool/endpoint and update get_table_order_summary to accept visible table references and order filters. Also update Android lookup UI labels and related docs to reflect the expanded search capabilities.

Closes #514 