### PR TITLE
feat(check-in): manage entrance fulfillment (strap issuance & delivery adjustments)

### DIFF
--- a/backend/app/routers/volunteer_ops.py
+++ b/backend/app/routers/volunteer_ops.py
@@ -28,7 +28,7 @@ from app.dependencies import Pagination
 from app.live import live_bus
 from app.live import mapping as live_mapping
 from app.models import Event, Person, Registration, Table
-from app.schemas import CheckInGuestOut, CheckInOut
+from app.schemas import CheckInGuestOut, CheckInOut, OrderItemBase
 from app.services.operational_search import (
     DEFAULT_RESULT_LIMIT,
     best_registration_match,
@@ -51,6 +51,11 @@ router = APIRouter(
 
 class VolunteerCheckInRequest(BaseModel):
     issue_strap: bool = True
+
+
+class VolunteerRegistrationUpdate(BaseModel):
+    pre_orders: list[OrderItemBase] | None = None
+    strap_issued: bool | None = None
 
 
 async def _resolve_tables(db: AsyncSession, reference: str) -> list[Table]:
@@ -270,6 +275,84 @@ async def search_registrations(
         registration_to_checkin_dict(registration, registration.person, registration.event, table_name=table_name)
         for _, registration, table_name in ranked_rows[offset : offset + limit]
     ]
+
+
+@router.put("/registrations/{registration_id}", response_model=CheckInGuestOut)
+async def update_volunteer_registration(
+    registration_id: str,
+    body: VolunteerRegistrationUpdate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> dict:
+    """Update entrance-facing registration fields from volunteer check-in."""
+
+    row = (
+        await db.execute(
+            select(Registration, Table.name)
+            .outerjoin(Table, Registration.table_id == Table.id)
+            .where(Registration.id == registration_id)
+            .options(selectinload(Registration.person), selectinload(Registration.event))
+        )
+    ).one_or_none()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Registration not found.")
+
+    registration, table_name = row
+    if registration.person is None or registration.event is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Registration not found.")
+
+    previous_orders = list(registration.pre_orders) if registration.pre_orders else []
+    previous_strap_issued = registration.strap_issued
+    changed = False
+    request_id = getattr(request.state, "request_id", None)
+    audit_base = {
+        "actor": actor,
+        "resource_type": "registration",
+        "resource_id": registration.id,
+        "request_id": request_id,
+    }
+
+    if body.pre_orders is not None:
+        registration.pre_orders = [item.model_dump() for item in body.pre_orders]
+        if registration.pre_orders != previous_orders:
+            changed = True
+            await write_audit_entry(
+                db,
+                action="delivery_updated",
+                details={"event_id": registration.event_id, "source": "volunteer_check_in"},
+                **audit_base,
+            )
+
+    if body.strap_issued is not None:
+        registration.strap_issued = body.strap_issued
+        if registration.strap_issued != previous_strap_issued:
+            changed = True
+            await write_audit_entry(
+                db,
+                action="strap_issued" if registration.strap_issued else "strap_revoked",
+                details={"event_id": registration.event_id, "source": "volunteer_check_in"},
+                **audit_base,
+            )
+
+    if changed:
+        await db.commit()
+        await db.refresh(registration)
+        try:
+            await live_bus.publish(
+                live_mapping.registration_changed(
+                    action="updated",
+                    registration_id=registration.id,
+                    event_id=registration.event_id,
+                    edition_id=registration.event.edition_id,
+                )
+            )
+        except Exception:
+            logger.warning(
+                "live_bus.publish failed for volunteer registration update %s", registration.id, exc_info=True
+            )
+
+    return registration_to_checkin_dict(registration, registration.person, registration.event, table_name=table_name)
 
 
 @router.post("/registrations/{registration_id}/check-in", response_model=CheckInOut)

--- a/backend/app/routers/volunteer_ops.py
+++ b/backend/app/routers/volunteer_ops.py
@@ -337,7 +337,6 @@ async def update_volunteer_registration(
 
     if changed:
         await db.commit()
-        await db.refresh(registration)
         try:
             await live_bus.publish(
                 live_mapping.registration_changed(

--- a/backend/tests/test_volunteer_ops.py
+++ b/backend/tests/test_volunteer_ops.py
@@ -147,6 +147,39 @@ async def test_volunteer_can_check_in_from_registration_search(client):
 
 
 @pytest.mark.anyio
+async def test_volunteer_can_issue_strap_and_update_delivery_from_check_in_card(client):
+    registration = await _post_registration(client, path="/api/registrations")
+    assert registration.status_code == 201
+    registration_id = registration.json()["id"]
+
+    r = await client.put(
+        f"/api/volunteer/registrations/{registration_id}",
+        json={
+            "strap_issued": True,
+            "pre_orders": [
+                {
+                    "product_id": "prod-01",
+                    "name": "Champagne bottle",
+                    "quantity": 2,
+                    "delivered_quantity": 1,
+                    "price": 42,
+                    "category": "champagne",
+                    "delivered": False,
+                }
+            ],
+        },
+    )
+
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["id"] == registration_id
+    assert payload["strap_issued"] is True
+    assert payload["pre_orders"][0]["delivered_quantity"] == 1
+    assert "email" not in payload
+    assert "phone" not in payload
+
+
+@pytest.mark.anyio
 async def test_volunteer_table_order_lookup_returns_candidates_for_ambiguous_reference(client):
     await _create_table(client, name="Table 12")
     await _create_table(client, name="Table 12 terrace")

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -231,7 +231,7 @@
   "checkin_pre_orders": "Pre-orders",
   "checkin_not_found": "Reservation not found.",
   "checkin_invalid_token": "Invalid check-in code.",
-  "checkin_do_checkin": "Check in & issue strap",
+  "checkin_do_checkin": "Check in",
   "checkin_error": "An error occurred during check-in.",
   "admin_content_tab": "Content",
   "admin_content_editions_section": "Festival Editions",
@@ -588,5 +588,8 @@
   "checkin_manual_search_no_results": "No matching registrations found.",
   "checkin_manual_search_unauthorized": "Sign in as a volunteer or admin to search registrations.",
   "checkin_manual_not_checked_in": "Not checked in",
-  "checkin_search_error": "Could not search registrations."
+  "checkin_search_error": "Could not search registrations.",
+  "checkin_table": "Table",
+  "checkin_actions_login_required": "Sign in as a volunteer or admin to issue straps and update pre-orders.",
+  "checkin_actions_unauthorized": "Sign in as a volunteer or admin to update entrance actions."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -231,7 +231,7 @@
   "checkin_pre_orders": "Précommandes",
   "checkin_not_found": "Réservation introuvable.",
   "checkin_invalid_token": "Code d'enregistrement invalide.",
-  "checkin_do_checkin": "Enregistrer & remettre le bracelet",
+  "checkin_do_checkin": "Enregistrer",
   "checkin_error": "Une erreur s'est produite lors de l'enregistrement.",
   "admin_content_tab": "Contenu",
   "admin_content_editions_section": "Éditions du festival",
@@ -588,5 +588,8 @@
   "checkin_manual_search_no_results": "Aucune réservation correspondante trouvée.",
   "checkin_manual_search_unauthorized": "Connectez-vous comme bénévole ou admin pour rechercher des réservations.",
   "checkin_manual_not_checked_in": "Pas encore enregistré",
-  "checkin_search_error": "Impossible de rechercher les réservations."
+  "checkin_search_error": "Impossible de rechercher les réservations.",
+  "checkin_table": "Table",
+  "checkin_actions_login_required": "Connectez-vous comme bénévole ou admin pour remettre les bracelets et mettre à jour les précommandes.",
+  "checkin_actions_unauthorized": "Connectez-vous comme bénévole ou admin pour mettre à jour les actions d’entrée."
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -231,7 +231,7 @@
   "checkin_pre_orders": "Voorbestellingen",
   "checkin_not_found": "Reservatie niet gevonden.",
   "checkin_invalid_token": "Ongeldige check-in code.",
-  "checkin_do_checkin": "Inchecken & polsband uitreiken",
+  "checkin_do_checkin": "Inchecken",
   "checkin_error": "Er is een fout opgetreden bij het inchecken.",
   "admin_content_tab": "Inhoud",
   "admin_content_editions_section": "Festival Edities",
@@ -588,5 +588,8 @@
   "checkin_manual_search_no_results": "Geen overeenkomende registraties gevonden.",
   "checkin_manual_search_unauthorized": "Meld je aan als vrijwilliger of admin om registraties te zoeken.",
   "checkin_manual_not_checked_in": "Niet ingecheckt",
-  "checkin_search_error": "Registraties zoeken is mislukt."
+  "checkin_search_error": "Registraties zoeken is mislukt.",
+  "checkin_table": "Tafel",
+  "checkin_actions_login_required": "Meld je aan als vrijwilliger of admin om polsbanden uit te reiken en voorbestellingen bij te werken.",
+  "checkin_actions_unauthorized": "Meld je aan als vrijwilliger of admin om acties aan de ingang bij te werken."
 }

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -20,14 +20,22 @@ import {
   submitCheckIn,
   type CheckInData,
 } from "@/utils/publicRegistrationApi";
-import { searchVolunteerRegistrations, submitVolunteerCheckIn } from "@/utils/volunteerApi";
+import {
+  searchVolunteerRegistrations,
+  submitVolunteerCheckIn,
+  updateVolunteerRegistration,
+} from "@/utils/volunteerApi";
 
 interface CheckInCardProps {
   registration: CheckInData;
   success: boolean;
   isAlreadyCheckedIn: boolean;
   isCheckingIn: boolean;
+  isUpdatingRegistration: boolean;
+  canManageEntranceActions: boolean;
   onCheckIn: () => void;
+  onAdjustPreOrder: (productId: string, delta: number) => void;
+  onIssueStrap: () => void;
 }
 
 function CheckInCard({
@@ -35,7 +43,11 @@ function CheckInCard({
   success,
   isAlreadyCheckedIn,
   isCheckingIn,
+  isUpdatingRegistration,
+  canManageEntranceActions,
   onCheckIn,
+  onAdjustPreOrder,
+  onIssueStrap,
 }: CheckInCardProps) {
   return (
     <Card
@@ -74,7 +86,7 @@ function CheckInCard({
           <Alert variant="success" className="mb-3">
             <i className="bi bi-check-circle-fill me-2" aria-hidden="true" />
             <strong>{m.checkin_success()}</strong>
-            <div className="mt-1">{m.checkin_strap_issued()}</div>
+            {registration.strapIssued && <div className="mt-1">{m.checkin_strap_issued()}</div>}
           </Alert>
         )}
 
@@ -94,6 +106,12 @@ function CheckInCard({
             <span className="text-secondary">{m.checkin_guests()}</span>
             <span>{registration.guestCount}</span>
           </ListGroup.Item>
+          {registration.tableName && (
+            <ListGroup.Item className="bg-dark text-light border-secondary d-flex justify-content-between gap-3">
+              <span className="text-secondary">{m.checkin_table()}</span>
+              <span className="fw-semibold text-warning">{registration.tableName}</span>
+            </ListGroup.Item>
+          )}
         </ListGroup>
 
         {registration.preOrders.length > 0 && (
@@ -111,13 +129,41 @@ function CheckInCard({
                   <span>
                     {item.name} <Badge bg="secondary">×{item.quantity}</Badge>
                   </span>
-                  <div className="d-flex gap-2 flex-wrap">
+                  <div className="d-flex align-items-center gap-2 flex-wrap">
                     <Badge bg={item.delivered ? "success" : "secondary"}>
                       {m.admin_bottle_delivered()}: {item.deliveredQuantity}/{item.quantity}
                     </Badge>
                     <Badge bg={item.remainingQuantity > 0 ? "warning" : "success"} text="dark">
                       {m.admin_bottle_not_delivered()}: {item.remainingQuantity}
                     </Badge>
+                    <Button
+                      size="sm"
+                      variant="outline-secondary"
+                      onClick={() => onAdjustPreOrder(item.productId, -1)}
+                      disabled={
+                        !canManageEntranceActions ||
+                        isUpdatingRegistration ||
+                        item.deliveredQuantity <= 0
+                      }
+                      title={m.admin_mark_not_delivered()}
+                    >
+                      <i className="bi bi-dash" aria-hidden="true" />
+                      <span className="visually-hidden">{m.admin_mark_not_delivered()}</span>
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant={item.delivered ? "success" : "outline-success"}
+                      onClick={() => onAdjustPreOrder(item.productId, 1)}
+                      disabled={
+                        !canManageEntranceActions ||
+                        isUpdatingRegistration ||
+                        item.deliveredQuantity >= item.quantity
+                      }
+                      title={m.admin_mark_delivered()}
+                    >
+                      <i className="bi bi-plus" aria-hidden="true" />
+                      <span className="visually-hidden">{m.admin_mark_delivered()}</span>
+                    </Button>
                   </div>
                 </ListGroup.Item>
               ))}
@@ -126,23 +172,50 @@ function CheckInCard({
         )}
       </Card.Body>
 
-      {!registration.checkedIn && (
-        <Card.Footer className="bg-dark border-secondary">
-          <Button variant="warning" className="w-100" onClick={onCheckIn} disabled={isCheckingIn}>
-            {isCheckingIn ? (
-              <Spinner
-                as="span"
-                animation="border"
-                size="sm"
-                role="status"
-                aria-hidden="true"
-                className="me-2"
-              />
-            ) : (
-              <i className="bi bi-person-check-fill me-2" aria-hidden="true" />
-            )}
-            {m.checkin_do_checkin()}
-          </Button>
+      {(!registration.checkedIn || !registration.strapIssued) && (
+        <Card.Footer className="bg-dark border-secondary d-grid gap-2">
+          {!registration.checkedIn && (
+            <Button variant="warning" className="w-100" onClick={onCheckIn} disabled={isCheckingIn}>
+              {isCheckingIn ? (
+                <Spinner
+                  as="span"
+                  animation="border"
+                  size="sm"
+                  role="status"
+                  aria-hidden="true"
+                  className="me-2"
+                />
+              ) : (
+                <i className="bi bi-person-check-fill me-2" aria-hidden="true" />
+              )}
+              {m.checkin_do_checkin()}
+            </Button>
+          )}
+          {registration.checkedIn && !registration.strapIssued && (
+            <Button
+              variant="info"
+              className="w-100"
+              onClick={onIssueStrap}
+              disabled={!canManageEntranceActions || isUpdatingRegistration}
+            >
+              {isUpdatingRegistration ? (
+                <Spinner
+                  as="span"
+                  animation="border"
+                  size="sm"
+                  role="status"
+                  aria-hidden="true"
+                  className="me-2"
+                />
+              ) : (
+                <i className="bi bi-person-badge-fill me-2" aria-hidden="true" />
+              )}
+              {m.admin_issue_strap()}
+            </Button>
+          )}
+          {!canManageEntranceActions && (
+            <div className="small text-secondary">{m.checkin_actions_login_required()}</div>
+          )}
         </Card.Footer>
       )}
     </Card>
@@ -200,7 +273,10 @@ export default function CheckInPage() {
       setSuccess(false);
       setAlreadyCheckedIn(false);
     },
-    onSuccess: ({ registration: updatedRegistration, alreadyCheckedIn: mutationAlreadyCheckedIn }) => {
+    onSuccess: ({
+      registration: updatedRegistration,
+      alreadyCheckedIn: mutationAlreadyCheckedIn,
+    }) => {
       queryClient.setQueryData(checkInQueryKey, updatedRegistration);
       setSuccess(true);
       setAlreadyCheckedIn(mutationAlreadyCheckedIn || updatedRegistration.checkedIn);
@@ -217,7 +293,10 @@ export default function CheckInPage() {
       setSuccess(false);
       setAlreadyCheckedIn(false);
     },
-    onSuccess: ({ registration: updatedRegistration, alreadyCheckedIn: mutationAlreadyCheckedIn }) => {
+    onSuccess: ({
+      registration: updatedRegistration,
+      alreadyCheckedIn: mutationAlreadyCheckedIn,
+    }) => {
       setManualRegistration(updatedRegistration);
       setSuccess(true);
       setAlreadyCheckedIn(mutationAlreadyCheckedIn || updatedRegistration.checkedIn);
@@ -230,14 +309,47 @@ export default function CheckInPage() {
     },
   });
 
-  const registration =
-    volunteerCheckInMutation.data?.registration ??
-    manualRegistration ??
-    checkInMutation.data?.registration ??
-    registrationQuery.data ??
-    null;
+  const updateRegistrationMutation = useMutation({
+    mutationFn: ({
+      targetRegistration,
+      preOrders,
+      strapIssued,
+    }: {
+      targetRegistration: CheckInData;
+      preOrders?: CheckInData["preOrders"];
+      strapIssued?: boolean;
+    }) =>
+      updateVolunteerRegistration(targetRegistration.id, { preOrders, strapIssued }, authHeaders),
+    retry: false,
+    onSuccess: (updatedRegistration) => {
+      setManualRegistration((prev) =>
+        prev?.id === updatedRegistration.id ? updatedRegistration : prev,
+      );
+      if (hasQrCredentials) {
+        queryClient.setQueryData(checkInQueryKey, updatedRegistration);
+      }
+      queryClient.setQueryData<CheckInData[]>(
+        queryKeys.volunteerRegistrationSearch(debouncedSearchTerm),
+        (prev) =>
+          prev?.map((item) => (item.id === updatedRegistration.id ? updatedRegistration : item)),
+      );
+    },
+    onSettled: async () => {
+      if (hasQrCredentials) {
+        await queryClient.invalidateQueries({ queryKey: checkInQueryKey });
+      }
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.volunteerRegistrationSearch(debouncedSearchTerm),
+      });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.admin.registrations });
+    },
+  });
+
+  const registration = manualRegistration ?? registrationQuery.data ?? null;
   const isLoading = hasQrCredentials ? registrationQuery.isPending : false;
   const isCheckingIn = checkInMutation.isPending || volunteerCheckInMutation.isPending;
+  const canManageEntranceActions = auth.isAuthenticated;
+  const isUpdatingRegistration = updateRegistrationMutation.isPending;
   const queryError = registrationQuery.isError ? registrationQuery.error.message : "";
   const mutationError = checkInMutation.isError
     ? checkInMutation.error instanceof CheckInError
@@ -245,7 +357,11 @@ export default function CheckInPage() {
       : m.checkin_error()
     : volunteerCheckInMutation.isError
       ? volunteerCheckInMutation.error.message
-      : "";
+      : updateRegistrationMutation.isError
+        ? updateRegistrationMutation.error.message === "unauthorized"
+          ? m.checkin_actions_unauthorized()
+          : updateRegistrationMutation.error.message
+        : "";
   const isAlreadyCheckedIn = success ? alreadyCheckedIn : (registration?.checkedIn ?? false);
   const searchResults = volunteerSearchQuery.data ?? [];
   const showSearchHint = useMemo(
@@ -261,6 +377,35 @@ export default function CheckInPage() {
     if (!manualRegistration) return;
     volunteerCheckInMutation.mutate();
   }, [checkInMutation, hasQrCredentials, manualRegistration, volunteerCheckInMutation]);
+
+  const handleAdjustPreOrder = useCallback(
+    (productId: string, delta: number) => {
+      if (!registration) return;
+      const updatedOrders = registration.preOrders.map((item) => {
+        if (item.productId !== productId) return item;
+        const deliveredQuantity = Math.max(
+          0,
+          Math.min(item.quantity, item.deliveredQuantity + delta),
+        );
+        return {
+          ...item,
+          deliveredQuantity,
+          remainingQuantity: item.quantity - deliveredQuantity,
+          delivered: deliveredQuantity === item.quantity,
+        };
+      });
+      updateRegistrationMutation.mutate({
+        targetRegistration: registration,
+        preOrders: updatedOrders,
+      });
+    },
+    [registration, updateRegistrationMutation],
+  );
+
+  const handleIssueStrap = useCallback(() => {
+    if (!registration) return;
+    updateRegistrationMutation.mutate({ targetRegistration: registration, strapIssued: true });
+  }, [registration, updateRegistrationMutation]);
 
   const handleSelectManualRegistration = useCallback((selected: CheckInData) => {
     setManualRegistration(selected);
@@ -308,7 +453,10 @@ export default function CheckInPage() {
                   <Collapse in={searchOpen}>
                     <Card.Body id="manual-checkin-search">
                       {!auth.isAuthenticated && (
-                        <Alert variant="info" className="d-flex justify-content-between align-items-center gap-3 flex-wrap">
+                        <Alert
+                          variant="info"
+                          className="d-flex justify-content-between align-items-center gap-3 flex-wrap"
+                        >
                           <span>{m.checkin_manual_search_login_required()}</span>
                           <Button variant="outline-warning" size="sm" onClick={auth.login}>
                             {m.admin_login_button()}
@@ -336,7 +484,9 @@ export default function CheckInPage() {
                       </Form.Group>
 
                       {showSearchHint && (
-                        <div className="text-secondary mt-3">{m.checkin_manual_search_min_chars()}</div>
+                        <div className="text-secondary mt-3">
+                          {m.checkin_manual_search_min_chars()}
+                        </div>
                       )}
 
                       {volunteerSearchQuery.isFetching && (
@@ -384,11 +534,14 @@ export default function CheckInPage() {
                               <span>
                                 <span className="fw-semibold d-block">{result.name}</span>
                                 <span className="text-secondary small">
-                                  {result.eventTitle || result.eventId} · {m.checkin_guests()}: {result.guestCount}
+                                  {result.eventTitle || result.eventId} · {m.checkin_guests()}:{" "}
+                                  {result.guestCount}
                                 </span>
                               </span>
                               <Badge bg={result.checkedIn ? "success" : "secondary"}>
-                                {result.checkedIn ? m.admin_checked_in() : m.checkin_manual_not_checked_in()}
+                                {result.checkedIn
+                                  ? m.admin_checked_in()
+                                  : m.checkin_manual_not_checked_in()}
                               </Badge>
                             </ListGroup.Item>
                           ))}
@@ -422,7 +575,11 @@ export default function CheckInPage() {
                 success={success}
                 isAlreadyCheckedIn={isAlreadyCheckedIn}
                 isCheckingIn={isCheckingIn}
+                isUpdatingRegistration={isUpdatingRegistration}
+                canManageEntranceActions={canManageEntranceActions}
                 onCheckIn={handleCheckIn}
+                onAdjustPreOrder={handleAdjustPreOrder}
+                onIssueStrap={handleIssueStrap}
               />
             )}
           </div>

--- a/frontend/src/mocks/handlers/admin.ts
+++ b/frontend/src/mocks/handlers/admin.ts
@@ -1,5 +1,11 @@
 import { http, HttpResponse } from "msw";
-import { editions, events, resetEditionStore, type SeedEdition, type SeedEvent } from "../data/editionStore";
+import {
+  editions,
+  events,
+  resetEditionStore,
+  type SeedEdition,
+  type SeedEvent,
+} from "../data/editionStore";
 import { seedExhibitors } from "../data/exhibitors";
 import { seedPeople } from "../data/people";
 import {
@@ -125,7 +131,7 @@ function tablesWithRegistrationAssignments(): Record<string, unknown>[] {
   return tables.map((table) => {
     const tableId = table.id;
     const registrationIds =
-      typeof tableId === "string" && tableId.length > 0 ? byTableId.get(tableId) ?? [] : [];
+      typeof tableId === "string" && tableId.length > 0 ? (byTableId.get(tableId) ?? []) : [];
     return { ...table, registration_ids: registrationIds };
   });
 }
@@ -138,16 +144,19 @@ function now(): string {
   return new Date().toISOString();
 }
 
-function registrationToCheckInResponse(registration: Record<string, unknown>): Record<string, unknown> {
+function registrationToCheckInResponse(
+  registration: Record<string, unknown>,
+): Record<string, unknown> {
   const person = registration.person as Record<string, unknown> | undefined;
   const event = registration.event as Record<string, unknown> | null | undefined;
+  const table = tables.find((item) => item.id === registration.table_id);
   return {
     id: registration.id,
     name: person?.name ?? "",
     event_id: registration.event_id,
     event_title: event?.title ?? "",
     table_id: registration.table_id ?? null,
-    table_name: null,
+    table_name: table?.name ?? null,
     guest_count: registration.guest_count,
     pre_orders: registration.pre_orders,
     notes: registration.notes,
@@ -204,13 +213,7 @@ export const adminHandlers = [
       if (!query) return true;
       const person = registration.person as Record<string, unknown> | undefined;
       const event = registration.event as Record<string, unknown> | undefined;
-      return [
-        person?.name,
-        person?.email,
-        registration.id,
-        registration.event_id,
-        event?.title,
-      ]
+      return [person?.name, person?.email, registration.id, registration.event_id, event?.title]
         .filter((value): value is string => typeof value === "string")
         .some((value) => value.toLowerCase().includes(query));
     });
@@ -246,6 +249,21 @@ export const adminHandlers = [
       already_checked_in: alreadyCheckedIn,
       registration: registrationToCheckInResponse(sharedStore.registrations[idx]!),
     });
+  }),
+
+  http.put("/api/volunteer/registrations/:id", async ({ request, params }) => {
+    const authError = requireAuth(request);
+    if (authError) return authError;
+    const idx = sharedStore.registrations.findIndex((r) => r.id === params.id);
+    if (idx === -1) return HttpResponse.json(null, { status: 404 });
+    const body = (await request.json()) as Record<string, unknown>;
+    sharedStore.registrations[idx] = {
+      ...sharedStore.registrations[idx]!,
+      ...(Array.isArray(body.pre_orders) ? { pre_orders: body.pre_orders } : {}),
+      ...(typeof body.strap_issued === "boolean" ? { strap_issued: body.strap_issued } : {}),
+      updated_at: now(),
+    };
+    return HttpResponse.json(registrationToCheckInResponse(sharedStore.registrations[idx]!));
   }),
 
   // ──────────────────────────────────────────────────────────────

--- a/frontend/src/mocks/handlers/public.ts
+++ b/frontend/src/mocks/handlers/public.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { editions, events } from "../data/editionStore";
 import { sharedStore, resetSharedStore } from "../data/registrations";
+import { seedTables } from "../data/venue";
 
 export const publicHandlers = [
   /** GET /api/editions/active — returns the active edition. */
@@ -150,11 +151,13 @@ export const publicHandlers = [
 
     const regPerson = reg.person as Record<string, unknown>;
     const regEvent = reg.event as Record<string, unknown> | null | undefined;
+    const regTable = seedTables.find((table) => table.id === reg.table_id);
     return HttpResponse.json({
       id: reg.id,
       name: regPerson?.name ?? "",
       event_id: reg.event_id,
       event_title: regEvent?.title ?? "",
+      table_name: regTable?.name ?? null,
       guest_count: reg.guest_count,
       pre_orders: reg.pre_orders,
       notes: reg.notes,
@@ -201,6 +204,7 @@ export const publicHandlers = [
     const updatedReg = sharedStore.registrations[idx]!;
     const regPerson2 = updatedReg.person as Record<string, unknown>;
     const regEvent2 = updatedReg.event as Record<string, unknown> | null | undefined;
+    const regTable2 = seedTables.find((table) => table.id === updatedReg.table_id);
     return HttpResponse.json({
       already_checked_in: alreadyCheckedIn,
       registration: {
@@ -208,6 +212,7 @@ export const publicHandlers = [
         name: regPerson2?.name ?? "",
         event_id: updatedReg.event_id,
         event_title: regEvent2?.title ?? "",
+        table_name: regTable2?.name ?? null,
         guest_count: updatedReg.guest_count,
         pre_orders: updatedReg.pre_orders,
         notes: updatedReg.notes,

--- a/frontend/src/utils/publicRegistrationApi.ts
+++ b/frontend/src/utils/publicRegistrationApi.ts
@@ -12,6 +12,7 @@ export interface CheckInData {
   eventId: string;
   eventTitle: string;
   guestCount: number;
+  tableName?: string;
   preOrders: {
     productId: string;
     name: string;
@@ -36,6 +37,7 @@ interface CheckInResponseRegistration {
   event_id?: string;
   event_title?: string;
   guest_count?: number;
+  table_name?: string | null;
   pre_orders?: Record<string, unknown>[];
   notes?: string;
   accessibility_note?: string;
@@ -90,6 +92,7 @@ function mapCheckInData(data: CheckInResponseRegistration): CheckInData {
     eventId: data.event_id ?? "",
     eventTitle: data.event_title ?? "",
     guestCount: data.guest_count ?? 1,
+    tableName: data.table_name ?? undefined,
     preOrders: rawOrders.filter(isGuestOrderItemResponse).map((item) => ({
       ...normalizeDeliveredQuantities(item),
       productId: item.product_id,
@@ -139,7 +142,7 @@ export async function submitCheckIn(
   const response = await fetch(`/api/check-in/${encodeURIComponent(registrationId)}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ token: checkInToken, issue_strap: true }),
+    body: JSON.stringify({ token: checkInToken, issue_strap: false }),
   });
 
   if (response.status === 401) {
@@ -239,7 +242,9 @@ function isGuestOrderItemResponse(value: unknown): value is GuestOrderItemRespon
     typeof value.product_id === "string" &&
     typeof value.name === "string" &&
     typeof value.quantity === "number" &&
-    (value.delivered_quantity === undefined || value.delivered_quantity === null || typeof value.delivered_quantity === "number") &&
+    (value.delivered_quantity === undefined ||
+      value.delivered_quantity === null ||
+      typeof value.delivered_quantity === "number") &&
     typeof value.price === "number" &&
     typeof value.category === "string" &&
     typeof value.delivered === "boolean"

--- a/frontend/src/utils/volunteerApi.ts
+++ b/frontend/src/utils/volunteerApi.ts
@@ -1,7 +1,7 @@
 import { m } from "@/paraglide/messages";
 import { fetchArrayOrThrow, fetchJsonOrThrowWithUnauthorized } from "@/utils/adminApi";
 import type { CheckInData } from "@/utils/publicRegistrationApi";
-import type { OrderItemCategory, RegistrationStatus } from "@/types/registration";
+import type { OrderItem, OrderItemCategory, RegistrationStatus } from "@/types/registration";
 
 interface VolunteerRegistrationResponse {
   id?: string;
@@ -32,6 +32,7 @@ function mapVolunteerRegistration(data: VolunteerRegistrationResponse): CheckInD
     eventId: data.event_id ?? "",
     eventTitle: data.event_title ?? "",
     guestCount: data.guest_count ?? 1,
+    tableName: data.table_name ?? undefined,
     preOrders: rawOrders.map((item) => {
       const quantityRaw = Number(item.quantity ?? 0);
       const quantity = Number.isFinite(quantityRaw) ? Math.max(0, quantityRaw) : 0;
@@ -63,7 +64,6 @@ function mapVolunteerRegistration(data: VolunteerRegistrationResponse): CheckInD
   };
 }
 
-
 export async function searchVolunteerRegistrations(
   query: string,
   authHeaders: () => Record<string, string>,
@@ -87,13 +87,45 @@ export async function submitVolunteerCheckIn(
     {
       method: "POST",
       headers: authHeaders(),
-      body: JSON.stringify({ issue_strap: true }),
+      body: JSON.stringify({ issue_strap: false }),
     },
     m.checkin_error(),
   );
 
   return {
-    registration: mapVolunteerRegistration(registration.registration as VolunteerRegistrationResponse),
+    registration: mapVolunteerRegistration(
+      registration.registration as VolunteerRegistrationResponse,
+    ),
     alreadyCheckedIn: Boolean(registration.already_checked_in),
   };
+}
+
+export async function updateVolunteerRegistration(
+  registrationId: string,
+  payload: { preOrders?: OrderItem[]; strapIssued?: boolean },
+  authHeaders: () => Record<string, string>,
+): Promise<CheckInData> {
+  const body: Record<string, unknown> = {};
+  if (payload.preOrders) {
+    body.pre_orders = payload.preOrders.map((order) => ({
+      product_id: order.productId,
+      name: order.name,
+      quantity: order.quantity,
+      delivered_quantity: order.deliveredQuantity,
+      price: order.price,
+      category: order.category,
+      delivered: order.delivered,
+    }));
+  }
+  if (payload.strapIssued !== undefined) {
+    body.strap_issued = payload.strapIssued;
+  }
+
+  const registration = await fetchJsonOrThrowWithUnauthorized<VolunteerRegistrationResponse>(
+    `/api/volunteer/registrations/${encodeURIComponent(registrationId)}`,
+    { method: "PUT", headers: authHeaders(), body: JSON.stringify(body) },
+    m.admin_error_update_registration(),
+  );
+
+  return mapVolunteerRegistration(registration);
 }

--- a/frontend/tests/components/CheckInPage.test.tsx
+++ b/frontend/tests/components/CheckInPage.test.tsx
@@ -34,8 +34,11 @@ vi.mock("@/paraglide/messages", () => ({
     checkin_already_in: () => "Already checked in at",
     checkin_event: () => "Event",
     checkin_guests: () => "Guests",
+    checkin_table: () => "Table",
     checkin_pre_orders: () => "Pre-orders",
     checkin_do_checkin: () => "Check in now",
+    checkin_actions_login_required: () => "Login for entrance actions.",
+    checkin_actions_unauthorized: () => "Unauthorized entrance action.",
     checkin_manual_search_title: () => "Find guest manually",
     checkin_manual_search_login_required: () => "Volunteer login required.",
     checkin_manual_search_label: () => "Guest name or email",
@@ -50,15 +53,17 @@ vi.mock("@/paraglide/messages", () => ({
     admin_login_button: () => "Login",
     admin_checked_in: () => "Checked in",
     admin_strap_issued: () => "Strap issued",
+    admin_issue_strap: () => "Issue strap",
     admin_bottle_delivered: () => "Delivered",
     admin_bottle_not_delivered: () => "Pending",
+    admin_mark_delivered: () => "Mark as delivered",
+    admin_mark_not_delivered: () => "Mark as not delivered",
+    admin_error_update_registration: () => "Failed to update registration.",
   },
 }));
 
 describe("CheckInPage", () => {
-  async function renderPage(
-    initialEntry = `/check-in?id=${SEED_REG_ID}&token=${SEED_REG_TOKEN}`,
-  ) {
+  async function renderPage(initialEntry = `/check-in?id=${SEED_REG_ID}&token=${SEED_REG_TOKEN}`) {
     const rootRoute = createRootRoute();
     const checkInRoute = createRoute({
       getParentRoute: () => rootRoute,
@@ -81,6 +86,7 @@ describe("CheckInPage", () => {
     await waitFor(() => {
       expect(screen.getByText(SEED_REG_NAME)).toBeInTheDocument();
       expect(screen.getByText(new RegExp(SEED_EVENT_TITLE))).toBeInTheDocument();
+      expect(screen.getByText("T1")).toBeInTheDocument();
     });
   });
 
@@ -95,7 +101,7 @@ describe("CheckInPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Checked in successfully!")).toBeInTheDocument();
-      expect(screen.getByText("Strap issued.")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /issue strap/i })).toBeInTheDocument();
     });
   });
 
@@ -130,7 +136,6 @@ describe("CheckInPage", () => {
       });
     });
   });
-
 
   it("searches and selects a registration when the QR code is unavailable", async () => {
     await renderPage("/check-in");
@@ -167,7 +172,41 @@ describe("CheckInPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Checked in successfully!")).toBeInTheDocument();
-      expect(screen.getByText("Strap issued.")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /issue strap/i })).toBeInTheDocument();
+    });
+  });
+
+  it("issues a strap after check-in from the card", async () => {
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /check in now/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /check in now/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /issue strap/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /issue strap/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Strap issued")).toBeInTheDocument();
+    });
+  });
+
+  it("updates delivered pre-order quantities from the check-in card", async () => {
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Delivered: 2/4")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTitle("Mark as delivered"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delivered: 3/4")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
### Motivation
- Volunteers need to be able to manage entrance fulfillment (issue wristbands and adjust pre-order delivery counts) from the on-site check-in flow without exposing PII.
- The check-in card should surface table assignments so volunteers can confirm seating at the same time as check-in actions.

### Description
- Frontend: display `tableName` on the check-in card, add +/- controls next to each pre-order and an "Issue strap" button, and gate those actions behind volunteer/admin authentication; wire these actions to new mutations that update caches and invalidate relevant queries (`CheckInPage.tsx`, UI/messages updates).
- Frontend API: add `updateVolunteerRegistration` client to call `PUT /api/volunteer/registrations/:id`, and map `table_name` through public/volunteer mappers; adjust mock handlers to include `table_name` and the new update endpoint (`frontend/src/utils/volunteerApi.ts`, `frontend/src/utils/publicRegistrationApi.ts`, `frontend/src/mocks/*`).
- Backend: add a volunteer-scoped update endpoint `PUT /api/volunteer/registrations/{registration_id}` that accepts entrance-facing fields (`pre_orders`, `strap_issued`), writes audit entries for delivery/strap changes, publishes live updates, and returns the PII-minimal check-in payload (`backend/app/routers/volunteer_ops.py`).
- Tests & i18n: add frontend unit tests for table display, strap issuance and delivery adjustments, add a backend test for the volunteer update endpoint, and add i18n strings for table/action guidance in English/Dutch/French.

### Testing
- Ran frontend unit tests: `cd frontend && pnpm exec vitest run tests/components/CheckInPage.test.tsx` — all tests passed (9 passed).
- Ran frontend typecheck: `cd frontend && pnpm typecheck` — passed.
- Ran frontend lint: `cd frontend && pnpm lint` — passed (existing hook dependency warnings reported earlier remain informational).
- Ran backend static checks: `cd backend && uv run ruff check app tests/test_volunteer_ops.py && uv run ty check app` — passed.
- Attempted backend integration tests: `cd backend && uv run pytest tests/test_volunteer_ops.py` — could not run due to missing PostgreSQL (environment lacked Docker / db at localhost:5432); tests were added and are expected to pass when a test database is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24276f4b4c832ea60b89eaa3135a2a)