### PR TITLE
feat: add admin shortcut to public header

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,6 +3,7 @@ import LanguageSwitcher from "./LanguageSwitcher";
 import Navbar from "react-bootstrap/Navbar";
 import Container from "react-bootstrap/Container";
 import { navigationItems } from "@/config/navigation";
+import { Link } from "@tanstack/react-router";
 
 interface HeaderProps {
   logoSrc?: string;
@@ -25,7 +26,12 @@ const Header = ({ logoSrc = "/images/logo.svg" }: HeaderProps) => {
           ))}
         </div>
 
-        <LanguageSwitcher />
+        <div className="d-flex align-items-center gap-3">
+          <LanguageSwitcher />
+          <Link to="/admin" className="text-light" aria-label={m.admin_title()}>
+            <i className="bi bi-shield-lock" aria-hidden="true" />
+          </Link>
+        </div>
       </Container>
     </Navbar>
   );

--- a/frontend/tests/components/Header.test.tsx
+++ b/frontend/tests/components/Header.test.tsx
@@ -7,6 +7,7 @@ vi.mock("@/paraglide/messages", () => ({
     festival_name: () => "Champagne Festival",
     language_select: () => "Select language",
     header_logo_alt: () => "Champagne Festival logo",
+    admin_title: () => "Administration",
     nav_schedule: () => "Schedule",
     nav_community_events: () => "Community events",
     nav_faq: () => "FAQ",
@@ -22,6 +23,12 @@ vi.mock("@/paraglide/runtime", () => ({
 
 vi.mock("@/components/LanguageSwitcher", () => ({
   default: () => <div data-testid="language-switcher" />,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ to, ...props }: { to: string } & React.ComponentProps<"a">) => (
+    <a href={to} {...props} />
+  ),
 }));
 
 describe("Header component", () => {
@@ -54,5 +61,12 @@ describe("Header component", () => {
     render(<Header />);
     const brand = screen.getByText("Champagne Festival").closest("a");
     expect(brand).toHaveAttribute("href", "#welcome");
+  });
+
+  it("links to the administration page", () => {
+    render(<Header />);
+    const adminLink = screen.getByRole("link", { name: "Administration" });
+    expect(adminLink).toHaveAttribute("href", "/admin");
+    expect(adminLink.querySelector(".bi-shield-lock")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/Header.test.tsx
+++ b/frontend/tests/components/Header.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@/components/LanguageSwitcher", () => ({
 }));
 
 vi.mock("@tanstack/react-router", () => ({
-  Link: ({ to, ...props }: { to: string } & React.ComponentProps<"a">) => (
+  Link: ({ to, ...props }: { to: string } & import("react").ComponentProps<"a">) => (
     <a href={to} {...props} />
   ),
 }));


### PR DESCRIPTION
### Motivation

- Provide an always-visible, accessible shortcut to the admin UI from the public site header so admins can reach `/admin` quickly without needing to open a menu. 
- Keep the UI minimally intrusive by using a shield-lock icon and an accessible `aria-label` localized via the existing message module.

### Description

- Add a TanStack Router `Link` import and an admin shortcut next to the language switcher in `frontend/src/components/Header.tsx`, using `m.admin_title()` for the accessible label and rendering a `bi-shield-lock` icon. 
- Update `frontend/tests/components/Header.test.tsx` to mock `@tanstack/react-router`'s `Link`, add `admin_title` to the message mock, and add a test asserting the admin link exists, points to `/admin`, and contains the shield icon. 
- Commit recorded as `feat: add admin shortcut to public header`.

### Testing

- Ran component tests: `cd frontend && pnpm test -- tests/components/Header.test.tsx` and full suite `cd frontend && pnpm test`, and all tests passed (`32` test files, `278` tests on final run). 
- Ran lint: `cd frontend && pnpm lint`, which completed successfully while reporting three pre-existing `react-hooks(exhaustive-deps)` warnings in unrelated admin components. 
- Ran typecheck: `cd frontend && pnpm typecheck`, which completed successfully. 
- Built the frontend: `cd frontend && pnpm build`, which completed successfully and produced the `dist/` output; `git diff --check` returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca7353c48832eb3973c75585c6636)