### PR TITLE
Add volunteer manual check-in fallback

### DIFF
--- a/backend/app/routers/volunteer_ops.py
+++ b/backend/app/routers/volunteer_ops.py
@@ -28,7 +28,7 @@ from app.dependencies import Pagination
 from app.live import live_bus
 from app.live import mapping as live_mapping
 from app.models import Event, Person, Registration, Table
-from app.schemas import CheckInGuestOut, CheckInOut
+from app.schemas import CheckInGuestOut, CheckInOut, OrderItemBase
 from app.services.operational_search import (
     DEFAULT_RESULT_LIMIT,
     best_registration_match,
@@ -51,6 +51,11 @@ router = APIRouter(
 
 class VolunteerCheckInRequest(BaseModel):
     issue_strap: bool = True
+
+
+class VolunteerRegistrationUpdate(BaseModel):
+    pre_orders: list[OrderItemBase] | None = None
+    strap_issued: bool | None = None
 
 
 async def _resolve_tables(db: AsyncSession, reference: str) -> list[Table]:
@@ -270,6 +275,83 @@ async def search_registrations(
         registration_to_checkin_dict(registration, registration.person, registration.event, table_name=table_name)
         for _, registration, table_name in ranked_rows[offset : offset + limit]
     ]
+
+
+@router.put("/registrations/{registration_id}", response_model=CheckInGuestOut)
+async def update_volunteer_registration(
+    registration_id: str,
+    body: VolunteerRegistrationUpdate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> dict:
+    """Update entrance-facing registration fields from volunteer check-in."""
+
+    row = (
+        await db.execute(
+            select(Registration, Table.name)
+            .outerjoin(Table, Registration.table_id == Table.id)
+            .where(Registration.id == registration_id)
+            .options(selectinload(Registration.person), selectinload(Registration.event))
+        )
+    ).one_or_none()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Registration not found.")
+
+    registration, table_name = row
+    if registration.person is None or registration.event is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Registration not found.")
+
+    previous_orders = list(registration.pre_orders) if registration.pre_orders else []
+    previous_strap_issued = registration.strap_issued
+    changed = False
+    request_id = getattr(request.state, "request_id", None)
+    audit_base = {
+        "actor": actor,
+        "resource_type": "registration",
+        "resource_id": registration.id,
+        "request_id": request_id,
+    }
+
+    if body.pre_orders is not None:
+        registration.pre_orders = [item.model_dump() for item in body.pre_orders]
+        if registration.pre_orders != previous_orders:
+            changed = True
+            await write_audit_entry(
+                db,
+                action="delivery_updated",
+                details={"event_id": registration.event_id, "source": "volunteer_check_in"},
+                **audit_base,
+            )
+
+    if body.strap_issued is not None:
+        registration.strap_issued = body.strap_issued
+        if registration.strap_issued != previous_strap_issued:
+            changed = True
+            await write_audit_entry(
+                db,
+                action="strap_issued" if registration.strap_issued else "strap_revoked",
+                details={"event_id": registration.event_id, "source": "volunteer_check_in"},
+                **audit_base,
+            )
+
+    if changed:
+        await db.commit()
+        try:
+            await live_bus.publish(
+                live_mapping.registration_changed(
+                    action="updated",
+                    registration_id=registration.id,
+                    event_id=registration.event_id,
+                    edition_id=registration.event.edition_id,
+                )
+            )
+        except Exception:
+            logger.warning(
+                "live_bus.publish failed for volunteer registration update %s", registration.id, exc_info=True
+            )
+
+    return registration_to_checkin_dict(registration, registration.person, registration.event, table_name=table_name)
 
 
 @router.post("/registrations/{registration_id}/check-in", response_model=CheckInOut)

--- a/backend/app/routers/volunteer_ops.py
+++ b/backend/app/routers/volunteer_ops.py
@@ -11,18 +11,24 @@ staff).
 
 from __future__ import annotations
 
+import logging
+from datetime import UTC, datetime
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from pydantic import BaseModel
 from sqlalchemy import Text, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.auth import require_volunteer
+from app.audit import write_audit_entry
+from app.auth import get_actor_id, require_volunteer
 from app.database import get_db
 from app.dependencies import Pagination
+from app.live import live_bus
+from app.live import mapping as live_mapping
 from app.models import Event, Person, Registration, Table
-from app.schemas import CheckInGuestOut
+from app.schemas import CheckInGuestOut, CheckInOut
 from app.services.operational_search import (
     DEFAULT_RESULT_LIMIT,
     best_registration_match,
@@ -34,11 +40,17 @@ from app.services.operational_search import (
 )
 from app.utils import registration_to_checkin_dict
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(
     prefix="/api/volunteer",
     tags=["volunteer"],
     dependencies=[Depends(require_volunteer)],
 )
+
+
+class VolunteerCheckInRequest(BaseModel):
+    issue_strap: bool = True
 
 
 async def _resolve_tables(db: AsyncSession, reference: str) -> list[Table]:
@@ -258,3 +270,91 @@ async def search_registrations(
         registration_to_checkin_dict(registration, registration.person, registration.event, table_name=table_name)
         for _, registration, table_name in ranked_rows[offset : offset + limit]
     ]
+
+
+@router.post("/registrations/{registration_id}/check-in", response_model=CheckInOut)
+async def volunteer_check_in_registration(
+    registration_id: str,
+    body: VolunteerCheckInRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> dict:
+    """Mark a registration checked in from the authenticated volunteer flow.
+
+    This is the QR-code fallback for entrance volunteers. It accepts the same
+    ``issue_strap`` flag as the token-gated public check-in endpoint, but uses
+    the volunteer/admin Bearer token dependency instead of a per-registration
+    QR token. The response remains PII-free.
+    """
+
+    row = (
+        await db.execute(
+            select(Registration, Table.name)
+            .outerjoin(Table, Registration.table_id == Table.id)
+            .where(Registration.id == registration_id)
+            .options(selectinload(Registration.person), selectinload(Registration.event))
+        )
+    ).one_or_none()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Registration not found.")
+
+    registration, table_name = row
+    if registration.person is None or registration.event is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Registration not found.")
+
+    already = registration.checked_in
+    changed = False
+    strap_newly_issued = False
+
+    if not already:
+        registration.checked_in = True
+        registration.checked_in_at = datetime.now(UTC)
+        changed = True
+
+    if body.issue_strap and not registration.strap_issued:
+        registration.strap_issued = True
+        strap_newly_issued = True
+        changed = True
+
+    if changed:
+        request_id = getattr(request.state, "request_id", None)
+        audit_base = {
+            "actor": actor,
+            "resource_type": "registration",
+            "resource_id": registration.id,
+            "request_id": request_id,
+        }
+        if not already:
+            await write_audit_entry(
+                db,
+                action="check_in",
+                details={"event_id": registration.event_id, "source": "volunteer_search"},
+                **audit_base,
+            )
+        if strap_newly_issued:
+            await write_audit_entry(
+                db,
+                action="strap_issued",
+                details={"event_id": registration.event_id, "source": "volunteer_search"},
+                **audit_base,
+            )
+        await db.commit()
+        await db.refresh(registration)
+        try:
+            await live_bus.publish(
+                live_mapping.check_in_changed(
+                    registration_id=registration.id,
+                    event_id=registration.event_id,
+                    edition_id=registration.event.edition_id,
+                )
+            )
+        except Exception:
+            logger.warning("live_bus.publish failed for volunteer check-in %s", registration.id, exc_info=True)
+
+    return {
+        "registration": registration_to_checkin_dict(
+            registration, registration.person, registration.event, table_name=table_name
+        ),
+        "already_checked_in": already,
+    }

--- a/backend/app/routers/volunteer_ops.py
+++ b/backend/app/routers/volunteer_ops.py
@@ -315,16 +315,15 @@ async def update_volunteer_registration(
                 **audit_base,
             )
 
-    if body.strap_issued is not None:
+    if body.strap_issued is not None and body.strap_issued != previous_strap_issued:
         registration.strap_issued = body.strap_issued
-        if registration.strap_issued != previous_strap_issued:
-            changed = True
-            await write_audit_entry(
-                db,
-                action="strap_issued" if registration.strap_issued else "strap_revoked",
-                details={"event_id": registration.event_id, "source": "volunteer_check_in"},
-                **audit_base,
-            )
+        changed = True
+        await write_audit_entry(
+            db,
+            action="strap_issued" if registration.strap_issued else "strap_revoked",
+            details={"event_id": registration.event_id, "source": "volunteer_check_in"},
+            **audit_base,
+        )
 
     if changed:
         await db.commit()

--- a/backend/app/routers/volunteer_ops.py
+++ b/backend/app/routers/volunteer_ops.py
@@ -399,6 +399,10 @@ async def volunteer_check_in_registration(
         strap_newly_issued = True
         changed = True
 
+    registration_dict = registration_to_checkin_dict(
+        registration, registration.person, registration.event, table_name=table_name
+    )
+
     if changed:
         request_id = getattr(request.state, "request_id", None)
         audit_base = {
@@ -421,22 +425,22 @@ async def volunteer_check_in_registration(
                 details={"event_id": registration.event_id, "source": "volunteer_search"},
                 **audit_base,
             )
+        reg_id = registration.id
+        event_id = registration.event_id
+        edition_id = registration.event.edition_id
         await db.commit()
-        await db.refresh(registration)
         try:
             await live_bus.publish(
                 live_mapping.check_in_changed(
-                    registration_id=registration.id,
-                    event_id=registration.event_id,
-                    edition_id=registration.event.edition_id,
+                    registration_id=reg_id,
+                    event_id=event_id,
+                    edition_id=edition_id,
                 )
             )
         except Exception:
-            logger.warning("live_bus.publish failed for volunteer check-in %s", registration.id, exc_info=True)
+            logger.warning("live_bus.publish failed for volunteer check-in %s", reg_id, exc_info=True)
 
     return {
-        "registration": registration_to_checkin_dict(
-            registration, registration.person, registration.event, table_name=table_name
-        ),
+        "registration": registration_dict,
         "already_checked_in": already,
     }

--- a/backend/app/routers/volunteer_ops.py
+++ b/backend/app/routers/volunteer_ops.py
@@ -16,7 +16,6 @@ from datetime import UTC, datetime
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from pydantic import BaseModel
 from sqlalchemy import Text, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -28,7 +27,7 @@ from app.dependencies import Pagination
 from app.live import live_bus
 from app.live import mapping as live_mapping
 from app.models import Event, Person, Registration, Table
-from app.schemas import CheckInGuestOut, CheckInOut, OrderItemBase
+from app.schemas import CheckInGuestOut, CheckInOut, VolunteerCheckInRequest, VolunteerRegistrationUpdate
 from app.services.operational_search import (
     DEFAULT_RESULT_LIMIT,
     best_registration_match,
@@ -47,15 +46,6 @@ router = APIRouter(
     tags=["volunteer"],
     dependencies=[Depends(require_volunteer)],
 )
-
-
-class VolunteerCheckInRequest(BaseModel):
-    issue_strap: bool = True
-
-
-class VolunteerRegistrationUpdate(BaseModel):
-    pre_orders: list[OrderItemBase] | None = None
-    strap_issued: bool | None = None
 
 
 async def _resolve_tables(db: AsyncSession, reference: str) -> list[Table]:
@@ -314,8 +304,9 @@ async def update_volunteer_registration(
     }
 
     if body.pre_orders is not None:
-        registration.pre_orders = [item.model_dump() for item in body.pre_orders]
-        if registration.pre_orders != previous_orders:
+        new_orders = [item.model_dump() for item in body.pre_orders]
+        if new_orders != previous_orders:
+            registration.pre_orders = new_orders
             changed = True
             await write_audit_entry(
                 db,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -424,6 +424,15 @@ class CheckInOut(BaseModel):
     already_checked_in: bool
 
 
+class VolunteerCheckInRequest(BaseModel):
+    issue_strap: bool = True
+
+
+class VolunteerRegistrationUpdate(BaseModel):
+    pre_orders: list[OrderItemBase] | None = None
+    strap_issued: bool | None = None
+
+
 # ---------------------------------------------------------------------------
 # People
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_volunteer_ops.py
+++ b/backend/tests/test_volunteer_ops.py
@@ -147,6 +147,39 @@ async def test_volunteer_can_check_in_from_registration_search(client):
 
 
 @pytest.mark.anyio
+async def test_volunteer_can_issue_strap_and_update_delivery_from_check_in_card(client):
+    registration = await _post_registration(client, path="/api/registrations")
+    assert registration.status_code == 201
+    registration_id = registration.json()["id"]
+
+    r = await client.put(
+        f"/api/volunteer/registrations/{registration_id}",
+        json={
+            "strap_issued": True,
+            "pre_orders": [
+                {
+                    "product_id": "prod-01",
+                    "name": "Champagne bottle",
+                    "quantity": 2,
+                    "delivered_quantity": 1,
+                    "price": 42,
+                    "category": "champagne",
+                    "delivered": False,
+                }
+            ],
+        },
+    )
+
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["id"] == registration_id
+    assert payload["strap_issued"] is True
+    assert payload["pre_orders"][0]["delivered_quantity"] == 1
+    assert "email" not in payload
+    assert "phone" not in payload
+
+
+@pytest.mark.anyio
 async def test_volunteer_table_order_lookup_returns_candidates_for_ambiguous_reference(client):
     await _create_table(client, name="Table 12")
     await _create_table(client, name="Table 12 terrace")

--- a/backend/tests/test_volunteer_ops.py
+++ b/backend/tests/test_volunteer_ops.py
@@ -120,6 +120,33 @@ async def test_volunteer_registrations_normalize_visible_table_reference_and_fil
 
 
 @pytest.mark.anyio
+async def test_volunteer_can_check_in_from_registration_search(client):
+    registration = await _post_registration(client, path="/api/registrations")
+    assert registration.status_code == 201
+    registration_id = registration.json()["id"]
+
+    r = await client.post(
+        f"/api/volunteer/registrations/{registration_id}/check-in",
+        json={"issue_strap": True},
+    )
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["already_checked_in"] is False
+    assert payload["registration"]["id"] == registration_id
+    assert payload["registration"]["checked_in"] is True
+    assert payload["registration"]["strap_issued"] is True
+    assert "email" not in payload["registration"]
+    assert "phone" not in payload["registration"]
+
+    r = await client.post(
+        f"/api/volunteer/registrations/{registration_id}/check-in",
+        json={"issue_strap": True},
+    )
+    assert r.status_code == 200
+    assert r.json()["already_checked_in"] is True
+
+
+@pytest.mark.anyio
 async def test_volunteer_table_order_lookup_returns_candidates_for_ambiguous_reference(client):
     await _create_table(client, name="Table 12")
     await _create_table(client, name="Table 12 terrace")

--- a/backend/tests/test_volunteer_ops.py
+++ b/backend/tests/test_volunteer_ops.py
@@ -180,6 +180,24 @@ async def test_volunteer_can_issue_strap_and_update_delivery_from_check_in_card(
 
 
 @pytest.mark.anyio
+async def test_volunteer_update_registration_returns_404_for_unknown_id(client):
+    r = await client.put(
+        "/api/volunteer/registrations/nonexistent-id",
+        json={"strap_issued": True},
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_volunteer_check_in_returns_404_for_unknown_id(client):
+    r = await client.post(
+        "/api/volunteer/registrations/nonexistent-id/check-in",
+        json={"issue_strap": False},
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.anyio
 async def test_volunteer_table_order_lookup_returns_candidates_for_ambiguous_reference(client):
     await _create_table(client, name="Table 12")
     await _create_table(client, name="Table 12 terrace")

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -231,7 +231,7 @@
   "checkin_pre_orders": "Pre-orders",
   "checkin_not_found": "Reservation not found.",
   "checkin_invalid_token": "Invalid check-in code.",
-  "checkin_do_checkin": "Check in & issue strap",
+  "checkin_do_checkin": "Check in",
   "checkin_error": "An error occurred during check-in.",
   "admin_content_tab": "Content",
   "admin_content_editions_section": "Festival Editions",
@@ -588,5 +588,8 @@
   "checkin_manual_search_no_results": "No matching registrations found.",
   "checkin_manual_search_unauthorized": "Sign in as a volunteer or admin to search registrations.",
   "checkin_manual_not_checked_in": "Not checked in",
-  "checkin_search_error": "Could not search registrations."
+  "checkin_search_error": "Could not search registrations.",
+  "checkin_table": "Table",
+  "checkin_actions_login_required": "Sign in as a volunteer or admin to issue straps and update pre-orders.",
+  "checkin_actions_unauthorized": "Sign in as a volunteer or admin to update entrance actions."
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -221,7 +221,7 @@
   "admin_error_check_in": "Check-in failed.",
   "admin_error_bottle_delivery": "Failed to update delivery status.",
   "checkin_title": "Check-in",
-  "checkin_scan_prompt": "Scan the QR code or enter the reservation ID",
+  "checkin_scan_prompt": "Scan a QR code to begin, or use volunteer search when a QR code is unavailable.",
   "checkin_looking_up": "Looking up reservation...",
   "checkin_success": "Successfully checked in!",
   "checkin_already_in": "This guest already checked in at",
@@ -577,5 +577,16 @@
   "admin_bulk_content_archive_error": "{failed} of {total} items could not be archived.",
   "admin_select_all": "Select all visible",
   "admin_value_yes": "Yes",
-  "admin_value_no": "No"
+  "admin_value_no": "No",
+  "checkin_manual_search_title": "Find guest manually",
+  "checkin_manual_search_login_required": "Volunteer authentication is required to search registrations manually.",
+  "checkin_manual_search_label": "Guest name or email",
+  "checkin_manual_search_placeholder": "Search by guest name or email…",
+  "checkin_manual_search_help": "Results hide email and phone details and only show entrance check-in information.",
+  "checkin_manual_search_min_chars": "Enter at least 2 characters to search.",
+  "checkin_manual_search_loading": "Searching registrations…",
+  "checkin_manual_search_no_results": "No matching registrations found.",
+  "checkin_manual_search_unauthorized": "Sign in as a volunteer or admin to search registrations.",
+  "checkin_manual_not_checked_in": "Not checked in",
+  "checkin_search_error": "Could not search registrations."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -221,7 +221,7 @@
   "admin_error_check_in": "Échec de l'enregistrement.",
   "admin_error_bottle_delivery": "Échec de la mise à jour du statut de livraison.",
   "checkin_title": "Enregistrement",
-  "checkin_scan_prompt": "Scannez le code QR ou entrez l'identifiant de réservation",
+  "checkin_scan_prompt": "Scannez un code QR pour commencer, ou utilisez la recherche bénévole lorsqu’aucun code QR n’est disponible.",
   "checkin_looking_up": "Recherche de la réservation...",
   "checkin_success": "Enregistrement réussi !",
   "checkin_already_in": "Cet invité s'est déjà enregistré le",
@@ -577,5 +577,16 @@
   "admin_bulk_content_archive_error": "{failed} élément(s) sur {total} n'ont pas pu être archivés.",
   "admin_select_all": "Tout sélectionner (visibles)",
   "admin_value_yes": "Oui",
-  "admin_value_no": "Non"
+  "admin_value_no": "Non",
+  "checkin_manual_search_title": "Rechercher un invité manuellement",
+  "checkin_manual_search_login_required": "Une authentification bénévole est requise pour rechercher des réservations manuellement.",
+  "checkin_manual_search_label": "Nom ou e-mail de l’invité",
+  "checkin_manual_search_placeholder": "Rechercher par nom ou e-mail d’invité…",
+  "checkin_manual_search_help": "Les résultats masquent l’e-mail et le téléphone et affichent uniquement les informations utiles à l’entrée.",
+  "checkin_manual_search_min_chars": "Saisissez au moins 2 caractères pour rechercher.",
+  "checkin_manual_search_loading": "Recherche des réservations…",
+  "checkin_manual_search_no_results": "Aucune réservation correspondante trouvée.",
+  "checkin_manual_search_unauthorized": "Connectez-vous comme bénévole ou admin pour rechercher des réservations.",
+  "checkin_manual_not_checked_in": "Pas encore enregistré",
+  "checkin_search_error": "Impossible de rechercher les réservations."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -231,7 +231,7 @@
   "checkin_pre_orders": "Précommandes",
   "checkin_not_found": "Réservation introuvable.",
   "checkin_invalid_token": "Code d'enregistrement invalide.",
-  "checkin_do_checkin": "Enregistrer & remettre le bracelet",
+  "checkin_do_checkin": "Enregistrer",
   "checkin_error": "Une erreur s'est produite lors de l'enregistrement.",
   "admin_content_tab": "Contenu",
   "admin_content_editions_section": "Éditions du festival",
@@ -588,5 +588,8 @@
   "checkin_manual_search_no_results": "Aucune réservation correspondante trouvée.",
   "checkin_manual_search_unauthorized": "Connectez-vous comme bénévole ou admin pour rechercher des réservations.",
   "checkin_manual_not_checked_in": "Pas encore enregistré",
-  "checkin_search_error": "Impossible de rechercher les réservations."
+  "checkin_search_error": "Impossible de rechercher les réservations.",
+  "checkin_table": "Table",
+  "checkin_actions_login_required": "Connectez-vous comme bénévole ou admin pour remettre les bracelets et mettre à jour les précommandes.",
+  "checkin_actions_unauthorized": "Connectez-vous comme bénévole ou admin pour mettre à jour les actions d’entrée."
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -221,7 +221,7 @@
   "admin_error_check_in": "Inchecken mislukt.",
   "admin_error_bottle_delivery": "Levering bijwerken mislukt.",
   "checkin_title": "Incheck",
-  "checkin_scan_prompt": "Scan de QR-code of voer het reservatienummer in",
+  "checkin_scan_prompt": "Scan een QR-code om te beginnen, of gebruik de vrijwilligerszoekfunctie wanneer er geen QR-code beschikbaar is.",
   "checkin_looking_up": "Reservatie opzoeken...",
   "checkin_success": "Succesvol ingecheckt!",
   "checkin_already_in": "Deze gast is al ingecheckt op",
@@ -577,5 +577,16 @@
   "admin_bulk_content_archive_error": "{failed} van {total} items konden niet worden gearchiveerd.",
   "admin_select_all": "Alle zichtbare selecteren",
   "admin_value_yes": "Ja",
-  "admin_value_no": "Nee"
+  "admin_value_no": "Nee",
+  "checkin_manual_search_title": "Gast handmatig zoeken",
+  "checkin_manual_search_login_required": "Vrijwilligersauthenticatie is vereist om registraties handmatig te zoeken.",
+  "checkin_manual_search_label": "Naam of e-mailadres van gast",
+  "checkin_manual_search_placeholder": "Zoek op naam of e-mailadres van gast…",
+  "checkin_manual_search_help": "Resultaten verbergen e-mail- en telefoongegevens en tonen alleen informatie voor de ingang.",
+  "checkin_manual_search_min_chars": "Voer minstens 2 tekens in om te zoeken.",
+  "checkin_manual_search_loading": "Registraties zoeken…",
+  "checkin_manual_search_no_results": "Geen overeenkomende registraties gevonden.",
+  "checkin_manual_search_unauthorized": "Meld je aan als vrijwilliger of admin om registraties te zoeken.",
+  "checkin_manual_not_checked_in": "Niet ingecheckt",
+  "checkin_search_error": "Registraties zoeken is mislukt."
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -231,7 +231,7 @@
   "checkin_pre_orders": "Voorbestellingen",
   "checkin_not_found": "Reservatie niet gevonden.",
   "checkin_invalid_token": "Ongeldige check-in code.",
-  "checkin_do_checkin": "Inchecken & polsband uitreiken",
+  "checkin_do_checkin": "Inchecken",
   "checkin_error": "Er is een fout opgetreden bij het inchecken.",
   "admin_content_tab": "Inhoud",
   "admin_content_editions_section": "Festival Edities",
@@ -588,5 +588,8 @@
   "checkin_manual_search_no_results": "Geen overeenkomende registraties gevonden.",
   "checkin_manual_search_unauthorized": "Meld je aan als vrijwilliger of admin om registraties te zoeken.",
   "checkin_manual_not_checked_in": "Niet ingecheckt",
-  "checkin_search_error": "Registraties zoeken is mislukt."
+  "checkin_search_error": "Registraties zoeken is mislukt.",
+  "checkin_table": "Tafel",
+  "checkin_actions_login_required": "Meld je aan als vrijwilliger of admin om polsbanden uit te reiken en voorbestellingen bij te werken.",
+  "checkin_actions_unauthorized": "Meld je aan als vrijwilliger of admin om acties aan de ingang bij te werken."
 }

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -287,7 +287,7 @@ export default function CheckInPage() {
   });
 
   const volunteerCheckInMutation = useMutation({
-    mutationFn: () => submitVolunteerCheckIn(manualRegistration!.id, authHeaders),
+    mutationFn: (regId: string) => submitVolunteerCheckIn(regId, authHeaders),
     retry: false,
     onMutate: () => {
       setSuccess(false);
@@ -375,7 +375,7 @@ export default function CheckInPage() {
       return;
     }
     if (!manualRegistration) return;
-    volunteerCheckInMutation.mutate();
+    volunteerCheckInMutation.mutate(manualRegistration.id);
   }, [checkInMutation, hasQrCredentials, manualRegistration, volunteerCheckInMutation]);
 
   const handleAdjustPreOrder = useCallback(

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -168,6 +168,12 @@ function CheckInCard({
                 </ListGroup.Item>
               ))}
             </ListGroup>
+            {!canManageEntranceActions && registration.checkedIn && registration.strapIssued && (
+              <div className="small text-secondary mt-2">
+                <i className="bi bi-info-circle me-1" aria-hidden="true" />
+                {m.checkin_actions_login_required()}
+              </div>
+            )}
           </div>
         )}
       </Card.Body>
@@ -252,6 +258,16 @@ export default function CheckInPage() {
     }, 300);
     return () => window.clearTimeout(timer);
   }, [searchTerm]);
+
+  useEffect(() => {
+    if (hasQrCredentials) {
+      setManualRegistration(null);
+      setSuccess(false);
+      setAlreadyCheckedIn(false);
+      setSearchTerm("");
+      setDebouncedSearchTerm("");
+    }
+  }, [registrationId, checkInToken, hasQrCredentials]);
 
   const registrationQuery = useQuery({
     queryKey: checkInQueryKey,
@@ -366,7 +382,7 @@ export default function CheckInPage() {
           : updateRegistrationMutation.error.message
         : "";
   const isAlreadyCheckedIn = success ? alreadyCheckedIn : (registration?.checkedIn ?? false);
-  const searchResults = volunteerSearchQuery.data ?? [];
+  const searchResults = debouncedSearchTerm.length >= 2 ? (volunteerSearchQuery.data ?? []) : [];
   const showSearchHint = !hasQrCredentials && searchTerm.trim().length > 0 && searchTerm.trim().length < 2;
 
   const handleCheckIn = useCallback(() => {

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useSearch } from "@tanstack/react-router";
 import Container from "react-bootstrap/Container";
 import Card from "react-bootstrap/Card";
@@ -236,10 +236,13 @@ export default function CheckInPage() {
   const checkInQueryKey = queryKeys.checkInRegistration(registrationId ?? "", checkInToken ?? "");
 
   const authHeaders = useCallback(
-    (): Record<string, string> => ({
-      "Content-Type": "application/json",
-      ...(auth.getAccessToken() ? { Authorization: `Bearer ${auth.getAccessToken()}` } : {}),
-    }),
+    (): Record<string, string> => {
+      const token = auth.getAccessToken();
+      return {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      };
+    },
     [auth],
   );
 
@@ -364,10 +367,7 @@ export default function CheckInPage() {
         : "";
   const isAlreadyCheckedIn = success ? alreadyCheckedIn : (registration?.checkedIn ?? false);
   const searchResults = volunteerSearchQuery.data ?? [];
-  const showSearchHint = useMemo(
-    () => !hasQrCredentials && searchTerm.trim().length > 0 && searchTerm.trim().length < 2,
-    [hasQrCredentials, searchTerm],
-  );
+  const showSearchHint = !hasQrCredentials && searchTerm.trim().length > 0 && searchTerm.trim().length < 2;
 
   const handleCheckIn = useCallback(() => {
     if (hasQrCredentials) {

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useSearch } from "@tanstack/react-router";
 import Container from "react-bootstrap/Container";
 import Card from "react-bootstrap/Card";
@@ -9,27 +9,188 @@ import Alert from "react-bootstrap/Alert";
 import Spinner from "react-bootstrap/Spinner";
 import Badge from "react-bootstrap/Badge";
 import ListGroup from "react-bootstrap/ListGroup";
+import Form from "react-bootstrap/Form";
+import Collapse from "react-bootstrap/Collapse";
 import { m } from "@/paraglide/messages";
+import { useAuth } from "@/contexts/AuthContext";
 import { queryKeys } from "@/utils/queryKeys";
 import {
   CheckInError,
   fetchCheckInRegistration,
   submitCheckIn,
+  type CheckInData,
 } from "@/utils/publicRegistrationApi";
+import { searchVolunteerRegistrations, submitVolunteerCheckIn } from "@/utils/volunteerApi";
+
+interface CheckInCardProps {
+  registration: CheckInData;
+  success: boolean;
+  isAlreadyCheckedIn: boolean;
+  isCheckingIn: boolean;
+  onCheckIn: () => void;
+}
+
+function CheckInCard({
+  registration,
+  success,
+  isAlreadyCheckedIn,
+  isCheckingIn,
+  onCheckIn,
+}: CheckInCardProps) {
+  return (
+    <Card
+      bg="dark"
+      text="white"
+      border={success ? "success" : isAlreadyCheckedIn ? "warning" : "secondary"}
+    >
+      <Card.Header
+        className={clsx(
+          "d-flex align-items-center justify-content-between gap-3 flex-wrap",
+          success ? "border-success" : isAlreadyCheckedIn ? "border-warning" : "border-secondary",
+        )}
+      >
+        <span className="fw-semibold fs-5">
+          <i className="bi bi-person-fill me-2" aria-hidden="true" />
+          {registration.name}
+        </span>
+        <div className="d-flex gap-2 flex-wrap">
+          {registration.checkedIn && (
+            <Badge bg="success">
+              <i className="bi bi-check-circle-fill me-1" aria-hidden="true" />
+              {m.admin_checked_in()}
+            </Badge>
+          )}
+          {registration.strapIssued && (
+            <Badge bg="info">
+              <i className="bi bi-person-badge-fill me-1" aria-hidden="true" />
+              {m.admin_strap_issued()}
+            </Badge>
+          )}
+        </div>
+      </Card.Header>
+
+      <Card.Body>
+        {success && (
+          <Alert variant="success" className="mb-3">
+            <i className="bi bi-check-circle-fill me-2" aria-hidden="true" />
+            <strong>{m.checkin_success()}</strong>
+            <div className="mt-1">{m.checkin_strap_issued()}</div>
+          </Alert>
+        )}
+
+        {isAlreadyCheckedIn && !success && registration.checkedInAt && (
+          <Alert variant="warning" className="mb-3">
+            <i className="bi bi-exclamation-circle-fill me-2" aria-hidden="true" />
+            {m.checkin_already_in()} {new Date(registration.checkedInAt).toLocaleTimeString()}
+          </Alert>
+        )}
+
+        <ListGroup variant="flush" className="bg-dark">
+          <ListGroup.Item className="bg-dark text-light border-secondary d-flex justify-content-between gap-3">
+            <span className="text-secondary">{m.checkin_event()}</span>
+            <span className="text-end">{registration.eventTitle || registration.eventId}</span>
+          </ListGroup.Item>
+          <ListGroup.Item className="bg-dark text-light border-secondary d-flex justify-content-between gap-3">
+            <span className="text-secondary">{m.checkin_guests()}</span>
+            <span>{registration.guestCount}</span>
+          </ListGroup.Item>
+        </ListGroup>
+
+        {registration.preOrders.length > 0 && (
+          <div className="mt-3">
+            <p className="fw-semibold text-warning mb-2">
+              <i className="bi bi-cart-fill me-2" aria-hidden="true" />
+              {m.checkin_pre_orders()}
+            </p>
+            <ListGroup variant="flush">
+              {registration.preOrders.map((item, idx) => (
+                <ListGroup.Item
+                  key={`${item.productId}-${idx}`}
+                  className="bg-dark text-light border-secondary d-flex justify-content-between align-items-center gap-3 flex-wrap"
+                >
+                  <span>
+                    {item.name} <Badge bg="secondary">×{item.quantity}</Badge>
+                  </span>
+                  <div className="d-flex gap-2 flex-wrap">
+                    <Badge bg={item.delivered ? "success" : "secondary"}>
+                      {m.admin_bottle_delivered()}: {item.deliveredQuantity}/{item.quantity}
+                    </Badge>
+                    <Badge bg={item.remainingQuantity > 0 ? "warning" : "success"} text="dark">
+                      {m.admin_bottle_not_delivered()}: {item.remainingQuantity}
+                    </Badge>
+                  </div>
+                </ListGroup.Item>
+              ))}
+            </ListGroup>
+          </div>
+        )}
+      </Card.Body>
+
+      {!registration.checkedIn && (
+        <Card.Footer className="bg-dark border-secondary">
+          <Button variant="warning" className="w-100" onClick={onCheckIn} disabled={isCheckingIn}>
+            {isCheckingIn ? (
+              <Spinner
+                as="span"
+                animation="border"
+                size="sm"
+                role="status"
+                aria-hidden="true"
+                className="me-2"
+              />
+            ) : (
+              <i className="bi bi-person-check-fill me-2" aria-hidden="true" />
+            )}
+            {m.checkin_do_checkin()}
+          </Button>
+        </Card.Footer>
+      )}
+    </Card>
+  );
+}
 
 export default function CheckInPage() {
   const queryClient = useQueryClient();
+  const auth = useAuth();
   const { id: registrationId, token: checkInToken } = useSearch({ from: "/check-in" });
   const [success, setSuccess] = useState(false);
   const [alreadyCheckedIn, setAlreadyCheckedIn] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(true);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
+  const [manualRegistration, setManualRegistration] = useState<CheckInData | null>(null);
+  const hasQrCredentials = Boolean(registrationId && checkInToken);
   const checkInQueryKey = queryKeys.checkInRegistration(registrationId ?? "", checkInToken ?? "");
+
+  const authHeaders = useCallback(
+    (): Record<string, string> => ({
+      "Content-Type": "application/json",
+      ...(auth.getAccessToken() ? { Authorization: `Bearer ${auth.getAccessToken()}` } : {}),
+    }),
+    [auth],
+  );
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedSearchTerm(searchTerm.trim());
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [searchTerm]);
 
   const registrationQuery = useQuery({
     queryKey: checkInQueryKey,
     queryFn: () => fetchCheckInRegistration(registrationId!, checkInToken!),
-    enabled: Boolean(registrationId && checkInToken),
+    enabled: hasQrCredentials,
     retry: false,
     staleTime: 30 * 1000,
+  });
+
+  const volunteerSearchQuery = useQuery({
+    queryKey: queryKeys.volunteerRegistrationSearch(debouncedSearchTerm),
+    queryFn: ({ signal }) => searchVolunteerRegistrations(debouncedSearchTerm, authHeaders, signal),
+    enabled: !hasQrCredentials && auth.isAuthenticated && debouncedSearchTerm.length >= 2,
+    retry: false,
+    staleTime: 15 * 1000,
   });
 
   const checkInMutation = useMutation({
@@ -39,10 +200,7 @@ export default function CheckInPage() {
       setSuccess(false);
       setAlreadyCheckedIn(false);
     },
-    onSuccess: ({
-      registration: updatedRegistration,
-      alreadyCheckedIn: mutationAlreadyCheckedIn,
-    }) => {
+    onSuccess: ({ registration: updatedRegistration, alreadyCheckedIn: mutationAlreadyCheckedIn }) => {
       queryClient.setQueryData(checkInQueryKey, updatedRegistration);
       setSuccess(true);
       setAlreadyCheckedIn(mutationAlreadyCheckedIn || updatedRegistration.checkedIn);
@@ -52,42 +210,64 @@ export default function CheckInPage() {
     },
   });
 
-  const registration = checkInMutation.data?.registration ?? registrationQuery.data ?? null;
-  const isLoading = registrationQuery.isPending;
-  const isCheckingIn = checkInMutation.isPending;
+  const volunteerCheckInMutation = useMutation({
+    mutationFn: () => submitVolunteerCheckIn(manualRegistration!.id, authHeaders),
+    retry: false,
+    onMutate: () => {
+      setSuccess(false);
+      setAlreadyCheckedIn(false);
+    },
+    onSuccess: ({ registration: updatedRegistration, alreadyCheckedIn: mutationAlreadyCheckedIn }) => {
+      setManualRegistration(updatedRegistration);
+      setSuccess(true);
+      setAlreadyCheckedIn(mutationAlreadyCheckedIn || updatedRegistration.checkedIn);
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.volunteerRegistrationSearch(debouncedSearchTerm),
+      });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.admin.registrations });
+    },
+  });
+
+  const registration =
+    volunteerCheckInMutation.data?.registration ??
+    manualRegistration ??
+    checkInMutation.data?.registration ??
+    registrationQuery.data ??
+    null;
+  const isLoading = hasQrCredentials ? registrationQuery.isPending : false;
+  const isCheckingIn = checkInMutation.isPending || volunteerCheckInMutation.isPending;
   const queryError = registrationQuery.isError ? registrationQuery.error.message : "";
   const mutationError = checkInMutation.isError
     ? checkInMutation.error instanceof CheckInError
       ? checkInMutation.error.message
       : m.checkin_error()
-    : "";
+    : volunteerCheckInMutation.isError
+      ? volunteerCheckInMutation.error.message
+      : "";
   const isAlreadyCheckedIn = success ? alreadyCheckedIn : (registration?.checkedIn ?? false);
+  const searchResults = volunteerSearchQuery.data ?? [];
+  const showSearchHint = useMemo(
+    () => !hasQrCredentials && searchTerm.trim().length > 0 && searchTerm.trim().length < 2,
+    [hasQrCredentials, searchTerm],
+  );
 
   const handleCheckIn = useCallback(() => {
-    if (!registrationId || !checkInToken) return;
-    checkInMutation.mutate();
-  }, [checkInMutation, checkInToken, registrationId]);
+    if (hasQrCredentials) {
+      checkInMutation.mutate();
+      return;
+    }
+    if (!manualRegistration) return;
+    volunteerCheckInMutation.mutate();
+  }, [checkInMutation, hasQrCredentials, manualRegistration, volunteerCheckInMutation]);
 
-  if (!registrationId || !checkInToken) {
-    return (
-      <section id="check-in" className="py-5" aria-labelledby="checkin-title">
-        <Container>
-          <h2 id="checkin-title" className="text-center mb-4 text-warning">
-            <i className="bi bi-qr-code-scan me-2" aria-hidden="true" />
-            {m.checkin_title()}
-          </h2>
-          <div className="row justify-content-center">
-            <div className="col-12 col-sm-8 col-md-6">
-              <Alert variant="warning" className="text-center">
-                <i className="bi bi-info-circle me-2" aria-hidden="true" />
-                {m.checkin_scan_prompt()}
-              </Alert>
-            </div>
-          </div>
-        </Container>
-      </section>
-    );
-  }
+  const handleSelectManualRegistration = useCallback((selected: CheckInData) => {
+    setManualRegistration(selected);
+    setSuccess(false);
+    setAlreadyCheckedIn(selected.checkedIn);
+    setSearchOpen(false);
+  }, []);
 
   return (
     <section id="check-in" className="py-5" aria-labelledby="checkin-title">
@@ -99,6 +279,127 @@ export default function CheckInPage() {
 
         <div className="row justify-content-center">
           <div className="col-12 col-sm-10 col-md-8 col-lg-6">
+            {!hasQrCredentials && (
+              <>
+                <Alert variant="warning" className="text-center">
+                  <i className="bi bi-info-circle me-2" aria-hidden="true" />
+                  {m.checkin_scan_prompt()}
+                </Alert>
+
+                <Card bg="dark" text="white" border="secondary" className="mb-3">
+                  <Card.Header className="bg-dark border-secondary p-0">
+                    <Button
+                      variant="link"
+                      className="w-100 text-start text-warning text-decoration-none p-3 d-flex justify-content-between align-items-center"
+                      onClick={() => setSearchOpen((open) => !open)}
+                      aria-expanded={searchOpen}
+                      aria-controls="manual-checkin-search"
+                    >
+                      <span>
+                        <i className="bi bi-search me-2" aria-hidden="true" />
+                        {m.checkin_manual_search_title()}
+                      </span>
+                      <i
+                        className={clsx("bi", searchOpen ? "bi-chevron-up" : "bi-chevron-down")}
+                        aria-hidden="true"
+                      />
+                    </Button>
+                  </Card.Header>
+                  <Collapse in={searchOpen}>
+                    <Card.Body id="manual-checkin-search">
+                      {!auth.isAuthenticated && (
+                        <Alert variant="info" className="d-flex justify-content-between align-items-center gap-3 flex-wrap">
+                          <span>{m.checkin_manual_search_login_required()}</span>
+                          <Button variant="outline-warning" size="sm" onClick={auth.login}>
+                            {m.admin_login_button()}
+                          </Button>
+                        </Alert>
+                      )}
+
+                      <Form.Group controlId="manual-checkin-query">
+                        <Form.Label>{m.checkin_manual_search_label()}</Form.Label>
+                        <Form.Control
+                          type="search"
+                          value={searchTerm}
+                          onChange={(event) => {
+                            setSearchTerm(event.currentTarget.value);
+                            setManualRegistration(null);
+                            setSuccess(false);
+                            setAlreadyCheckedIn(false);
+                          }}
+                          placeholder={m.checkin_manual_search_placeholder()}
+                          disabled={!auth.isAuthenticated}
+                        />
+                        <Form.Text className="text-secondary">
+                          {m.checkin_manual_search_help()}
+                        </Form.Text>
+                      </Form.Group>
+
+                      {showSearchHint && (
+                        <div className="text-secondary mt-3">{m.checkin_manual_search_min_chars()}</div>
+                      )}
+
+                      {volunteerSearchQuery.isFetching && (
+                        <div className="text-secondary mt-3">
+                          <Spinner
+                            as="span"
+                            animation="border"
+                            size="sm"
+                            role="status"
+                            aria-hidden="true"
+                            className="me-2"
+                          />
+                          {m.checkin_manual_search_loading()}
+                        </div>
+                      )}
+
+                      {volunteerSearchQuery.isError && (
+                        <Alert variant="danger" className="mt-3 mb-0">
+                          <i className="bi bi-exclamation-triangle-fill me-2" aria-hidden="true" />
+                          {volunteerSearchQuery.error.message === "unauthorized"
+                            ? m.checkin_manual_search_unauthorized()
+                            : volunteerSearchQuery.error.message}
+                        </Alert>
+                      )}
+
+                      {!volunteerSearchQuery.isFetching &&
+                        debouncedSearchTerm.length >= 2 &&
+                        searchResults.length === 0 &&
+                        !volunteerSearchQuery.isError && (
+                          <div className="text-secondary mt-3">
+                            {m.checkin_manual_search_no_results()}
+                          </div>
+                        )}
+
+                      {searchResults.length > 0 && (
+                        <ListGroup className="mt-3">
+                          {searchResults.map((result) => (
+                            <ListGroup.Item
+                              key={result.id}
+                              action
+                              variant="dark"
+                              className="border-secondary d-flex justify-content-between align-items-center gap-3"
+                              onClick={() => handleSelectManualRegistration(result)}
+                            >
+                              <span>
+                                <span className="fw-semibold d-block">{result.name}</span>
+                                <span className="text-secondary small">
+                                  {result.eventTitle || result.eventId} · {m.checkin_guests()}: {result.guestCount}
+                                </span>
+                              </span>
+                              <Badge bg={result.checkedIn ? "success" : "secondary"}>
+                                {result.checkedIn ? m.admin_checked_in() : m.checkin_manual_not_checked_in()}
+                              </Badge>
+                            </ListGroup.Item>
+                          ))}
+                        </ListGroup>
+                      )}
+                    </Card.Body>
+                  </Collapse>
+                </Card>
+              </>
+            )}
+
             {isLoading && (
               <div className="text-center py-4">
                 <Spinner animation="border" variant="warning" role="status">
@@ -116,124 +417,13 @@ export default function CheckInPage() {
             )}
 
             {registration && !isLoading && (
-              <Card
-                bg="dark"
-                text="white"
-                border={success ? "success" : isAlreadyCheckedIn ? "warning" : "secondary"}
-              >
-                <Card.Header
-                  className={clsx(
-                    "d-flex align-items-center justify-content-between",
-                    success
-                      ? "border-success"
-                      : isAlreadyCheckedIn
-                        ? "border-warning"
-                        : "border-secondary",
-                  )}
-                >
-                  <span className="fw-semibold fs-5">
-                    <i className="bi bi-person-fill me-2" aria-hidden="true" />
-                    {registration.name}
-                  </span>
-                  <div className="d-flex gap-2 flex-wrap">
-                    {registration.checkedIn && (
-                      <Badge bg="success">
-                        <i className="bi bi-check-circle-fill me-1" aria-hidden="true" />
-                        {m.admin_checked_in()}
-                      </Badge>
-                    )}
-                    {registration.strapIssued && (
-                      <Badge bg="info">
-                        <i className="bi bi-person-badge-fill me-1" aria-hidden="true" />
-                        {m.admin_strap_issued()}
-                      </Badge>
-                    )}
-                  </div>
-                </Card.Header>
-
-                <Card.Body>
-                  {success && (
-                    <Alert variant="success" className="mb-3">
-                      <i className="bi bi-check-circle-fill me-2" aria-hidden="true" />
-                      <strong>{m.checkin_success()}</strong>
-                      <div className="mt-1">{m.checkin_strap_issued()}</div>
-                    </Alert>
-                  )}
-
-                  {isAlreadyCheckedIn && !success && registration.checkedInAt && (
-                    <Alert variant="warning" className="mb-3">
-                      <i className="bi bi-exclamation-circle-fill me-2" aria-hidden="true" />
-                      {m.checkin_already_in()}{" "}
-                      {new Date(registration.checkedInAt).toLocaleTimeString()}
-                    </Alert>
-                  )}
-
-                  <ListGroup variant="flush" className="bg-dark">
-                    <ListGroup.Item className="bg-dark text-light border-secondary d-flex justify-content-between">
-                      <span className="text-secondary">{m.checkin_event()}</span>
-                      <span>{registration.eventTitle || registration.eventId}</span>
-                    </ListGroup.Item>
-                    <ListGroup.Item className="bg-dark text-light border-secondary d-flex justify-content-between">
-                      <span className="text-secondary">{m.checkin_guests()}</span>
-                      <span>{registration.guestCount}</span>
-                    </ListGroup.Item>
-                  </ListGroup>
-
-                  {registration.preOrders.length > 0 && (
-                    <div className="mt-3">
-                      <p className="fw-semibold text-warning mb-2">
-                        <i className="bi bi-cart-fill me-2" aria-hidden="true" />
-                        {m.checkin_pre_orders()}
-                      </p>
-                      <ListGroup variant="flush">
-                        {registration.preOrders.map((item, idx) => (
-                          <ListGroup.Item
-                            key={`${item.productId}-${idx}`}
-                            className="bg-dark text-light border-secondary d-flex justify-content-between align-items-center"
-                          >
-                            <span>
-                              {item.name} <Badge bg="secondary">×{item.quantity}</Badge>
-                            </span>
-                            <div className="d-flex gap-2">
-                              <Badge bg={item.delivered ? "success" : "secondary"}>
-                                {m.admin_bottle_delivered()}: {item.deliveredQuantity}/{item.quantity}
-                              </Badge>
-                              <Badge bg={item.remainingQuantity > 0 ? "warning" : "success"} text="dark">
-                                {m.admin_bottle_not_delivered()}: {item.remainingQuantity}
-                              </Badge>
-                            </div>
-                          </ListGroup.Item>
-                        ))}
-                      </ListGroup>
-                    </div>
-                  )}
-                </Card.Body>
-
-                {!registration.checkedIn && (
-                  <Card.Footer className="bg-dark border-secondary">
-                    <Button
-                      variant="warning"
-                      className="w-100"
-                      onClick={handleCheckIn}
-                      disabled={isCheckingIn}
-                    >
-                      {isCheckingIn ? (
-                        <Spinner
-                          as="span"
-                          animation="border"
-                          size="sm"
-                          role="status"
-                          aria-hidden="true"
-                          className="me-2"
-                        />
-                      ) : (
-                        <i className="bi bi-person-check-fill me-2" aria-hidden="true" />
-                      )}
-                      {m.checkin_do_checkin()}
-                    </Button>
-                  </Card.Footer>
-                )}
-              </Card>
+              <CheckInCard
+                registration={registration}
+                success={success}
+                isAlreadyCheckedIn={isAlreadyCheckedIn}
+                isCheckingIn={isCheckingIn}
+                onCheckIn={handleCheckIn}
+              />
             )}
           </div>
         </div>

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -20,14 +20,22 @@ import {
   submitCheckIn,
   type CheckInData,
 } from "@/utils/publicRegistrationApi";
-import { searchVolunteerRegistrations, submitVolunteerCheckIn } from "@/utils/volunteerApi";
+import {
+  searchVolunteerRegistrations,
+  submitVolunteerCheckIn,
+  updateVolunteerRegistration,
+} from "@/utils/volunteerApi";
 
 interface CheckInCardProps {
   registration: CheckInData;
   success: boolean;
   isAlreadyCheckedIn: boolean;
   isCheckingIn: boolean;
+  isUpdatingRegistration: boolean;
+  canManageEntranceActions: boolean;
   onCheckIn: () => void;
+  onAdjustPreOrder: (productId: string, delta: number) => void;
+  onIssueStrap: () => void;
 }
 
 function CheckInCard({
@@ -35,7 +43,11 @@ function CheckInCard({
   success,
   isAlreadyCheckedIn,
   isCheckingIn,
+  isUpdatingRegistration,
+  canManageEntranceActions,
   onCheckIn,
+  onAdjustPreOrder,
+  onIssueStrap,
 }: CheckInCardProps) {
   return (
     <Card
@@ -74,7 +86,7 @@ function CheckInCard({
           <Alert variant="success" className="mb-3">
             <i className="bi bi-check-circle-fill me-2" aria-hidden="true" />
             <strong>{m.checkin_success()}</strong>
-            <div className="mt-1">{m.checkin_strap_issued()}</div>
+            {registration.strapIssued && <div className="mt-1">{m.checkin_strap_issued()}</div>}
           </Alert>
         )}
 
@@ -94,6 +106,12 @@ function CheckInCard({
             <span className="text-secondary">{m.checkin_guests()}</span>
             <span>{registration.guestCount}</span>
           </ListGroup.Item>
+          {registration.tableName && (
+            <ListGroup.Item className="bg-dark text-light border-secondary d-flex justify-content-between gap-3">
+              <span className="text-secondary">{m.checkin_table()}</span>
+              <span className="fw-semibold text-warning">{registration.tableName}</span>
+            </ListGroup.Item>
+          )}
         </ListGroup>
 
         {registration.preOrders.length > 0 && (
@@ -111,13 +129,41 @@ function CheckInCard({
                   <span>
                     {item.name} <Badge bg="secondary">×{item.quantity}</Badge>
                   </span>
-                  <div className="d-flex gap-2 flex-wrap">
+                  <div className="d-flex align-items-center gap-2 flex-wrap">
                     <Badge bg={item.delivered ? "success" : "secondary"}>
                       {m.admin_bottle_delivered()}: {item.deliveredQuantity}/{item.quantity}
                     </Badge>
                     <Badge bg={item.remainingQuantity > 0 ? "warning" : "success"} text="dark">
                       {m.admin_bottle_not_delivered()}: {item.remainingQuantity}
                     </Badge>
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      onClick={() => onAdjustPreOrder(item.productId, -1)}
+                      disabled={
+                        !canManageEntranceActions ||
+                        isUpdatingRegistration ||
+                        item.deliveredQuantity <= 0
+                      }
+                      title={m.admin_mark_not_delivered()}
+                    >
+                      <i className="bi bi-dash" aria-hidden="true" />
+                      <span className="visually-hidden">{m.admin_mark_not_delivered()}</span>
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant={item.delivered ? "success" : "outline-success"}
+                      onClick={() => onAdjustPreOrder(item.productId, 1)}
+                      disabled={
+                        !canManageEntranceActions ||
+                        isUpdatingRegistration ||
+                        item.deliveredQuantity >= item.quantity
+                      }
+                      title={m.admin_mark_delivered()}
+                    >
+                      <i className="bi bi-plus" aria-hidden="true" />
+                      <span className="visually-hidden">{m.admin_mark_delivered()}</span>
+                    </Button>
                   </div>
                 </ListGroup.Item>
               ))}
@@ -126,23 +172,50 @@ function CheckInCard({
         )}
       </Card.Body>
 
-      {!registration.checkedIn && (
-        <Card.Footer className="bg-dark border-secondary">
-          <Button variant="warning" className="w-100" onClick={onCheckIn} disabled={isCheckingIn}>
-            {isCheckingIn ? (
-              <Spinner
-                as="span"
-                animation="border"
-                size="sm"
-                role="status"
-                aria-hidden="true"
-                className="me-2"
-              />
-            ) : (
-              <i className="bi bi-person-check-fill me-2" aria-hidden="true" />
-            )}
-            {m.checkin_do_checkin()}
-          </Button>
+      {(!registration.checkedIn || !registration.strapIssued) && (
+        <Card.Footer className="bg-dark border-secondary d-grid gap-2">
+          {!registration.checkedIn && (
+            <Button variant="warning" className="w-100" onClick={onCheckIn} disabled={isCheckingIn}>
+              {isCheckingIn ? (
+                <Spinner
+                  as="span"
+                  animation="border"
+                  size="sm"
+                  role="status"
+                  aria-hidden="true"
+                  className="me-2"
+                />
+              ) : (
+                <i className="bi bi-person-check-fill me-2" aria-hidden="true" />
+              )}
+              {m.checkin_do_checkin()}
+            </Button>
+          )}
+          {registration.checkedIn && !registration.strapIssued && (
+            <Button
+              variant="info"
+              className="w-100"
+              onClick={onIssueStrap}
+              disabled={!canManageEntranceActions || isUpdatingRegistration}
+            >
+              {isUpdatingRegistration ? (
+                <Spinner
+                  as="span"
+                  animation="border"
+                  size="sm"
+                  role="status"
+                  aria-hidden="true"
+                  className="me-2"
+                />
+              ) : (
+                <i className="bi bi-person-badge-fill me-2" aria-hidden="true" />
+              )}
+              {m.admin_issue_strap()}
+            </Button>
+          )}
+          {!canManageEntranceActions && (
+            <div className="small text-secondary">{m.checkin_actions_login_required()}</div>
+          )}
         </Card.Footer>
       )}
     </Card>
@@ -200,7 +273,10 @@ export default function CheckInPage() {
       setSuccess(false);
       setAlreadyCheckedIn(false);
     },
-    onSuccess: ({ registration: updatedRegistration, alreadyCheckedIn: mutationAlreadyCheckedIn }) => {
+    onSuccess: ({
+      registration: updatedRegistration,
+      alreadyCheckedIn: mutationAlreadyCheckedIn,
+    }) => {
       queryClient.setQueryData(checkInQueryKey, updatedRegistration);
       setSuccess(true);
       setAlreadyCheckedIn(mutationAlreadyCheckedIn || updatedRegistration.checkedIn);
@@ -217,7 +293,10 @@ export default function CheckInPage() {
       setSuccess(false);
       setAlreadyCheckedIn(false);
     },
-    onSuccess: ({ registration: updatedRegistration, alreadyCheckedIn: mutationAlreadyCheckedIn }) => {
+    onSuccess: ({
+      registration: updatedRegistration,
+      alreadyCheckedIn: mutationAlreadyCheckedIn,
+    }) => {
       setManualRegistration(updatedRegistration);
       setSuccess(true);
       setAlreadyCheckedIn(mutationAlreadyCheckedIn || updatedRegistration.checkedIn);
@@ -230,14 +309,47 @@ export default function CheckInPage() {
     },
   });
 
-  const registration =
-    volunteerCheckInMutation.data?.registration ??
-    manualRegistration ??
-    checkInMutation.data?.registration ??
-    registrationQuery.data ??
-    null;
+  const updateRegistrationMutation = useMutation({
+    mutationFn: ({
+      targetRegistration,
+      preOrders,
+      strapIssued,
+    }: {
+      targetRegistration: CheckInData;
+      preOrders?: CheckInData["preOrders"];
+      strapIssued?: boolean;
+    }) =>
+      updateVolunteerRegistration(targetRegistration.id, { preOrders, strapIssued }, authHeaders),
+    retry: false,
+    onSuccess: (updatedRegistration) => {
+      setManualRegistration((prev) =>
+        prev?.id === updatedRegistration.id ? updatedRegistration : prev,
+      );
+      if (hasQrCredentials) {
+        queryClient.setQueryData(checkInQueryKey, updatedRegistration);
+      }
+      queryClient.setQueryData<CheckInData[]>(
+        queryKeys.volunteerRegistrationSearch(debouncedSearchTerm),
+        (prev) =>
+          prev?.map((item) => (item.id === updatedRegistration.id ? updatedRegistration : item)),
+      );
+    },
+    onSettled: async () => {
+      if (hasQrCredentials) {
+        await queryClient.invalidateQueries({ queryKey: checkInQueryKey });
+      }
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.volunteerRegistrationSearch(debouncedSearchTerm),
+      });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.admin.registrations });
+    },
+  });
+
+  const registration = manualRegistration ?? registrationQuery.data ?? null;
   const isLoading = hasQrCredentials ? registrationQuery.isPending : false;
   const isCheckingIn = checkInMutation.isPending || volunteerCheckInMutation.isPending;
+  const canManageEntranceActions = auth.isAuthenticated;
+  const isUpdatingRegistration = updateRegistrationMutation.isPending;
   const queryError = registrationQuery.isError ? registrationQuery.error.message : "";
   const mutationError = checkInMutation.isError
     ? checkInMutation.error instanceof CheckInError
@@ -245,7 +357,11 @@ export default function CheckInPage() {
       : m.checkin_error()
     : volunteerCheckInMutation.isError
       ? volunteerCheckInMutation.error.message
-      : "";
+      : updateRegistrationMutation.isError
+        ? updateRegistrationMutation.error.message === "unauthorized"
+          ? m.checkin_actions_unauthorized()
+          : updateRegistrationMutation.error.message
+        : "";
   const isAlreadyCheckedIn = success ? alreadyCheckedIn : (registration?.checkedIn ?? false);
   const searchResults = volunteerSearchQuery.data ?? [];
   const showSearchHint = useMemo(
@@ -261,6 +377,35 @@ export default function CheckInPage() {
     if (!manualRegistration) return;
     volunteerCheckInMutation.mutate();
   }, [checkInMutation, hasQrCredentials, manualRegistration, volunteerCheckInMutation]);
+
+  const handleAdjustPreOrder = useCallback(
+    (productId: string, delta: number) => {
+      if (!registration) return;
+      const updatedOrders = registration.preOrders.map((item) => {
+        if (item.productId !== productId) return item;
+        const deliveredQuantity = Math.max(
+          0,
+          Math.min(item.quantity, item.deliveredQuantity + delta),
+        );
+        return {
+          ...item,
+          deliveredQuantity,
+          remainingQuantity: item.quantity - deliveredQuantity,
+          delivered: deliveredQuantity === item.quantity,
+        };
+      });
+      updateRegistrationMutation.mutate({
+        targetRegistration: registration,
+        preOrders: updatedOrders,
+      });
+    },
+    [registration, updateRegistrationMutation],
+  );
+
+  const handleIssueStrap = useCallback(() => {
+    if (!registration) return;
+    updateRegistrationMutation.mutate({ targetRegistration: registration, strapIssued: true });
+  }, [registration, updateRegistrationMutation]);
 
   const handleSelectManualRegistration = useCallback((selected: CheckInData) => {
     setManualRegistration(selected);
@@ -308,7 +453,10 @@ export default function CheckInPage() {
                   <Collapse in={searchOpen}>
                     <Card.Body id="manual-checkin-search">
                       {!auth.isAuthenticated && (
-                        <Alert variant="info" className="d-flex justify-content-between align-items-center gap-3 flex-wrap">
+                        <Alert
+                          variant="info"
+                          className="d-flex justify-content-between align-items-center gap-3 flex-wrap"
+                        >
                           <span>{m.checkin_manual_search_login_required()}</span>
                           <Button variant="outline-warning" size="sm" onClick={auth.login}>
                             {m.admin_login_button()}
@@ -336,7 +484,9 @@ export default function CheckInPage() {
                       </Form.Group>
 
                       {showSearchHint && (
-                        <div className="text-secondary mt-3">{m.checkin_manual_search_min_chars()}</div>
+                        <div className="text-secondary mt-3">
+                          {m.checkin_manual_search_min_chars()}
+                        </div>
                       )}
 
                       {volunteerSearchQuery.isFetching && (
@@ -384,11 +534,14 @@ export default function CheckInPage() {
                               <span>
                                 <span className="fw-semibold d-block">{result.name}</span>
                                 <span className="text-secondary small">
-                                  {result.eventTitle || result.eventId} · {m.checkin_guests()}: {result.guestCount}
+                                  {result.eventTitle || result.eventId} · {m.checkin_guests()}:{" "}
+                                  {result.guestCount}
                                 </span>
                               </span>
                               <Badge bg={result.checkedIn ? "success" : "secondary"}>
-                                {result.checkedIn ? m.admin_checked_in() : m.checkin_manual_not_checked_in()}
+                                {result.checkedIn
+                                  ? m.admin_checked_in()
+                                  : m.checkin_manual_not_checked_in()}
                               </Badge>
                             </ListGroup.Item>
                           ))}
@@ -422,7 +575,11 @@ export default function CheckInPage() {
                 success={success}
                 isAlreadyCheckedIn={isAlreadyCheckedIn}
                 isCheckingIn={isCheckingIn}
+                isUpdatingRegistration={isUpdatingRegistration}
+                canManageEntranceActions={canManageEntranceActions}
                 onCheckIn={handleCheckIn}
+                onAdjustPreOrder={handleAdjustPreOrder}
+                onIssueStrap={handleIssueStrap}
               />
             )}
           </div>

--- a/frontend/src/mocks/handlers/admin.ts
+++ b/frontend/src/mocks/handlers/admin.ts
@@ -138,6 +138,26 @@ function now(): string {
   return new Date().toISOString();
 }
 
+function registrationToCheckInResponse(registration: Record<string, unknown>): Record<string, unknown> {
+  const person = registration.person as Record<string, unknown> | undefined;
+  const event = registration.event as Record<string, unknown> | null | undefined;
+  return {
+    id: registration.id,
+    name: person?.name ?? "",
+    event_id: registration.event_id,
+    event_title: event?.title ?? "",
+    table_id: registration.table_id ?? null,
+    table_name: null,
+    guest_count: registration.guest_count,
+    pre_orders: registration.pre_orders,
+    notes: registration.notes,
+    status: registration.status,
+    checked_in: registration.checked_in,
+    checked_in_at: registration.checked_in_at,
+    strap_issued: registration.strap_issued,
+  };
+}
+
 export const adminHandlers = [
   http.get("/api/mock/scenario", () => {
     return HttpResponse.json({
@@ -170,6 +190,62 @@ export const adminHandlers = [
     const authError = requireAuth(request);
     if (authError) return authError;
     return HttpResponse.json(sharedStore.registrations);
+  }),
+
+  http.get("/api/volunteer/registrations", ({ request }) => {
+    const authError = requireAuth(request);
+    if (authError) return authError;
+
+    const url = new URL(request.url);
+    const query = (url.searchParams.get("q") ?? "").trim().toLowerCase();
+    const limit = Number(url.searchParams.get("limit") ?? 10);
+
+    const matches = sharedStore.registrations.filter((registration) => {
+      if (!query) return true;
+      const person = registration.person as Record<string, unknown> | undefined;
+      const event = registration.event as Record<string, unknown> | undefined;
+      return [
+        person?.name,
+        person?.email,
+        registration.id,
+        registration.event_id,
+        event?.title,
+      ]
+        .filter((value): value is string => typeof value === "string")
+        .some((value) => value.toLowerCase().includes(query));
+    });
+
+    return HttpResponse.json(matches.slice(0, limit).map(registrationToCheckInResponse));
+  }),
+
+  http.post("/api/volunteer/registrations/:id/check-in", async ({ request, params }) => {
+    const authError = requireAuth(request);
+    if (authError) return authError;
+
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return HttpResponse.json({ error: "Malformed JSON payload" }, { status: 400 });
+    }
+
+    const idx = sharedStore.registrations.findIndex((r) => r.id === params.id);
+    if (idx === -1) return HttpResponse.json(null, { status: 404 });
+
+    const reg = sharedStore.registrations[idx]!;
+    const alreadyCheckedIn = Boolean(reg.checked_in);
+    sharedStore.registrations[idx] = {
+      ...reg,
+      checked_in: true,
+      checked_in_at: alreadyCheckedIn ? reg.checked_in_at : now(),
+      strap_issued: Boolean(reg.strap_issued) || body.issue_strap === true,
+      updated_at: now(),
+    };
+
+    return HttpResponse.json({
+      already_checked_in: alreadyCheckedIn,
+      registration: registrationToCheckInResponse(sharedStore.registrations[idx]!),
+    });
   }),
 
   // ──────────────────────────────────────────────────────────────

--- a/frontend/src/mocks/handlers/admin.ts
+++ b/frontend/src/mocks/handlers/admin.ts
@@ -1,5 +1,11 @@
 import { http, HttpResponse } from "msw";
-import { editions, events, resetEditionStore, type SeedEdition, type SeedEvent } from "../data/editionStore";
+import {
+  editions,
+  events,
+  resetEditionStore,
+  type SeedEdition,
+  type SeedEvent,
+} from "../data/editionStore";
 import { seedExhibitors } from "../data/exhibitors";
 import { seedPeople } from "../data/people";
 import {
@@ -125,7 +131,7 @@ function tablesWithRegistrationAssignments(): Record<string, unknown>[] {
   return tables.map((table) => {
     const tableId = table.id;
     const registrationIds =
-      typeof tableId === "string" && tableId.length > 0 ? byTableId.get(tableId) ?? [] : [];
+      typeof tableId === "string" && tableId.length > 0 ? (byTableId.get(tableId) ?? []) : [];
     return { ...table, registration_ids: registrationIds };
   });
 }
@@ -138,16 +144,19 @@ function now(): string {
   return new Date().toISOString();
 }
 
-function registrationToCheckInResponse(registration: Record<string, unknown>): Record<string, unknown> {
+function registrationToCheckInResponse(
+  registration: Record<string, unknown>,
+): Record<string, unknown> {
   const person = registration.person as Record<string, unknown> | undefined;
   const event = registration.event as Record<string, unknown> | null | undefined;
+  const table = tables.find((item) => item.id === registration.table_id);
   return {
     id: registration.id,
     name: person?.name ?? "",
     event_id: registration.event_id,
     event_title: event?.title ?? "",
     table_id: registration.table_id ?? null,
-    table_name: null,
+    table_name: table?.name ?? null,
     guest_count: registration.guest_count,
     pre_orders: registration.pre_orders,
     notes: registration.notes,
@@ -204,13 +213,7 @@ export const adminHandlers = [
       if (!query) return true;
       const person = registration.person as Record<string, unknown> | undefined;
       const event = registration.event as Record<string, unknown> | undefined;
-      return [
-        person?.name,
-        person?.email,
-        registration.id,
-        registration.event_id,
-        event?.title,
-      ]
+      return [person?.name, person?.email, registration.id, registration.event_id, event?.title]
         .filter((value): value is string => typeof value === "string")
         .some((value) => value.toLowerCase().includes(query));
     });
@@ -246,6 +249,21 @@ export const adminHandlers = [
       already_checked_in: alreadyCheckedIn,
       registration: registrationToCheckInResponse(sharedStore.registrations[idx]!),
     });
+  }),
+
+  http.put("/api/volunteer/registrations/:id", async ({ request, params }) => {
+    const authError = requireAuth(request);
+    if (authError) return authError;
+    const idx = sharedStore.registrations.findIndex((r) => r.id === params.id);
+    if (idx === -1) return HttpResponse.json(null, { status: 404 });
+    const body = (await request.json()) as Record<string, unknown>;
+    sharedStore.registrations[idx] = {
+      ...sharedStore.registrations[idx]!,
+      ...(Array.isArray(body.pre_orders) ? { pre_orders: body.pre_orders } : {}),
+      ...(typeof body.strap_issued === "boolean" ? { strap_issued: body.strap_issued } : {}),
+      updated_at: now(),
+    };
+    return HttpResponse.json(registrationToCheckInResponse(sharedStore.registrations[idx]!));
   }),
 
   // ──────────────────────────────────────────────────────────────

--- a/frontend/src/mocks/handlers/public.ts
+++ b/frontend/src/mocks/handlers/public.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { editions, events } from "../data/editionStore";
 import { sharedStore, resetSharedStore } from "../data/registrations";
+import { seedTables } from "../data/venue";
 
 export const publicHandlers = [
   /** GET /api/editions/active — returns the active edition. */
@@ -150,11 +151,13 @@ export const publicHandlers = [
 
     const regPerson = reg.person as Record<string, unknown>;
     const regEvent = reg.event as Record<string, unknown> | null | undefined;
+    const regTable = seedTables.find((table) => table.id === reg.table_id);
     return HttpResponse.json({
       id: reg.id,
       name: regPerson?.name ?? "",
       event_id: reg.event_id,
       event_title: regEvent?.title ?? "",
+      table_name: regTable?.name ?? null,
       guest_count: reg.guest_count,
       pre_orders: reg.pre_orders,
       notes: reg.notes,
@@ -201,6 +204,7 @@ export const publicHandlers = [
     const updatedReg = sharedStore.registrations[idx]!;
     const regPerson2 = updatedReg.person as Record<string, unknown>;
     const regEvent2 = updatedReg.event as Record<string, unknown> | null | undefined;
+    const regTable2 = seedTables.find((table) => table.id === updatedReg.table_id);
     return HttpResponse.json({
       already_checked_in: alreadyCheckedIn,
       registration: {
@@ -208,6 +212,7 @@ export const publicHandlers = [
         name: regPerson2?.name ?? "",
         event_id: updatedReg.event_id,
         event_title: regEvent2?.title ?? "",
+        table_name: regTable2?.name ?? null,
         guest_count: updatedReg.guest_count,
         pre_orders: updatedReg.pre_orders,
         notes: updatedReg.notes,

--- a/frontend/src/utils/publicRegistrationApi.ts
+++ b/frontend/src/utils/publicRegistrationApi.ts
@@ -12,6 +12,7 @@ export interface CheckInData {
   eventId: string;
   eventTitle: string;
   guestCount: number;
+  tableName?: string;
   preOrders: {
     productId: string;
     name: string;
@@ -36,6 +37,7 @@ interface CheckInResponseRegistration {
   event_id?: string;
   event_title?: string;
   guest_count?: number;
+  table_name?: string | null;
   pre_orders?: Record<string, unknown>[];
   notes?: string;
   accessibility_note?: string;
@@ -90,6 +92,7 @@ function mapCheckInData(data: CheckInResponseRegistration): CheckInData {
     eventId: data.event_id ?? "",
     eventTitle: data.event_title ?? "",
     guestCount: data.guest_count ?? 1,
+    tableName: data.table_name ?? undefined,
     preOrders: rawOrders.filter(isGuestOrderItemResponse).map((item) => ({
       ...normalizeDeliveredQuantities(item),
       productId: item.product_id,
@@ -139,7 +142,7 @@ export async function submitCheckIn(
   const response = await fetch(`/api/check-in/${encodeURIComponent(registrationId)}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ token: checkInToken, issue_strap: true }),
+    body: JSON.stringify({ token: checkInToken, issue_strap: false }),
   });
 
   if (response.status === 401) {
@@ -239,7 +242,9 @@ function isGuestOrderItemResponse(value: unknown): value is GuestOrderItemRespon
     typeof value.product_id === "string" &&
     typeof value.name === "string" &&
     typeof value.quantity === "number" &&
-    (value.delivered_quantity === undefined || value.delivered_quantity === null || typeof value.delivered_quantity === "number") &&
+    (value.delivered_quantity === undefined ||
+      value.delivered_quantity === null ||
+      typeof value.delivered_quantity === "number") &&
     typeof value.price === "number" &&
     typeof value.category === "string" &&
     typeof value.delivered === "boolean"

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -3,6 +3,7 @@ export const queryKeys = {
   myRegistrations: (token: string) => ["my-registrations", token] as const,
   checkInRegistration: (registrationId: string, checkInToken: string) =>
     ["check-in", registrationId, checkInToken] as const,
+  volunteerRegistrationSearch: (query: string) => ["volunteer", "registrations", query] as const,
   admin: {
     registrations: ["admin", "registrations"] as const,
     tables: ["admin", "tables"] as const,

--- a/frontend/src/utils/volunteerApi.ts
+++ b/frontend/src/utils/volunteerApi.ts
@@ -1,7 +1,7 @@
 import { m } from "@/paraglide/messages";
 import { fetchArrayOrThrow, fetchJsonOrThrowWithUnauthorized } from "@/utils/adminApi";
 import type { CheckInData } from "@/utils/publicRegistrationApi";
-import type { OrderItemCategory, RegistrationStatus } from "@/types/registration";
+import type { OrderItem, OrderItemCategory, RegistrationStatus } from "@/types/registration";
 
 interface VolunteerRegistrationResponse {
   id?: string;
@@ -32,6 +32,7 @@ function mapVolunteerRegistration(data: VolunteerRegistrationResponse): CheckInD
     eventId: data.event_id ?? "",
     eventTitle: data.event_title ?? "",
     guestCount: data.guest_count ?? 1,
+    tableName: data.table_name ?? undefined,
     preOrders: rawOrders.map((item) => {
       const quantityRaw = Number(item.quantity ?? 0);
       const quantity = Number.isFinite(quantityRaw) ? Math.max(0, quantityRaw) : 0;
@@ -63,7 +64,6 @@ function mapVolunteerRegistration(data: VolunteerRegistrationResponse): CheckInD
   };
 }
 
-
 export async function searchVolunteerRegistrations(
   query: string,
   authHeaders: () => Record<string, string>,
@@ -87,13 +87,45 @@ export async function submitVolunteerCheckIn(
     {
       method: "POST",
       headers: authHeaders(),
-      body: JSON.stringify({ issue_strap: true }),
+      body: JSON.stringify({ issue_strap: false }),
     },
     m.checkin_error(),
   );
 
   return {
-    registration: mapVolunteerRegistration(registration.registration as VolunteerRegistrationResponse),
+    registration: mapVolunteerRegistration(
+      registration.registration as VolunteerRegistrationResponse,
+    ),
     alreadyCheckedIn: Boolean(registration.already_checked_in),
   };
+}
+
+export async function updateVolunteerRegistration(
+  registrationId: string,
+  payload: { preOrders?: OrderItem[]; strapIssued?: boolean },
+  authHeaders: () => Record<string, string>,
+): Promise<CheckInData> {
+  const body: Record<string, unknown> = {};
+  if (payload.preOrders) {
+    body.pre_orders = payload.preOrders.map((order) => ({
+      product_id: order.productId,
+      name: order.name,
+      quantity: order.quantity,
+      delivered_quantity: order.deliveredQuantity,
+      price: order.price,
+      category: order.category,
+      delivered: order.delivered,
+    }));
+  }
+  if (payload.strapIssued !== undefined) {
+    body.strap_issued = payload.strapIssued;
+  }
+
+  const registration = await fetchJsonOrThrowWithUnauthorized<VolunteerRegistrationResponse>(
+    `/api/volunteer/registrations/${encodeURIComponent(registrationId)}`,
+    { method: "PUT", headers: authHeaders(), body: JSON.stringify(body) },
+    m.admin_error_update_registration(),
+  );
+
+  return mapVolunteerRegistration(registration);
 }

--- a/frontend/src/utils/volunteerApi.ts
+++ b/frontend/src/utils/volunteerApi.ts
@@ -1,0 +1,99 @@
+import { m } from "@/paraglide/messages";
+import { fetchArrayOrThrow, fetchJsonOrThrowWithUnauthorized } from "@/utils/adminApi";
+import type { CheckInData } from "@/utils/publicRegistrationApi";
+import type { OrderItemCategory, RegistrationStatus } from "@/types/registration";
+
+interface VolunteerRegistrationResponse {
+  id?: string;
+  name?: string;
+  event_id?: string;
+  event_title?: string;
+  table_id?: string | null;
+  table_name?: string | null;
+  guest_count?: number;
+  pre_orders?: Record<string, unknown>[];
+  notes?: string;
+  status?: RegistrationStatus;
+  checked_in?: boolean;
+  checked_in_at?: string | null;
+  strap_issued?: boolean;
+}
+
+function isOrderItemCategory(value: unknown): value is OrderItemCategory {
+  return value === "champagne" || value === "food" || value === "other";
+}
+
+function mapVolunteerRegistration(data: VolunteerRegistrationResponse): CheckInData {
+  const rawOrders = Array.isArray(data.pre_orders) ? data.pre_orders : [];
+
+  return {
+    id: data.id ?? "",
+    name: data.name ?? "",
+    eventId: data.event_id ?? "",
+    eventTitle: data.event_title ?? "",
+    guestCount: data.guest_count ?? 1,
+    preOrders: rawOrders.map((item) => {
+      const quantityRaw = Number(item.quantity ?? 0);
+      const quantity = Number.isFinite(quantityRaw) ? Math.max(0, quantityRaw) : 0;
+      const deliveredQuantityRaw = Number(
+        item.delivered_quantity ?? (item.delivered === true ? quantity : 0),
+      );
+      const deliveredQuantity = Number.isFinite(deliveredQuantityRaw)
+        ? Math.max(0, Math.min(quantity, deliveredQuantityRaw))
+        : 0;
+      const remainingQuantity = quantity - deliveredQuantity;
+
+      return {
+        productId: String(item.product_id ?? ""),
+        name: String(item.name ?? ""),
+        quantity,
+        deliveredQuantity,
+        remainingQuantity,
+        price: Number(item.price ?? 0),
+        category: isOrderItemCategory(item.category) ? item.category : "other",
+        delivered: remainingQuantity === 0,
+      };
+    }),
+    notes: data.notes ?? "",
+    accessibilityNote: "",
+    status: data.status ?? "pending",
+    checkedIn: data.checked_in ?? false,
+    checkedInAt: data.checked_in_at ?? undefined,
+    strapIssued: data.strap_issued ?? false,
+  };
+}
+
+
+export async function searchVolunteerRegistrations(
+  query: string,
+  authHeaders: () => Record<string, string>,
+  signal?: AbortSignal,
+): Promise<CheckInData[]> {
+  const params = new URLSearchParams({ q: query, limit: "10" });
+  return fetchArrayOrThrow<CheckInData>(
+    `/api/volunteer/registrations?${params.toString()}`,
+    { method: "GET", headers: authHeaders(), signal },
+    m.checkin_search_error(),
+    (item) => mapVolunteerRegistration(item),
+  );
+}
+
+export async function submitVolunteerCheckIn(
+  registrationId: string,
+  authHeaders: () => Record<string, string>,
+): Promise<{ registration: CheckInData; alreadyCheckedIn: boolean }> {
+  const registration = await fetchJsonOrThrowWithUnauthorized<Record<string, unknown>>(
+    `/api/volunteer/registrations/${encodeURIComponent(registrationId)}/check-in`,
+    {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ issue_strap: true }),
+    },
+    m.checkin_error(),
+  );
+
+  return {
+    registration: mapVolunteerRegistration(registration.registration as VolunteerRegistrationResponse),
+    alreadyCheckedIn: Boolean(registration.already_checked_in),
+  };
+}

--- a/frontend/tests/components/CheckInPage.test.tsx
+++ b/frontend/tests/components/CheckInPage.test.tsx
@@ -34,8 +34,11 @@ vi.mock("@/paraglide/messages", () => ({
     checkin_already_in: () => "Already checked in at",
     checkin_event: () => "Event",
     checkin_guests: () => "Guests",
+    checkin_table: () => "Table",
     checkin_pre_orders: () => "Pre-orders",
     checkin_do_checkin: () => "Check in now",
+    checkin_actions_login_required: () => "Login for entrance actions.",
+    checkin_actions_unauthorized: () => "Unauthorized entrance action.",
     checkin_manual_search_title: () => "Find guest manually",
     checkin_manual_search_login_required: () => "Volunteer login required.",
     checkin_manual_search_label: () => "Guest name or email",
@@ -50,15 +53,17 @@ vi.mock("@/paraglide/messages", () => ({
     admin_login_button: () => "Login",
     admin_checked_in: () => "Checked in",
     admin_strap_issued: () => "Strap issued",
+    admin_issue_strap: () => "Issue strap",
     admin_bottle_delivered: () => "Delivered",
     admin_bottle_not_delivered: () => "Pending",
+    admin_mark_delivered: () => "Mark as delivered",
+    admin_mark_not_delivered: () => "Mark as not delivered",
+    admin_error_update_registration: () => "Failed to update registration.",
   },
 }));
 
 describe("CheckInPage", () => {
-  async function renderPage(
-    initialEntry = `/check-in?id=${SEED_REG_ID}&token=${SEED_REG_TOKEN}`,
-  ) {
+  async function renderPage(initialEntry = `/check-in?id=${SEED_REG_ID}&token=${SEED_REG_TOKEN}`) {
     const rootRoute = createRootRoute();
     const checkInRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -81,6 +86,7 @@ describe("CheckInPage", () => {
     await waitFor(() => {
       expect(screen.getByText(SEED_REG_NAME)).toBeInTheDocument();
       expect(screen.getByText(new RegExp(SEED_EVENT_TITLE))).toBeInTheDocument();
+      expect(screen.getByText("T1")).toBeInTheDocument();
     });
   });
 
@@ -95,7 +101,7 @@ describe("CheckInPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Checked in successfully!")).toBeInTheDocument();
-      expect(screen.getByText("Strap issued.")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /issue strap/i })).toBeInTheDocument();
     });
   });
 
@@ -130,7 +136,6 @@ describe("CheckInPage", () => {
       });
     });
   });
-
 
   it("searches and selects a registration when the QR code is unavailable", async () => {
     await renderPage("/check-in");
@@ -167,7 +172,41 @@ describe("CheckInPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Checked in successfully!")).toBeInTheDocument();
-      expect(screen.getByText("Strap issued.")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /issue strap/i })).toBeInTheDocument();
+    });
+  });
+
+  it("issues a strap after check-in from the card", async () => {
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /check in now/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /check in now/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /issue strap/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /issue strap/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Strap issued")).toBeInTheDocument();
+    });
+  });
+
+  it("updates delivered pre-order quantities from the check-in card", async () => {
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Delivered: 2/4")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTitle("Mark as delivered"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delivered: 3/4")).toBeInTheDocument();
     });
   });
 

--- a/frontend/tests/components/CheckInPage.test.tsx
+++ b/frontend/tests/components/CheckInPage.test.tsx
@@ -36,6 +36,18 @@ vi.mock("@/paraglide/messages", () => ({
     checkin_guests: () => "Guests",
     checkin_pre_orders: () => "Pre-orders",
     checkin_do_checkin: () => "Check in now",
+    checkin_manual_search_title: () => "Find guest manually",
+    checkin_manual_search_login_required: () => "Volunteer login required.",
+    checkin_manual_search_label: () => "Guest name or email",
+    checkin_manual_search_placeholder: () => "Search by guest name or email…",
+    checkin_manual_search_help: () => "PII-minimal results.",
+    checkin_manual_search_min_chars: () => "Enter at least 2 characters to search.",
+    checkin_manual_search_loading: () => "Searching registrations…",
+    checkin_manual_search_no_results: () => "No matching registrations found.",
+    checkin_manual_search_unauthorized: () => "Sign in as a volunteer or admin.",
+    checkin_manual_not_checked_in: () => "Not checked in",
+    checkin_search_error: () => "Could not search registrations.",
+    admin_login_button: () => "Login",
     admin_checked_in: () => "Checked in",
     admin_strap_issued: () => "Strap issued",
     admin_bottle_delivered: () => "Delivered",
@@ -68,7 +80,7 @@ describe("CheckInPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText(SEED_REG_NAME)).toBeInTheDocument();
-      expect(screen.getByText(SEED_EVENT_TITLE)).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(SEED_EVENT_TITLE))).toBeInTheDocument();
     });
   });
 
@@ -116,6 +128,46 @@ describe("CheckInPage", () => {
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: ["check-in", SEED_REG_ID, SEED_REG_TOKEN],
       });
+    });
+  });
+
+
+  it("searches and selects a registration when the QR code is unavailable", async () => {
+    await renderPage("/check-in");
+
+    expect(screen.getByText("Scan a QR code to begin.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Guest name or email"), {
+      target: { value: SEED_REG_NAME },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(new RegExp(SEED_EVENT_TITLE))).toBeInTheDocument();
+      expect(screen.getByText("Not checked in")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(SEED_REG_NAME));
+
+    expect(screen.getByRole("button", { name: /check in now/i })).toBeInTheDocument();
+  });
+
+  it("submits manual check-in for a selected volunteer search result", async () => {
+    await renderPage("/check-in");
+
+    fireEvent.change(screen.getByLabelText("Guest name or email"), {
+      target: { value: SEED_REG_NAME },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(new RegExp(SEED_EVENT_TITLE))).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(SEED_REG_NAME));
+    fireEvent.click(screen.getByRole("button", { name: /check in now/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Checked in successfully!")).toBeInTheDocument();
+      expect(screen.getByText("Strap issued.")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
### Motivation
- Provide an authenticated fallback for entrance volunteers to look up guests and mark them checked-in when a QR token is not available. 
- Keep the volunteer flow PII-minimal and reuse existing check-in UI and ordering semantics.

### Description
- Add authenticated volunteer endpoint `POST /api/volunteer/registrations/{registration_id}/check-in` that marks a registration checked-in, optionally issues a strap, writes audit entries, and publishes live updates while returning a PII-free `CheckInOut` payload. (`backend/app/routers/volunteer_ops.py`)
- Add frontend manual search UI to the existing check-in page to allow volunteers to search registrations, select a guest, and perform a manual check-in when no `id`/`token` QR credentials are present. (`frontend/src/components/CheckInPage.tsx`)
- Add frontend helpers `searchVolunteerRegistrations` and `submitVolunteerCheckIn` to map PII-minimal API responses to the check-in UI shapes. (`frontend/src/utils/volunteerApi.ts`)
- Wire a new React Query key `volunteerRegistrationSearch` for caching and invalidation. (`frontend/src/utils/queryKeys.ts`)
- Add MSW mock handlers for `GET /api/volunteer/registrations` and `POST /api/volunteer/registrations/:id/check-in` to support dev and test flows. (`frontend/src/mocks/handlers/admin.ts`)
- Add localized copy for the manual search UI in English/Dutch/French and tests that exercise the manual search + check-in flow. (`frontend/messages/*.json`, `frontend/tests/components/CheckInPage.test.tsx`, `backend/tests/test_volunteer_ops.py`)

### Testing
- Ran the frontend unit tests for the check-in page with Vitest: `pnpm exec vitest run tests/components/CheckInPage.test.tsx` — all tests passed (7/7). 
- Ran frontend typecheck, lint, and build: `pnpm typecheck`, `pnpm lint`, `pnpm build` — succeeded; lint reports unrelated existing hook warnings. 
- Ran static checks on backend Python: `uv run ruff check app tests/test_volunteer_ops.py` — passed after fixes. 
- Backend integration tests with `pytest` (tests touching the DB) could not be completed in this environment because a PostgreSQL test database was not reachable and Docker is not available here; those tests therefore were not run to completion (`uv run pytest tests/test_volunteer_ops.py` was blocked by connection errors). 
- Captured an app screenshot of the manual search UI using Playwright while the dev server ran: screenshot generated successfully (`pnpm dlx playwright screenshot`).

If you want, I can split the backend endpoint into a separate PR, add more unit tests, or help with running the full backend test suite in CI (requires a running Postgres instance or Docker).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2410205580832eb75c32fa6b2ae921)