### PR TITLE
Android: add static analysis, certificate pinning, Retrofit factory and network tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
+      - name: Static analysis
+        run: ./gradlew ktlintCheck detekt
+
       - name: Lint
         run: ./gradlew lintDebug
 

--- a/android/.editorconfig
+++ b/android/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{kt,kts}]
+indent_style = space
+indent_size = 4
+# Compose functions and route constants intentionally use PascalCase/camelCase names.
+ktlint_standard_function-naming = disabled
+ktlint_standard_property-naming = disabled

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.ktlint)
 }
 
 android {
@@ -26,6 +28,7 @@ android {
             buildConfigField("String", "API_BASE_URL", "\"http://10.0.2.2:8000/\"")
             buildConfigField("String", "OIDC_ISSUER_URL", "\"http://10.0.2.2:8080/realms/champagnefestival\"")
             buildConfigField("String", "OIDC_CLIENT_ID", "\"champagnefestival\"")
+            buildConfigField("Boolean", "CERTIFICATE_PINNING_ENABLED", "false")
         }
         release {
             isMinifyEnabled = true
@@ -34,6 +37,7 @@ android {
             buildConfigField("String", "API_BASE_URL", "\"https://champagnefestival.tjor.im/\"")
             buildConfigField("String", "OIDC_ISSUER_URL", "\"https://auth.tjor.im/realms/champagnefestival\"")
             buildConfigField("String", "OIDC_CLIENT_ID", "\"champagnefestival\"")
+            buildConfigField("Boolean", "CERTIFICATE_PINNING_ENABLED", "true")
         }
     }
 
@@ -105,4 +109,19 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+    testImplementation(libs.okhttp.mockwebserver)
+}
+
+detekt {
+    buildUponDefaultConfig = true
+    allRules = false
+    config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
+}
+
+ktlint {
+    android = true
+}
+
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+    jvmTarget = "17"
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,6 +6,20 @@ plugins {
     alias(libs.plugins.ktlint)
 }
 
+fun quoted(value: String) = "\"$value\""
+
+val prodCertificatePinHost =
+    providers
+        .gradleProperty("CHAMPAGNEFESTIVAL_ANDROID_PROD_CERTIFICATE_PIN_HOST")
+        .orElse("champagnefestival.tjor.im")
+val prodCertificatePins =
+    providers
+        .gradleProperty("CHAMPAGNEFESTIVAL_ANDROID_PROD_CERTIFICATE_PINS")
+        .orElse(
+            "sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=," +
+                "sha256/C5+Q0gPI67ZTmAD/C84YyfVdbRF+O60CHGxkg1/g7xs=",
+        )
+
 android {
     namespace = "be.champagnefestival.android"
     compileSdk = 37
@@ -29,6 +43,8 @@ android {
             buildConfigField("String", "OIDC_ISSUER_URL", "\"http://10.0.2.2:8080/realms/champagnefestival\"")
             buildConfigField("String", "OIDC_CLIENT_ID", "\"champagnefestival\"")
             buildConfigField("Boolean", "CERTIFICATE_PINNING_ENABLED", "false")
+            buildConfigField("String", "CERTIFICATE_PIN_HOST", quoted(""))
+            buildConfigField("String", "CERTIFICATE_PINS", quoted(""))
         }
         release {
             isMinifyEnabled = true
@@ -38,6 +54,8 @@ android {
             buildConfigField("String", "OIDC_ISSUER_URL", "\"https://auth.tjor.im/realms/champagnefestival\"")
             buildConfigField("String", "OIDC_CLIENT_ID", "\"champagnefestival\"")
             buildConfigField("Boolean", "CERTIFICATE_PINNING_ENABLED", "true")
+            buildConfigField("String", "CERTIFICATE_PIN_HOST", quoted(prodCertificatePinHost.get()))
+            buildConfigField("String", "CERTIFICATE_PINS", quoted(prodCertificatePins.get()))
         }
     }
 

--- a/android/app/src/main/kotlin/be/champagnefestival/android/ChampagneFestivalApp.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/ChampagneFestivalApp.kt
@@ -28,7 +28,7 @@ class ChampagneFestivalApp : Application() {
         super.onCreate()
         sessionDataStore = SessionDataStore(this, applicationScope)
         authManager = AuthManager(this, sessionDataStore, applicationScope)
-        networkModule = NetworkModule(sessionDataStore)
+        networkModule = NetworkModule(sessionDataStore, authManager)
         checkInRepository = DefaultCheckInRepository(networkModule.apiService)
         editionRepository = DefaultEditionRepository(networkModule.apiService)
     }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/app/NavGraph.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/app/NavGraph.kt
@@ -74,14 +74,16 @@ fun NavGraph(app: ChampagneFestivalApp) {
             )
         }
         composable(Routes.Lookup) {
-            val viewModel: GuestLookupViewModel = viewModel(
-                factory = simpleFactory {
-                    GuestLookupViewModel(
-                        repository = app.checkInRepository,
-                        authTokenProvider = app.authManager::getAccessToken,
-                    )
-                },
-            )
+            val viewModel: GuestLookupViewModel =
+                viewModel(
+                    factory =
+                        simpleFactory {
+                            GuestLookupViewModel(
+                                repository = app.checkInRepository,
+                                authTokenProvider = app.authManager::getAccessToken,
+                            )
+                        },
+                )
             GuestLookupScreen(
                 viewModel = viewModel,
                 onBack = { navController.popBackStack() },
@@ -89,16 +91,18 @@ fun NavGraph(app: ChampagneFestivalApp) {
         }
         composable(
             route = Routes.Registration,
-            arguments = listOf(
-                navArgument("id") { type = NavType.StringType },
-                navArgument("token") { type = NavType.StringType },
-            ),
+            arguments =
+                listOf(
+                    navArgument("id") { type = NavType.StringType },
+                    navArgument("token") { type = NavType.StringType },
+                ),
         ) { backStackEntry ->
             val id = Uri.decode(backStackEntry.arguments?.getString("id").orEmpty())
             val token = Uri.decode(backStackEntry.arguments?.getString("token").orEmpty())
-            val viewModel: RegistrationDetailViewModel = viewModel(
-                factory = simpleFactory { RegistrationDetailViewModel(app.checkInRepository) },
-            )
+            val viewModel: RegistrationDetailViewModel =
+                viewModel(
+                    factory = simpleFactory { RegistrationDetailViewModel(app.checkInRepository) },
+                )
             RegistrationDetailScreen(
                 id = id,
                 token = token,
@@ -111,10 +115,11 @@ fun NavGraph(app: ChampagneFestivalApp) {
         }
         composable(
             route = Routes.CheckInConfirm,
-            arguments = listOf(
-                navArgument("id") { type = NavType.StringType },
-                navArgument("token") { type = NavType.StringType },
-            ),
+            arguments =
+                listOf(
+                    navArgument("id") { type = NavType.StringType },
+                    navArgument("token") { type = NavType.StringType },
+                ),
         ) { backStackEntry ->
             val id = Uri.decode(backStackEntry.arguments?.getString("id").orEmpty())
             val token = Uri.decode(backStackEntry.arguments?.getString("token").orEmpty())
@@ -132,9 +137,10 @@ fun NavGraph(app: ChampagneFestivalApp) {
             )
         }
         composable(Routes.Settings) {
-            val viewModel: SettingsViewModel = viewModel(
-                factory = simpleFactory { SettingsViewModel(app.sessionDataStore, app.authManager) },
-            )
+            val viewModel: SettingsViewModel =
+                viewModel(
+                    factory = simpleFactory { SettingsViewModel(app.sessionDataStore, app.authManager) },
+                )
             SettingsScreen(
                 viewModel = viewModel,
                 onBack = { navController.popBackStack() },
@@ -150,5 +156,8 @@ fun NavGraph(app: ChampagneFestivalApp) {
 
 private inline fun <reified T : ViewModel> simpleFactory(crossinline initializer: () -> T): ViewModelProvider.Factory =
     object : ViewModelProvider.Factory {
-        override fun <VM : ViewModel> create(modelClass: Class<VM>, extras: CreationExtras): VM = initializer() as VM
+        override fun <VM : ViewModel> create(
+            modelClass: Class<VM>,
+            extras: CreationExtras,
+        ): VM = initializer() as VM
     }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/AuthManager.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/AuthManager.kt
@@ -11,13 +11,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.GrantTypeValues
 import net.openid.appauth.ResponseTypeValues
+import net.openid.appauth.TokenRequest
 import kotlin.coroutines.resume
 
 class AuthManager(
@@ -27,50 +31,85 @@ class AuthManager(
     private val oidcConfig: OidcConfig = OidcConfig(),
 ) {
     private val authService = AuthorizationService(context)
+    private val refreshMutex = Mutex()
 
     val loggedIn: StateFlow<String?> = sessionDataStore.accessTokenFlow
 
-    fun startLogin(activity: Activity) {
-        applicationScope.launch {
-            val configuration = runCatching { fetchConfiguration() }.getOrNull() ?: return@launch
+    suspend fun startLogin(activity: Activity): Result<Unit> {
+        val configuration = runCatching { fetchConfiguration() }.getOrElse { return Result.failure(it) }
+        val request =
+            AuthorizationRequest
+                .Builder(
+                    configuration,
+                    oidcConfig.clientId,
+                    ResponseTypeValues.CODE,
+                    oidcConfig.redirectUri,
+                ).setScope("openid profile email offline_access")
+                .build()
+
+        withContext(Dispatchers.Main) {
+            val completionIntent =
+                Intent(activity, activity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                }
+            val cancelIntent =
+                Intent(activity, activity::class.java).apply {
+                    action = "be.champagnefestival.android.AUTH_CANCELLED"
+                    flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                }
+            authService.performAuthorizationRequest(
+                request,
+                PendingIntent.getActivity(
+                    activity,
+                    1001,
+                    completionIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+                ),
+                PendingIntent.getActivity(
+                    activity,
+                    1002,
+                    cancelIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+                ),
+            )
+        }
+        return Result.success(Unit)
+    }
+
+    /**
+     * Exchanges the stored refresh token for a new access token. Used by
+     * [be.champagnefestival.android.core.network.TokenAuthenticator] to recover from an
+     * expired access token without forcing the user to sign in again mid-shift.
+     */
+    suspend fun getFreshAccessToken(): String? =
+        refreshMutex.withLock {
+            val refreshToken = sessionDataStore.refreshTokenFlow.value ?: return null
+            val configuration = runCatching { fetchConfiguration() }.getOrNull() ?: return null
             val request =
-                AuthorizationRequest
-                    .Builder(
-                        configuration,
-                        oidcConfig.clientId,
-                        ResponseTypeValues.CODE,
-                        oidcConfig.redirectUri,
-                    ).setScope("openid profile email offline_access")
+                TokenRequest
+                    .Builder(configuration, oidcConfig.clientId)
+                    .setGrantType(GrantTypeValues.REFRESH_TOKEN)
+                    .setRefreshToken(refreshToken)
                     .build()
 
-            withContext(Dispatchers.Main) {
-                val completionIntent =
-                    Intent(activity, activity::class.java).apply {
-                        flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            val (response, exception) =
+                suspendCancellableCoroutine<Pair<net.openid.appauth.TokenResponse?, AuthorizationException?>> { continuation ->
+                    authService.performTokenRequest(request) { tokenResponse, tokenException ->
+                        continuation.resume(tokenResponse to tokenException)
                     }
-                val cancelIntent =
-                    Intent(activity, activity::class.java).apply {
-                        action = "be.champagnefestival.android.AUTH_CANCELLED"
-                        flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                    }
-                authService.performAuthorizationRequest(
-                    request,
-                    PendingIntent.getActivity(
-                        activity,
-                        1001,
-                        completionIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
-                    ),
-                    PendingIntent.getActivity(
-                        activity,
-                        1002,
-                        cancelIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
-                    ),
-                )
+                }
+
+            val accessToken = response?.accessToken
+            if (exception != null || accessToken.isNullOrBlank()) {
+                return null
             }
+            sessionDataStore.saveTokens(
+                accessToken = accessToken,
+                refreshToken = response.refreshToken ?: refreshToken,
+                idToken = response.idToken,
+            )
+            accessToken
         }
-    }
 
     suspend fun handleAuthResponse(intent: Intent): Result<Unit> {
         if (intent.action == "be.champagnefestival.android.AUTH_CANCELLED") {

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/AuthManager.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/AuthManager.kt
@@ -32,6 +32,8 @@ class AuthManager(
 ) {
     private val authService = AuthorizationService(context)
     private val refreshMutex = Mutex()
+    private val configMutex = Mutex()
+    private var cachedConfiguration: AuthorizationServiceConfiguration? = null
 
     val loggedIn: StateFlow<String?> = sessionDataStore.accessTokenFlow
 
@@ -152,7 +154,19 @@ class AuthManager(
         sessionDataStore.clearSession()
     }
 
-    private suspend fun fetchConfiguration(): AuthorizationServiceConfiguration =
+    /**
+     * OIDC discovery only needs to happen once per process; the issuer's configuration
+     * does not change at runtime. Cache it so login and every token refresh don't each
+     * pay for a round trip to the discovery endpoint.
+     */
+    private suspend fun fetchConfiguration(): AuthorizationServiceConfiguration {
+        cachedConfiguration?.let { return it }
+        return configMutex.withLock {
+            cachedConfiguration ?: fetchConfigurationFromIssuer().also { cachedConfiguration = it }
+        }
+    }
+
+    private suspend fun fetchConfigurationFromIssuer(): AuthorizationServiceConfiguration =
         suspendCancellableCoroutine { continuation ->
             AuthorizationServiceConfiguration.fetchFromIssuer(Uri.parse(oidcConfig.issuerUrl)) { config, ex ->
                 when {

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/AuthManager.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/AuthManager.kt
@@ -33,23 +33,26 @@ class AuthManager(
     fun startLogin(activity: Activity) {
         applicationScope.launch {
             val configuration = runCatching { fetchConfiguration() }.getOrNull() ?: return@launch
-            val request = AuthorizationRequest.Builder(
-                configuration,
-                oidcConfig.clientId,
-                ResponseTypeValues.CODE,
-                oidcConfig.redirectUri,
-            )
-                .setScope("openid profile email offline_access")
-                .build()
+            val request =
+                AuthorizationRequest
+                    .Builder(
+                        configuration,
+                        oidcConfig.clientId,
+                        ResponseTypeValues.CODE,
+                        oidcConfig.redirectUri,
+                    ).setScope("openid profile email offline_access")
+                    .build()
 
             withContext(Dispatchers.Main) {
-                val completionIntent = Intent(activity, activity::class.java).apply {
-                    flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                }
-                val cancelIntent = Intent(activity, activity::class.java).apply {
-                    action = "be.champagnefestival.android.AUTH_CANCELLED"
-                    flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                }
+                val completionIntent =
+                    Intent(activity, activity::class.java).apply {
+                        flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    }
+                val cancelIntent =
+                    Intent(activity, activity::class.java).apply {
+                        action = "be.champagnefestival.android.AUTH_CANCELLED"
+                        flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    }
                 authService.performAuthorizationRequest(
                     request,
                     PendingIntent.getActivity(

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/network/ApiServiceFactory.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/network/ApiServiceFactory.kt
@@ -1,0 +1,29 @@
+package be.champagnefestival.android.core.network
+
+import be.champagnefestival.android.data.api.ChampagneApiService
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+object ApiServiceFactory {
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+            coerceInputValues = true
+        }
+
+    fun create(
+        baseUrl: String,
+        client: OkHttpClient,
+    ): ChampagneApiService =
+        Retrofit
+            .Builder()
+            .baseUrl(baseUrl)
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(ChampagneApiService::class.java)
+}

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/network/CertificatePinnerProvider.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/network/CertificatePinnerProvider.kt
@@ -1,0 +1,29 @@
+package be.champagnefestival.android.core.network
+
+import be.champagnefestival.android.BuildConfig
+import okhttp3.CertificatePinner
+
+object CertificatePinnerProvider {
+    private const val API_HOST = "champagnefestival.tjor.im"
+
+    // Leaf certificate observed in Certificate Transparency for the production API, expiring July 11, 2026.
+    private const val API_LEAF_PIN = "sha256/4iYSVdRc1jul5AgK0EfE3bsgOSZWv54PqqQX04BBEoM="
+
+    // Let's Encrypt E7 intermediate public key pin. This backup pin keeps renewals from requiring app updates
+    // while still limiting trust to the issuing CA currently used by the production API.
+    private const val LETS_ENCRYPT_E7_PIN = "sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU="
+
+    fun productionPinner(): CertificatePinner =
+        CertificatePinner
+            .Builder()
+            .add(API_HOST, API_LEAF_PIN)
+            .add(API_HOST, LETS_ENCRYPT_E7_PIN)
+            .build()
+
+    fun forCurrentBuild(): CertificatePinner? =
+        if (BuildConfig.CERTIFICATE_PINNING_ENABLED) {
+            productionPinner()
+        } else {
+            null
+        }
+}

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/network/CertificatePinnerProvider.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/network/CertificatePinnerProvider.kt
@@ -4,25 +4,29 @@ import be.champagnefestival.android.BuildConfig
 import okhttp3.CertificatePinner
 
 object CertificatePinnerProvider {
-    private const val API_HOST = "champagnefestival.tjor.im"
+    fun forCurrentBuild(): CertificatePinner =
+        fromConfig(
+            enabled = BuildConfig.CERTIFICATE_PINNING_ENABLED,
+            host = BuildConfig.CERTIFICATE_PIN_HOST,
+            pins = BuildConfig.CERTIFICATE_PINS.toCsvList(),
+        )
 
-    // Let's Encrypt E7 intermediate public key pin.
-    private const val LETS_ENCRYPT_E7_PIN = "sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU="
+    fun fromConfig(
+        enabled: Boolean,
+        host: String,
+        pins: List<String>,
+    ): CertificatePinner {
+        if (!enabled || host.isEmpty() || pins.isEmpty()) return CertificatePinner.DEFAULT
 
-    // ISRG Root X1 — backup pin so intermediate CA rotation doesn't brick the app.
-    private const val ISRG_ROOT_X1_PIN = "sha256/C5+Q0gPI67ZTmAD/C84YyfVdbRF+O60CHGxkg1/g7xs="
-
-    fun productionPinner(): CertificatePinner =
-        CertificatePinner
+        return CertificatePinner
             .Builder()
-            .add(API_HOST, LETS_ENCRYPT_E7_PIN)
-            .add(API_HOST, ISRG_ROOT_X1_PIN)
-            .build()
+            .apply {
+                pins.forEach { pin -> add(host, pin) }
+            }.build()
+    }
 
-    fun forCurrentBuild(): CertificatePinner? =
-        if (BuildConfig.CERTIFICATE_PINNING_ENABLED) {
-            productionPinner()
-        } else {
-            null
-        }
+    private fun String.toCsvList(): List<String> =
+        split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
 }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/network/CertificatePinnerProvider.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/network/CertificatePinnerProvider.kt
@@ -6,18 +6,17 @@ import okhttp3.CertificatePinner
 object CertificatePinnerProvider {
     private const val API_HOST = "champagnefestival.tjor.im"
 
-    // Leaf certificate observed in Certificate Transparency for the production API, expiring July 11, 2026.
-    private const val API_LEAF_PIN = "sha256/4iYSVdRc1jul5AgK0EfE3bsgOSZWv54PqqQX04BBEoM="
-
-    // Let's Encrypt E7 intermediate public key pin. This backup pin keeps renewals from requiring app updates
-    // while still limiting trust to the issuing CA currently used by the production API.
+    // Let's Encrypt E7 intermediate public key pin.
     private const val LETS_ENCRYPT_E7_PIN = "sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU="
+
+    // ISRG Root X1 — backup pin so intermediate CA rotation doesn't brick the app.
+    private const val ISRG_ROOT_X1_PIN = "sha256/C5+Q0gPI67ZTmAD/C84YyfVdbRF+O60CHGxkg1/g7xs="
 
     fun productionPinner(): CertificatePinner =
         CertificatePinner
             .Builder()
-            .add(API_HOST, API_LEAF_PIN)
             .add(API_HOST, LETS_ENCRYPT_E7_PIN)
+            .add(API_HOST, ISRG_ROOT_X1_PIN)
             .build()
 
     fun forCurrentBuild(): CertificatePinner? =

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/network/NetworkModule.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/network/NetworkModule.kt
@@ -1,6 +1,7 @@
 package be.champagnefestival.android.core.network
 
 import be.champagnefestival.android.BuildConfig
+import be.champagnefestival.android.core.auth.AuthManager
 import be.champagnefestival.android.core.storage.SessionDataStore
 import be.champagnefestival.android.data.api.ChampagneApiService
 import kotlinx.coroutines.flow.filterNotNull
@@ -12,12 +13,14 @@ import okhttp3.logging.HttpLoggingInterceptor
 
 class NetworkModule(
     sessionDataStore: SessionDataStore,
+    authManager: AuthManager,
 ) {
     private val client =
         OkHttpClient
             .Builder()
             .apply {
                 certificatePinner(CertificatePinnerProvider.forCurrentBuild())
+                authenticator(TokenAuthenticator(sessionDataStore, authManager))
             }.addInterceptor { chain ->
                 val originalRequest = chain.request()
                 val overrideBaseUrl =

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/network/NetworkModule.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/network/NetworkModule.kt
@@ -6,50 +6,41 @@ import be.champagnefestival.android.data.api.ChampagneApiService
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import retrofit2.Retrofit
-import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
-class NetworkModule(sessionDataStore: SessionDataStore) {
-    private val json = Json {
-        ignoreUnknownKeys = true
-        explicitNulls = false
-        coerceInputValues = true
-    }
+class NetworkModule(
+    sessionDataStore: SessionDataStore,
+) {
+    private val client =
+        OkHttpClient
+            .Builder()
+            .apply {
+                CertificatePinnerProvider.forCurrentBuild()?.let(::certificatePinner)
+            }.addInterceptor { chain ->
+                val originalRequest = chain.request()
+                val overrideBaseUrl = runBlocking { sessionDataStore.apiBaseUrlFlow.filterNotNull().first() }
+                val overrideBase = overrideBaseUrl.toHttpUrlOrNull()
+                val updatedRequest =
+                    if (overrideBase != null) {
+                        val updatedUrl =
+                            originalRequest.url
+                                .newBuilder()
+                                .scheme(overrideBase.scheme)
+                                .host(overrideBase.host)
+                                .port(overrideBase.port)
+                                .build()
+                        originalRequest.newBuilder().url(updatedUrl).build()
+                    } else {
+                        originalRequest
+                    }
+                chain.proceed(updatedRequest)
+            }.addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.BASIC
+                },
+            ).build()
 
-    private val client = OkHttpClient.Builder()
-        .addInterceptor { chain ->
-            val originalRequest = chain.request()
-            val overrideBaseUrl = runBlocking { sessionDataStore.apiBaseUrlFlow.filterNotNull().first() }
-            val overrideBase = overrideBaseUrl.toHttpUrlOrNull()
-            val updatedRequest = if (overrideBase != null) {
-                val updatedUrl = originalRequest.url.newBuilder()
-                    .scheme(overrideBase.scheme)
-                    .host(overrideBase.host)
-                    .port(overrideBase.port)
-                    .build()
-                originalRequest.newBuilder().url(updatedUrl).build()
-            } else {
-                originalRequest
-            }
-            chain.proceed(updatedRequest)
-        }
-        .addInterceptor(
-            HttpLoggingInterceptor().apply {
-                level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.BASIC
-            },
-        )
-        .build()
-
-    private val retrofit = Retrofit.Builder()
-        .baseUrl(BuildConfig.API_BASE_URL)
-        .client(client)
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-        .build()
-
-    val apiService: ChampagneApiService = retrofit.create(ChampagneApiService::class.java)
+    val apiService: ChampagneApiService = ApiServiceFactory.create(BuildConfig.API_BASE_URL, client)
 }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/network/NetworkModule.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/network/NetworkModule.kt
@@ -17,7 +17,7 @@ class NetworkModule(
         OkHttpClient
             .Builder()
             .apply {
-                CertificatePinnerProvider.forCurrentBuild()?.let(::certificatePinner)
+                certificatePinner(CertificatePinnerProvider.forCurrentBuild())
             }.addInterceptor { chain ->
                 val originalRequest = chain.request()
                 val overrideBaseUrl =

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/network/NetworkModule.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/network/NetworkModule.kt
@@ -20,7 +20,9 @@ class NetworkModule(
                 CertificatePinnerProvider.forCurrentBuild()?.let(::certificatePinner)
             }.addInterceptor { chain ->
                 val originalRequest = chain.request()
-                val overrideBaseUrl = runBlocking { sessionDataStore.apiBaseUrlFlow.filterNotNull().first() }
+                val overrideBaseUrl =
+                    sessionDataStore.apiBaseUrlFlow.value
+                        ?: runBlocking { sessionDataStore.apiBaseUrlFlow.filterNotNull().first() }
                 val overrideBase = overrideBaseUrl.toHttpUrlOrNull()
                 val updatedRequest =
                     if (overrideBase != null) {

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/network/NetworkModule.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/network/NetworkModule.kt
@@ -4,9 +4,6 @@ import be.champagnefestival.android.BuildConfig
 import be.champagnefestival.android.core.auth.AuthManager
 import be.champagnefestival.android.core.storage.SessionDataStore
 import be.champagnefestival.android.data.api.ChampagneApiService
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -23,9 +20,7 @@ class NetworkModule(
                 authenticator(TokenAuthenticator(sessionDataStore, authManager))
             }.addInterceptor { chain ->
                 val originalRequest = chain.request()
-                val overrideBaseUrl =
-                    sessionDataStore.apiBaseUrlFlow.value
-                        ?: runBlocking { sessionDataStore.apiBaseUrlFlow.filterNotNull().first() }
+                val overrideBaseUrl = sessionDataStore.apiBaseUrlFlow.value ?: BuildConfig.API_BASE_URL
                 val overrideBase = overrideBaseUrl.toHttpUrlOrNull()
                 val updatedRequest =
                     if (overrideBase != null) {

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/network/TokenAuthenticator.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/network/TokenAuthenticator.kt
@@ -1,0 +1,40 @@
+package be.champagnefestival.android.core.network
+
+import be.champagnefestival.android.core.auth.AuthManager
+import be.champagnefestival.android.core.storage.SessionDataStore
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+
+class TokenAuthenticator(
+    private val sessionDataStore: SessionDataStore,
+    private val authManager: AuthManager,
+) : Authenticator {
+    override fun authenticate(
+        route: Route?,
+        response: Response,
+    ): Request? {
+        if (response.priorResponse != null) return null
+        val authHeader = response.request.header("Authorization") ?: return null
+        val failedToken = authHeader.removePrefix("Bearer ").trim()
+
+        return runBlocking {
+            val currentToken = sessionDataStore.accessTokenFlow.value
+            val tokenToUse =
+                if (!currentToken.isNullOrBlank() && currentToken != failedToken) {
+                    currentToken
+                } else {
+                    authManager.getFreshAccessToken()
+                }
+
+            tokenToUse?.let { token ->
+                response.request
+                    .newBuilder()
+                    .header("Authorization", "Bearer $token")
+                    .build()
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/storage/SessionDataStore.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/storage/SessionDataStore.kt
@@ -2,12 +2,12 @@ package be.champagnefestival.android.core.storage
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStoreFile
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import be.champagnefestival.android.BuildConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,11 +18,15 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.io.IOException
 
-class SessionDataStore(context: Context, applicationScope: CoroutineScope) {
-    private val dataStore: DataStore<Preferences> = PreferenceDataStoreFactory.create(
-        scope = applicationScope,
-        produceFile = { context.preferencesDataStoreFile("session_preferences") },
-    )
+class SessionDataStore(
+    context: Context,
+    applicationScope: CoroutineScope,
+) {
+    private val dataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            scope = applicationScope,
+            produceFile = { context.preferencesDataStoreFile("session_preferences") },
+        )
 
     private val accessTokenKey = stringPreferencesKey("access_token")
     private val refreshTokenKey = stringPreferencesKey("refresh_token")
@@ -50,16 +54,14 @@ class SessionDataStore(context: Context, applicationScope: CoroutineScope) {
                     } else {
                         throw exception
                     }
-                }
-                .map { preferences ->
+                }.map { preferences ->
                     SessionSnapshot(
                         accessToken = preferences[accessTokenKey],
                         refreshToken = preferences[refreshTokenKey],
                         idToken = preferences[idTokenKey],
                         apiBaseUrl = preferences[apiBaseUrlKey] ?: BuildConfig.API_BASE_URL,
                     )
-                }
-                .collect { snapshot ->
+                }.collect { snapshot ->
                     _accessTokenFlow.value = snapshot.accessToken
                     _refreshTokenFlow.value = snapshot.refreshToken
                     _idTokenFlow.value = snapshot.idToken
@@ -68,7 +70,11 @@ class SessionDataStore(context: Context, applicationScope: CoroutineScope) {
         }
     }
 
-    suspend fun saveTokens(accessToken: String, refreshToken: String?, idToken: String?) {
+    suspend fun saveTokens(
+        accessToken: String,
+        refreshToken: String?,
+        idToken: String?,
+    ) {
         dataStore.edit { preferences ->
             preferences[accessTokenKey] = accessToken
             refreshToken?.let { preferences[refreshTokenKey] = it }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/data/model/CheckInModels.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/data/model/CheckInModels.kt
@@ -31,10 +31,15 @@ data class CheckInGuestOut(
 )
 
 @Serializable
-data class CheckInLookupRequest(val token: String)
+data class CheckInLookupRequest(
+    val token: String,
+)
 
 @Serializable
-data class CheckInRequest(val token: String, val issue_strap: Boolean = true)
+data class CheckInRequest(
+    val token: String,
+    val issue_strap: Boolean = true,
+)
 
 @Serializable
 data class CheckInOut(

--- a/android/app/src/main/kotlin/be/champagnefestival/android/data/repository/CheckInRepository.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/data/repository/CheckInRepository.kt
@@ -5,33 +5,52 @@ import be.champagnefestival.android.data.model.CheckInGuestOut
 import be.champagnefestival.android.data.model.CheckInLookupRequest
 import be.champagnefestival.android.data.model.CheckInOut
 import be.champagnefestival.android.data.model.CheckInRequest
-import java.io.IOException
 import retrofit2.HttpException
+import java.io.IOException
 
 interface CheckInRepository {
-    suspend fun lookupRegistration(id: String, token: String): Result<CheckInGuestOut>
-    suspend fun submitCheckIn(id: String, token: String): Result<CheckInOut>
-    suspend fun searchRegistrations(query: String, eventId: String?, authToken: String): Result<List<CheckInGuestOut>>
+    suspend fun lookupRegistration(
+        id: String,
+        token: String,
+    ): Result<CheckInGuestOut>
+
+    suspend fun submitCheckIn(
+        id: String,
+        token: String,
+    ): Result<CheckInOut>
+
+    suspend fun searchRegistrations(
+        query: String,
+        eventId: String?,
+        authToken: String,
+    ): Result<List<CheckInGuestOut>>
 }
 
-class DefaultCheckInRepository(private val apiService: ChampagneApiService) : CheckInRepository {
-    override suspend fun lookupRegistration(id: String, token: String): Result<CheckInGuestOut> =
-        runApiCall { apiService.lookupCheckIn(id = id, body = CheckInLookupRequest(token)) }
+class DefaultCheckInRepository(
+    private val apiService: ChampagneApiService,
+) : CheckInRepository {
+    override suspend fun lookupRegistration(
+        id: String,
+        token: String,
+    ): Result<CheckInGuestOut> = runApiCall { apiService.lookupCheckIn(id = id, body = CheckInLookupRequest(token)) }
 
-    override suspend fun submitCheckIn(id: String, token: String): Result<CheckInOut> =
-        runApiCall { apiService.submitCheckIn(id = id, body = CheckInRequest(token = token)) }
+    override suspend fun submitCheckIn(
+        id: String,
+        token: String,
+    ): Result<CheckInOut> = runApiCall { apiService.submitCheckIn(id = id, body = CheckInRequest(token = token)) }
 
     override suspend fun searchRegistrations(
         query: String,
         eventId: String?,
         authToken: String,
-    ): Result<List<CheckInGuestOut>> = runApiCall {
-        apiService.searchRegistrations(
-            auth = bearer(authToken),
-            query = query.takeIf { it.isNotBlank() },
-            eventId = eventId?.takeIf { it.isNotBlank() },
-        )
-    }
+    ): Result<List<CheckInGuestOut>> =
+        runApiCall {
+            apiService.searchRegistrations(
+                auth = bearer(authToken),
+                query = query.takeIf { it.isNotBlank() },
+                eventId = eventId?.takeIf { it.isNotBlank() },
+            )
+        }
 
     private suspend fun <T> runApiCall(block: suspend () -> T): Result<T> =
         try {
@@ -49,7 +68,11 @@ class DefaultCheckInRepository(private val apiService: ChampagneApiService) : Ch
         }
 }
 
-class ApiException(message: String, cause: Throwable? = null) : Exception(message, cause)
+class ApiException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)
+
 class UnauthorizedException : Exception("You are not authorized to perform this action.")
 
 private fun bearer(token: String): String = "Bearer $token"

--- a/android/app/src/main/kotlin/be/champagnefestival/android/data/repository/EditionRepository.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/data/repository/EditionRepository.kt
@@ -3,20 +3,30 @@ package be.champagnefestival.android.data.repository
 import be.champagnefestival.android.data.api.ChampagneApiService
 import be.champagnefestival.android.data.model.EditionOut
 import be.champagnefestival.android.data.model.EventSummary
-import java.io.IOException
 import retrofit2.HttpException
+import java.io.IOException
 
 interface EditionRepository {
     suspend fun getActiveEdition(): Result<EditionOut>
-    suspend fun getEvents(editionId: String?, authToken: String): Result<List<EventSummary>>
+
+    suspend fun getEvents(
+        editionId: String?,
+        authToken: String,
+    ): Result<List<EventSummary>>
 }
 
-class DefaultEditionRepository(private val apiService: ChampagneApiService) : EditionRepository {
+class DefaultEditionRepository(
+    private val apiService: ChampagneApiService,
+) : EditionRepository {
     override suspend fun getActiveEdition(): Result<EditionOut> = runApiCall { apiService.getActiveEdition() }
 
-    override suspend fun getEvents(editionId: String?, authToken: String): Result<List<EventSummary>> = runApiCall {
-        apiService.getEvents(auth = "Bearer $authToken", editionId = editionId)
-    }
+    override suspend fun getEvents(
+        editionId: String?,
+        authToken: String,
+    ): Result<List<EventSummary>> =
+        runApiCall {
+            apiService.getEvents(auth = "Bearer $authToken", editionId = editionId)
+        }
 
     private suspend fun <T> runApiCall(block: suspend () -> T): Result<T> =
         try {

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/edition/ActiveEditionScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/edition/ActiveEditionScreen.kt
@@ -45,26 +45,50 @@ fun ActiveEditionScreen(
         topBar = { TopAppBar(title = { Text("Active edition") }) },
         bottomBar = {
             NavigationBar {
-                NavigationBarItem(selected = false, onClick = onOpenScan, icon = { Icon(Icons.Default.QrCodeScanner, null) }, label = { Text("Scan") })
-                NavigationBarItem(selected = false, onClick = onOpenLookup, icon = { Icon(Icons.Default.Search, null) }, label = { Text("Lookup") })
-                NavigationBarItem(selected = false, onClick = onOpenSettings, icon = { Icon(Icons.Default.Settings, null) }, label = { Text("Settings") })
+                NavigationBarItem(
+                    selected = false,
+                    onClick = onOpenScan,
+                    icon = { Icon(Icons.Default.QrCodeScanner, null) },
+                    label = { Text("Scan") },
+                )
+                NavigationBarItem(
+                    selected = false,
+                    onClick = onOpenLookup,
+                    icon = { Icon(Icons.Default.Search, null) },
+                    label = { Text("Lookup") },
+                )
+                NavigationBarItem(
+                    selected = false,
+                    onClick = onOpenSettings,
+                    icon = { Icon(Icons.Default.Settings, null) },
+                    label = { Text("Settings") },
+                )
             }
         },
     ) { padding ->
         when (val state = uiState) {
             UiState.Loading -> LoadingContent(modifier = Modifier.padding(padding))
-            is UiState.Error -> ErrorContent(message = state.message, onRetry = viewModel::loadActiveEdition, modifier = Modifier.padding(padding))
+            is UiState.Error ->
+                ErrorContent(
+                    message = state.message,
+                    onRetry = viewModel::loadActiveEdition,
+                    modifier = Modifier.padding(padding),
+                )
             is UiState.Success -> EditionContent(edition = state.data, padding = padding)
         }
     }
 }
 
 @Composable
-private fun EditionContent(edition: EditionOut, padding: PaddingValues) {
+private fun EditionContent(
+    edition: EditionOut,
+    padding: PaddingValues,
+) {
     LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(padding),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(padding),
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/edition/ActiveEditionViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/edition/ActiveEditionViewModel.kt
@@ -10,7 +10,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-class ActiveEditionViewModel(private val repository: EditionRepository) : ViewModel() {
+class ActiveEditionViewModel(
+    private val repository: EditionRepository,
+) : ViewModel() {
     private val _uiState = MutableStateFlow<UiState<EditionOut>>(UiState.Loading)
     val uiState: StateFlow<UiState<EditionOut>> = _uiState.asStateFlow()
 
@@ -21,7 +23,8 @@ class ActiveEditionViewModel(private val repository: EditionRepository) : ViewMo
     fun loadActiveEdition() {
         _uiState.value = UiState.Loading
         viewModelScope.launch {
-            repository.getActiveEdition()
+            repository
+                .getActiveEdition()
                 .onSuccess { _uiState.value = UiState.Success(it) }
                 .onFailure { _uiState.value = UiState.Error(it.message ?: "Unable to load the active edition.") }
         }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/login/LoginScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/login/LoginScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -25,9 +26,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import be.champagnefestival.android.ui.UiState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -37,6 +40,7 @@ fun LoginScreen(
 ) {
     val context = LocalContext.current
     val loggedIn by viewModel.loggedIn.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
 
     LaunchedEffect(loggedIn) {
         if (!loggedIn.isNullOrBlank()) {
@@ -75,8 +79,21 @@ fun LoginScreen(
                 textAlign = TextAlign.Center,
             )
             Spacer(modifier = Modifier.height(32.dp))
-            Button(onClick = { viewModel.startLogin(context.findActivity()) }) {
-                Text("Sign in with OIDC")
+            val currentState = uiState
+            if (currentState is UiState.Loading) {
+                CircularProgressIndicator()
+            } else {
+                Button(onClick = { viewModel.startLogin(context.findActivity()) }) {
+                    Text("Sign in with OIDC")
+                }
+            }
+            if (currentState is UiState.Error) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = currentState.message,
+                    color = Color.Red,
+                    textAlign = TextAlign.Center,
+                )
             }
         }
     }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/login/LoginScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/login/LoginScreen.kt
@@ -48,10 +48,11 @@ fun LoginScreen(
         topBar = { TopAppBar(title = { Text("Volunteer Check-In") }) },
     ) { padding ->
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(24.dp),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(24.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -81,8 +82,9 @@ fun LoginScreen(
     }
 }
 
-private tailrec fun Context.findActivity(): Activity = when (this) {
-    is Activity -> this
-    is ContextWrapper -> baseContext.findActivity()
-    else -> error("Activity context required.")
-}
+private tailrec fun Context.findActivity(): Activity =
+    when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> error("Activity context required.")
+    }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/login/LoginViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/login/LoginViewModel.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class LoginViewModel(private val authManager: AuthManager) : ViewModel() {
+class LoginViewModel(
+    private val authManager: AuthManager,
+) : ViewModel() {
     private val _uiState = MutableStateFlow<UiState<Unit>>(UiState.Success(Unit))
     val uiState: StateFlow<UiState<Unit>> = _uiState.asStateFlow()
 

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/login/LoginViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/login/LoginViewModel.kt
@@ -2,11 +2,13 @@ package be.champagnefestival.android.feature.login
 
 import android.app.Activity
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import be.champagnefestival.android.core.auth.AuthManager
 import be.champagnefestival.android.ui.UiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class LoginViewModel(
     private val authManager: AuthManager,
@@ -17,8 +19,15 @@ class LoginViewModel(
     val loggedIn = authManager.loggedIn
 
     fun startLogin(activity: Activity) {
-        _uiState.value = UiState.Loading
-        authManager.startLogin(activity)
-        _uiState.value = UiState.Success(Unit)
+        viewModelScope.launch {
+            _uiState.value = UiState.Loading
+            _uiState.value =
+                authManager.startLogin(activity).fold(
+                    onSuccess = { UiState.Success(Unit) },
+                    onFailure = { error ->
+                        UiState.Error(error.message ?: "Unable to start sign-in. Check your connection and try again.")
+                    },
+                )
+        }
     }
 }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/lookup/GuestLookupScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/lookup/GuestLookupScreen.kt
@@ -80,8 +80,15 @@ fun GuestLookupScreen(
             when (val state = uiState) {
                 GuestLookupUiState.Idle -> Text(stringResource(R.string.search_guest_idle_message))
                 GuestLookupUiState.Loading -> LoadingContent(modifier = Modifier.weight(1f))
-                is GuestLookupUiState.Error -> ErrorContent(message = state.message, onRetry = { viewModel.search(query, eventId) }, modifier = Modifier.weight(1f))
-                is GuestLookupUiState.Success -> LookupResults(registrations = state.registrations, padding = PaddingValues(vertical = 8.dp))
+                is GuestLookupUiState.Error ->
+                    ErrorContent(message = state.message, onRetry = {
+                        viewModel.search(query, eventId)
+                    }, modifier = Modifier.weight(1f))
+                is GuestLookupUiState.Success ->
+                    LookupResults(
+                        registrations = state.registrations,
+                        padding = PaddingValues(vertical = 8.dp),
+                    )
             }
         }
     }
@@ -98,9 +105,10 @@ private fun LookupResults(
     }
 
     val checkedInCount = registrations.count { it.checked_in }
-    val undeliveredItems = registrations.sumOf { registration ->
-        registration.pre_orders.filter { !it.delivered }.sumOf { it.quantity }
-    }
+    val undeliveredItems =
+        registrations.sumOf { registration ->
+            registration.pre_orders.filter { !it.delivered }.sumOf { it.quantity }
+        }
 
     Card(modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/lookup/GuestLookupViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/lookup/GuestLookupViewModel.kt
@@ -14,9 +14,16 @@ import kotlinx.coroutines.launch
 
 sealed class GuestLookupUiState {
     data object Idle : GuestLookupUiState()
+
     data object Loading : GuestLookupUiState()
-    data class Success(val registrations: List<CheckInGuestOut>) : GuestLookupUiState()
-    data class Error(val message: String) : GuestLookupUiState()
+
+    data class Success(
+        val registrations: List<CheckInGuestOut>,
+    ) : GuestLookupUiState()
+
+    data class Error(
+        val message: String,
+    ) : GuestLookupUiState()
 }
 
 class GuestLookupViewModel(
@@ -28,31 +35,37 @@ class GuestLookupViewModel(
 
     private var searchJob: Job? = null
 
-    fun search(query: String, eventId: String?) {
+    fun search(
+        query: String,
+        eventId: String?,
+    ) {
         searchJob?.cancel()
         if (query.isBlank() && eventId.isNullOrBlank()) {
             _uiState.value = GuestLookupUiState.Idle
             return
         }
-        searchJob = viewModelScope.launch {
-            delay(300)
-            _uiState.value = GuestLookupUiState.Loading
-            val authToken = authTokenProvider()
-            if (authToken.isNullOrBlank()) {
-                _uiState.value = GuestLookupUiState.Error("Sign in again to search registrations.")
-                return@launch
-            }
-
-            repository.searchRegistrations(query = query, eventId = eventId, authToken = authToken)
-                .onSuccess { _uiState.value = GuestLookupUiState.Success(it) }
-                .onFailure {
-                    _uiState.value = GuestLookupUiState.Error(
-                        when (it) {
-                            is UnauthorizedException -> it.message ?: "Unauthorized"
-                            else -> it.message ?: "Unable to search registrations."
-                        },
-                    )
+        searchJob =
+            viewModelScope.launch {
+                delay(300)
+                _uiState.value = GuestLookupUiState.Loading
+                val authToken = authTokenProvider()
+                if (authToken.isNullOrBlank()) {
+                    _uiState.value = GuestLookupUiState.Error("Sign in again to search registrations.")
+                    return@launch
                 }
-        }
+
+                repository
+                    .searchRegistrations(query = query, eventId = eventId, authToken = authToken)
+                    .onSuccess { _uiState.value = GuestLookupUiState.Success(it) }
+                    .onFailure {
+                        _uiState.value =
+                            GuestLookupUiState.Error(
+                                when (it) {
+                                    is UnauthorizedException -> it.message ?: "Unauthorized"
+                                    else -> it.message ?: "Unable to search registrations."
+                                },
+                            )
+                    }
+            }
     }
 }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/CheckInConfirmationScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/CheckInConfirmationScreen.kt
@@ -55,16 +55,23 @@ fun CheckInConfirmationScreen(
     ) { padding ->
         when (val state = uiState) {
             CheckInUiState.Loading -> LoadingContent(modifier = Modifier.padding(padding))
-            is CheckInUiState.Error -> ErrorContent(message = state.message, onRetry = { viewModel.submitCheckIn(id, token) }, modifier = Modifier.padding(padding))
-            CheckInUiState.Unauthorized -> ErrorContent(message = "The check-in token is no longer valid.", onRetry = { viewModel.submitCheckIn(id, token) }, modifier = Modifier.padding(padding))
+            is CheckInUiState.Error ->
+                ErrorContent(message = state.message, onRetry = {
+                    viewModel.submitCheckIn(id, token)
+                }, modifier = Modifier.padding(padding))
+            CheckInUiState.Unauthorized ->
+                ErrorContent(message = "The check-in token is no longer valid.", onRetry = {
+                    viewModel.submitCheckIn(id, token)
+                }, modifier = Modifier.padding(padding))
             is CheckInUiState.RegistrationLoaded -> LoadingContent(modifier = Modifier.padding(padding))
             is CheckInUiState.CheckInSuccess -> {
                 val registration = state.registration
                 Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(padding)
-                        .padding(24.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(padding)
+                            .padding(24.dp),
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/CheckInViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/CheckInViewModel.kt
@@ -12,53 +12,76 @@ import kotlinx.coroutines.launch
 
 sealed class CheckInUiState {
     data object Loading : CheckInUiState()
-    data class RegistrationLoaded(val registration: CheckInGuestOut) : CheckInUiState()
-    data class CheckInSuccess(val registration: CheckInGuestOut, val alreadyCheckedIn: Boolean) : CheckInUiState()
-    data class Error(val message: String) : CheckInUiState()
+
+    data class RegistrationLoaded(
+        val registration: CheckInGuestOut,
+    ) : CheckInUiState()
+
+    data class CheckInSuccess(
+        val registration: CheckInGuestOut,
+        val alreadyCheckedIn: Boolean,
+    ) : CheckInUiState()
+
+    data class Error(
+        val message: String,
+    ) : CheckInUiState()
+
     data object Unauthorized : CheckInUiState()
 }
 
-class CheckInViewModel(private val repository: CheckInRepository) : ViewModel() {
+class CheckInViewModel(
+    private val repository: CheckInRepository,
+) : ViewModel() {
     private val _uiState = MutableStateFlow<CheckInUiState>(CheckInUiState.Loading)
     val uiState: StateFlow<CheckInUiState> = _uiState.asStateFlow()
 
     private var lastSubmittedId: String? = null
 
-    fun loadRegistration(id: String, token: String) {
+    fun loadRegistration(
+        id: String,
+        token: String,
+    ) {
         _uiState.value = CheckInUiState.Loading
         viewModelScope.launch {
-            repository.lookupRegistration(id = id, token = token)
+            repository
+                .lookupRegistration(id = id, token = token)
                 .onSuccess { _uiState.value = CheckInUiState.RegistrationLoaded(it) }
                 .onFailure { error ->
-                    _uiState.value = if (error is UnauthorizedException) {
-                        CheckInUiState.Unauthorized
-                    } else {
-                        CheckInUiState.Error(error.message ?: "Unable to load registration.")
-                    }
+                    _uiState.value =
+                        if (error is UnauthorizedException) {
+                            CheckInUiState.Unauthorized
+                        } else {
+                            CheckInUiState.Error(error.message ?: "Unable to load registration.")
+                        }
                 }
         }
     }
 
-    fun submitCheckIn(id: String, token: String) {
+    fun submitCheckIn(
+        id: String,
+        token: String,
+    ) {
         if (lastSubmittedId == id && _uiState.value is CheckInUiState.CheckInSuccess) {
             return
         }
         _uiState.value = CheckInUiState.Loading
         lastSubmittedId = id
         viewModelScope.launch {
-            repository.submitCheckIn(id = id, token = token)
+            repository
+                .submitCheckIn(id = id, token = token)
                 .onSuccess { result ->
-                    _uiState.value = CheckInUiState.CheckInSuccess(
-                        registration = result.registration,
-                        alreadyCheckedIn = result.already_checked_in,
-                    )
-                }
-                .onFailure { error ->
-                    _uiState.value = if (error is UnauthorizedException) {
-                        CheckInUiState.Unauthorized
-                    } else {
-                        CheckInUiState.Error(error.message ?: "Unable to submit check-in.")
-                    }
+                    _uiState.value =
+                        CheckInUiState.CheckInSuccess(
+                            registration = result.registration,
+                            alreadyCheckedIn = result.already_checked_in,
+                        )
+                }.onFailure { error ->
+                    _uiState.value =
+                        if (error is UnauthorizedException) {
+                            CheckInUiState.Unauthorized
+                        } else {
+                            CheckInUiState.Error(error.message ?: "Unable to submit check-in.")
+                        }
                 }
         }
     }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/CheckInViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/CheckInViewModel.kt
@@ -61,7 +61,7 @@ class CheckInViewModel(
         id: String,
         token: String,
     ) {
-        if (_uiState.value is CheckInUiState.Loading) {
+        if (lastSubmittedId == id && _uiState.value is CheckInUiState.Loading) {
             return
         }
         if (lastSubmittedId == id && _uiState.value is CheckInUiState.CheckInSuccess) {

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/CheckInViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/CheckInViewModel.kt
@@ -61,6 +61,9 @@ class CheckInViewModel(
         id: String,
         token: String,
     ) {
+        if (_uiState.value is CheckInUiState.Loading) {
+            return
+        }
         if (lastSubmittedId == id && _uiState.value is CheckInUiState.CheckInSuccess) {
             return
         }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/RegistrationDetailScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/RegistrationDetailScreen.kt
@@ -58,8 +58,14 @@ fun RegistrationDetailScreen(
     ) { padding ->
         when (val state = uiState) {
             UiState.Loading -> LoadingContent(modifier = Modifier.padding(padding))
-            is UiState.Error -> ErrorContent(message = state.message, onRetry = { viewModel.loadRegistration(id, token) }, modifier = Modifier.padding(padding))
-            is UiState.Success -> RegistrationContent(registration = state.data, modifier = Modifier.padding(padding), onCheckIn = { onCheckIn(id, token) })
+            is UiState.Error ->
+                ErrorContent(message = state.message, onRetry = {
+                    viewModel.loadRegistration(id, token)
+                }, modifier = Modifier.padding(padding))
+            is UiState.Success ->
+                RegistrationContent(registration = state.data, modifier = Modifier.padding(padding), onCheckIn = {
+                    onCheckIn(id, token)
+                })
         }
     }
 }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/RegistrationDetailViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/registration/RegistrationDetailViewModel.kt
@@ -10,14 +10,20 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-class RegistrationDetailViewModel(private val repository: CheckInRepository) : ViewModel() {
+class RegistrationDetailViewModel(
+    private val repository: CheckInRepository,
+) : ViewModel() {
     private val _uiState = MutableStateFlow<UiState<CheckInGuestOut>>(UiState.Loading)
     val uiState: StateFlow<UiState<CheckInGuestOut>> = _uiState.asStateFlow()
 
-    fun loadRegistration(id: String, token: String) {
+    fun loadRegistration(
+        id: String,
+        token: String,
+    ) {
         _uiState.value = UiState.Loading
         viewModelScope.launch {
-            repository.lookupRegistration(id = id, token = token)
+            repository
+                .lookupRegistration(id = id, token = token)
                 .onSuccess { _uiState.value = UiState.Success(it) }
                 .onFailure { _uiState.value = UiState.Error(it.message ?: "Unable to load registration.") }
         }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/scan/QrScanScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/scan/QrScanScreen.kt
@@ -64,13 +64,16 @@ fun QrScanScreen(
     val errorMessage by viewModel.errorMessage.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     var cameraPermissionGranted by remember {
-        mutableStateOf(ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == android.content.pm.PackageManager.PERMISSION_GRANTED)
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == android.content.pm.PackageManager.PERMISSION_GRANTED,
+        )
     }
     var hasNavigated by remember { mutableStateOf(false) }
     val cameraExecutor = remember { Executors.newSingleThreadExecutor() }
-    val permissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-        cameraPermissionGranted = granted
-    }
+    val permissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            cameraPermissionGranted = granted
+        }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -97,10 +100,11 @@ fun QrScanScreen(
     ) { padding ->
         if (!cameraPermissionGranted) {
             Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .padding(24.dp),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .padding(24.dp),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
@@ -114,9 +118,10 @@ fun QrScanScreen(
             }
         } else {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(padding),
             ) {
                 AndroidView(
                     modifier = Modifier.fillMaxSize(),
@@ -144,20 +149,22 @@ fun QrScanScreen(
                     },
                 )
                 Box(
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .fillMaxWidth(0.7f)
-                        .height(220.dp)
-                        .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(20.dp))
-                        .background(Color.Transparent),
+                    modifier =
+                        Modifier
+                            .align(Alignment.Center)
+                            .fillMaxWidth(0.7f)
+                            .height(220.dp)
+                            .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(20.dp))
+                            .background(Color.Transparent),
                 )
                 Text(
                     text = "Place the QR code inside the frame",
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(24.dp)
-                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f), RoundedCornerShape(12.dp))
-                        .padding(horizontal = 16.dp, vertical = 10.dp),
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(24.dp)
+                            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f), RoundedCornerShape(12.dp))
+                            .padding(horizontal = 16.dp, vertical = 10.dp),
                 )
             }
         }
@@ -179,27 +186,30 @@ private fun PreviewView.bindCamera(
                 val cameraProvider = cameraProviderFuture.get()
                 val preview = Preview.Builder().build().also { it.surfaceProvider = previewView.surfaceProvider }
                 val scanner = BarcodeScanning.getClient()
-                val analysis = ImageAnalysis.Builder()
-                    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                    .build()
-                    .also { imageAnalysis ->
-                        imageAnalysis.setAnalyzer(executor) { imageProxy ->
-                            val mediaImage = imageProxy.image
-                            if (mediaImage == null) {
-                                imageProxy.close()
-                                return@setAnalyzer
-                            }
-                            val image = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
-                            scanner.process(image)
-                                .addOnSuccessListener { barcodes ->
-                                    barcodes.firstOrNull { it.format == Barcode.FORMAT_QR_CODE }
-                                        ?.rawValue
-                                        ?.let(onQrDetected)
+                val analysis =
+                    ImageAnalysis
+                        .Builder()
+                        .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                        .build()
+                        .also { imageAnalysis ->
+                            imageAnalysis.setAnalyzer(executor) { imageProxy ->
+                                val mediaImage = imageProxy.image
+                                if (mediaImage == null) {
+                                    imageProxy.close()
+                                    return@setAnalyzer
                                 }
-                                .addOnFailureListener(onError)
-                                .addOnCompleteListener { imageProxy.close() }
+                                val image = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
+                                scanner
+                                    .process(image)
+                                    .addOnSuccessListener { barcodes ->
+                                        barcodes
+                                            .firstOrNull { it.format == Barcode.FORMAT_QR_CODE }
+                                            ?.rawValue
+                                            ?.let(onQrDetected)
+                                    }.addOnFailureListener(onError)
+                                    .addOnCompleteListener { imageProxy.close() }
+                            }
                         }
-                    }
                 cameraProvider.unbindAll()
                 cameraProvider.bindToLifecycle(lifecycleOwner, CameraSelector.DEFAULT_BACK_CAMERA, preview, analysis)
             }.onFailure(onError)

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/scan/QrScanScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/scan/QrScanScreen.kt
@@ -186,6 +186,13 @@ private fun PreviewView.bindCamera(
                 val cameraProvider = cameraProviderFuture.get()
                 val preview = Preview.Builder().build().also { it.surfaceProvider = previewView.surfaceProvider }
                 val scanner = BarcodeScanning.getClient()
+                lifecycleOwner.lifecycle.addObserver(
+                    object : androidx.lifecycle.DefaultLifecycleObserver {
+                        override fun onDestroy(owner: androidx.lifecycle.LifecycleOwner) {
+                            scanner.close()
+                        }
+                    },
+                )
                 val analysis =
                     ImageAnalysis
                         .Builder()

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/settings/SettingsScreen.kt
@@ -74,9 +74,10 @@ private fun SettingsContent(
     val isUrlInvalid = apiBaseUrl.isNotBlank() && !apiBaseUrl.startsWith("http://") && !apiBaseUrl.startsWith("https://")
 
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         OutlinedTextField(

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/settings/SettingsViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/settings/SettingsViewModel.kt
@@ -24,14 +24,15 @@ class SettingsViewModel(
     init {
         viewModelScope.launch {
             sessionDataStore.apiBaseUrlFlow.collect { apiBaseUrl ->
-                _uiState.value = UiState.Success(
-                    SettingsUiModel(
-                        apiBaseUrl = apiBaseUrl ?: BuildConfig.API_BASE_URL,
-                        defaultApiBaseUrl = BuildConfig.API_BASE_URL,
-                        oidcIssuerUrl = BuildConfig.OIDC_ISSUER_URL,
-                        versionName = BuildConfig.VERSION_NAME,
-                    ),
-                )
+                _uiState.value =
+                    UiState.Success(
+                        SettingsUiModel(
+                            apiBaseUrl = apiBaseUrl ?: BuildConfig.API_BASE_URL,
+                            defaultApiBaseUrl = BuildConfig.API_BASE_URL,
+                            oidcIssuerUrl = BuildConfig.OIDC_ISSUER_URL,
+                            versionName = BuildConfig.VERSION_NAME,
+                        ),
+                    )
             }
         }
     }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/ui/UiState.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/ui/UiState.kt
@@ -2,6 +2,12 @@ package be.champagnefestival.android.ui
 
 sealed class UiState<out T> {
     data object Loading : UiState<Nothing>()
-    data class Success<T>(val data: T) : UiState<T>()
-    data class Error(val message: String) : UiState<Nothing>()
+
+    data class Success<T>(
+        val data: T,
+    ) : UiState<T>()
+
+    data class Error(
+        val message: String,
+    ) : UiState<Nothing>()
 }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/ui/theme/Theme.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/ui/theme/Theme.kt
@@ -6,29 +6,31 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 
-private val LightColors = lightColorScheme(
-    primary = ChampagneGold,
-    onPrimary = MidnightNavy,
-    secondary = SparklingAmber,
-    onSecondary = MidnightNavy,
-    background = WarmCream,
-    onBackground = MidnightNavy,
-    surface = ColorWhite,
-    onSurface = DeepCharcoal,
-    error = ErrorRed,
-)
+private val LightColors =
+    lightColorScheme(
+        primary = ChampagneGold,
+        onPrimary = MidnightNavy,
+        secondary = SparklingAmber,
+        onSecondary = MidnightNavy,
+        background = WarmCream,
+        onBackground = MidnightNavy,
+        surface = ColorWhite,
+        onSurface = DeepCharcoal,
+        error = ErrorRed,
+    )
 
-private val DarkColors = darkColorScheme(
-    primary = SparklingAmber,
-    onPrimary = MidnightNavy,
-    secondary = ChampagneGold,
-    onSecondary = MidnightNavy,
-    background = MidnightNavy,
-    onBackground = WarmCream,
-    surface = DeepCharcoal,
-    onSurface = WarmCream,
-    error = ErrorRed,
-)
+private val DarkColors =
+    darkColorScheme(
+        primary = SparklingAmber,
+        onPrimary = MidnightNavy,
+        secondary = ChampagneGold,
+        onSecondary = MidnightNavy,
+        background = MidnightNavy,
+        onBackground = WarmCream,
+        surface = DeepCharcoal,
+        onSurface = WarmCream,
+        error = ErrorRed,
+    )
 
 @Composable
 fun ChampagneFestivalTheme(
@@ -41,4 +43,3 @@ fun ChampagneFestivalTheme(
         content = content,
     )
 }
-

--- a/android/app/src/test/kotlin/be/champagnefestival/android/core/network/CertificatePinnerProviderTest.kt
+++ b/android/app/src/test/kotlin/be/champagnefestival/android/core/network/CertificatePinnerProviderTest.kt
@@ -1,0 +1,56 @@
+package be.champagnefestival.android.core.network
+
+import okhttp3.CertificatePinner
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class CertificatePinnerProviderTest {
+    @Test
+    fun fallsBackToDefaultVerificationWhenPinningDisabled() {
+        val pinner =
+            CertificatePinnerProvider.fromConfig(
+                enabled = false,
+                host = "champagnefestival.tjor.im",
+                pins = listOf("sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU="),
+            )
+
+        assertEquals(CertificatePinner.DEFAULT, pinner)
+    }
+
+    @Test
+    fun createsPinnerWhenEnabledWithHostAndPins() {
+        val pinner =
+            CertificatePinnerProvider.fromConfig(
+                enabled = true,
+                host = "champagnefestival.tjor.im",
+                pins = listOf("sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU="),
+            )
+
+        assertNotEquals(CertificatePinner.DEFAULT, pinner)
+    }
+
+    @Test
+    fun fallsBackToDefaultVerificationWhenPinsAreEmpty() {
+        val pinner =
+            CertificatePinnerProvider.fromConfig(
+                enabled = true,
+                host = "champagnefestival.tjor.im",
+                pins = emptyList(),
+            )
+
+        assertEquals(CertificatePinner.DEFAULT, pinner)
+    }
+
+    @Test
+    fun fallsBackToDefaultVerificationWhenHostIsEmpty() {
+        val pinner =
+            CertificatePinnerProvider.fromConfig(
+                enabled = true,
+                host = "",
+                pins = listOf("sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU="),
+            )
+
+        assertEquals(CertificatePinner.DEFAULT, pinner)
+    }
+}

--- a/android/app/src/test/kotlin/be/champagnefestival/android/data/repository/CheckInNetworkRepositoryTest.kt
+++ b/android/app/src/test/kotlin/be/champagnefestival/android/data/repository/CheckInNetworkRepositoryTest.kt
@@ -35,7 +35,7 @@ class CheckInNetworkRepositoryTest {
     @Test
     fun `lookupRegistration posts token and decodes registration`() =
         runTest {
-            server.enqueue(MockResponse(body = sampleRegistrationJson()))
+            server.enqueue(MockResponse.Builder().body(sampleRegistrationJson()).build())
 
             val result = repository.lookupRegistration("reg-1", "qr-token")
 
@@ -52,7 +52,7 @@ class CheckInNetworkRepositoryTest {
     @Test
     fun `searchRegistrations sends bearer auth and query filters`() =
         runTest {
-            server.enqueue(MockResponse(body = "[${sampleRegistrationJson()}]"))
+            server.enqueue(MockResponse.Builder().body("[${sampleRegistrationJson()}]").build())
 
             val result =
                 repository.searchRegistrations(
@@ -74,7 +74,7 @@ class CheckInNetworkRepositoryTest {
     @Test
     fun `submitCheckIn maps server errors to repository failure`() =
         runTest {
-            server.enqueue(MockResponse(code = 500, body = "{\"detail\":\"boom\"}"))
+            server.enqueue(MockResponse.Builder().code(500).body("{\"detail\":\"boom\"}").build())
 
             val result = repository.submitCheckIn("reg-1", "qr-token")
 

--- a/android/app/src/test/kotlin/be/champagnefestival/android/data/repository/CheckInNetworkRepositoryTest.kt
+++ b/android/app/src/test/kotlin/be/champagnefestival/android/data/repository/CheckInNetworkRepositoryTest.kt
@@ -1,0 +1,98 @@
+package be.champagnefestival.android.data.repository
+
+import be.champagnefestival.android.core.network.ApiServiceFactory
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class CheckInNetworkRepositoryTest {
+    private lateinit var server: MockWebServer
+    private lateinit var repository: DefaultCheckInRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val apiService =
+            ApiServiceFactory.create(
+                baseUrl = server.url("/").toString(),
+                client = OkHttpClient(),
+            )
+        repository = DefaultCheckInRepository(apiService)
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    @Test
+    fun `lookupRegistration posts token and decodes registration`() =
+        runTest {
+            server.enqueue(MockResponse(body = sampleRegistrationJson()))
+
+            val result = repository.lookupRegistration("reg-1", "qr-token")
+
+            assertTrue(result.isSuccess)
+            assertEquals("Jane Doe", result.getOrNull()?.name)
+            assertEquals(2, result.getOrNull()?.guest_count)
+
+            val request = server.takeRequest()
+            assertEquals("POST", request.method)
+            assertEquals("/api/check-in/reg-1/lookup", request.url.encodedPath)
+            assertEquals("{\"token\":\"qr-token\"}", request.body?.utf8())
+        }
+
+    @Test
+    fun `searchRegistrations sends bearer auth and query filters`() =
+        runTest {
+            server.enqueue(MockResponse(body = "[${sampleRegistrationJson()}]"))
+
+            val result =
+                repository.searchRegistrations(
+                    query = "jane",
+                    eventId = "event-1",
+                    authToken = "access-token",
+                )
+
+            assertTrue(result.isSuccess)
+            assertEquals(1, result.getOrNull()?.size)
+
+            val request = server.takeRequest()
+            assertEquals("GET", request.method)
+            assertEquals("Bearer access-token", request.headers["Authorization"])
+            assertEquals("jane", request.url.queryParameter("q"))
+            assertEquals("event-1", request.url.queryParameter("event_id"))
+        }
+
+    @Test
+    fun `submitCheckIn maps server errors to repository failure`() =
+        runTest {
+            server.enqueue(MockResponse(code = 500, body = "{\"detail\":\"boom\"}"))
+
+            val result = repository.submitCheckIn("reg-1", "qr-token")
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is ApiException)
+        }
+
+    private fun sampleRegistrationJson(): String =
+        """
+        {
+          "id":"reg-1",
+          "name":"Jane Doe",
+          "event_id":"event-1",
+          "event_title":"Friday Tasting",
+          "guest_count":2,
+          "status":"confirmed",
+          "checked_in":false,
+          "strap_issued":false
+        }
+        """.trimIndent()
+}

--- a/android/app/src/test/kotlin/be/champagnefestival/android/data/repository/CheckInNetworkRepositoryTest.kt
+++ b/android/app/src/test/kotlin/be/champagnefestival/android/data/repository/CheckInNetworkRepositoryTest.kt
@@ -74,7 +74,13 @@ class CheckInNetworkRepositoryTest {
     @Test
     fun `submitCheckIn maps server errors to repository failure`() =
         runTest {
-            server.enqueue(MockResponse.Builder().code(500).body("{\"detail\":\"boom\"}").build())
+            server.enqueue(
+                MockResponse
+                    .Builder()
+                    .code(500)
+                    .body("{\"detail\":\"boom\"}")
+                    .build(),
+            )
 
             val result = repository.submitCheckIn("reg-1", "qr-token")
 

--- a/android/app/src/test/kotlin/be/champagnefestival/android/data/repository/CheckInRepositoryTest.kt
+++ b/android/app/src/test/kotlin/be/champagnefestival/android/data/repository/CheckInRepositoryTest.kt
@@ -5,6 +5,7 @@ import be.champagnefestival.android.data.model.CheckInGuestOut
 import be.champagnefestival.android.data.model.CheckInOut
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
@@ -12,66 +13,71 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import retrofit2.HttpException
 import retrofit2.Response
-import kotlinx.coroutines.test.runTest
 
 class CheckInRepositoryTest {
     private val apiService = mockk<ChampagneApiService>()
     private val repository = DefaultCheckInRepository(apiService)
 
     @Test
-    fun `lookupRegistration returns success`() = runTest {
-        val registration = sampleRegistration()
-        coEvery { apiService.lookupCheckIn("reg-1", any()) } returns registration
+    fun `lookupRegistration returns success`() =
+        runTest {
+            val registration = sampleRegistration()
+            coEvery { apiService.lookupCheckIn("reg-1", any()) } returns registration
 
-        val result = repository.lookupRegistration("reg-1", "token")
+            val result = repository.lookupRegistration("reg-1", "token")
 
-        assertTrue(result.isSuccess)
-        assertEquals(registration, result.getOrNull())
-    }
-
-    @Test
-    fun `lookupRegistration returns failure on api error`() = runTest {
-        coEvery { apiService.lookupCheckIn("reg-1", any()) } throws httpException(500)
-
-        val result = repository.lookupRegistration("reg-1", "token")
-
-        assertTrue(result.isFailure)
-    }
+            assertTrue(result.isSuccess)
+            assertEquals(registration, result.getOrNull())
+        }
 
     @Test
-    fun `submitCheckIn returns success with already checked in false`() = runTest {
-        val payload = CheckInOut(sampleRegistration(checkedIn = true), already_checked_in = false)
-        coEvery { apiService.submitCheckIn("reg-1", any()) } returns payload
+    fun `lookupRegistration returns failure on api error`() =
+        runTest {
+            coEvery { apiService.lookupCheckIn("reg-1", any()) } throws httpException(500)
 
-        val result = repository.submitCheckIn("reg-1", "token")
+            val result = repository.lookupRegistration("reg-1", "token")
 
-        assertTrue(result.isSuccess)
-        assertEquals(false, result.getOrNull()?.already_checked_in)
-    }
+            assertTrue(result.isFailure)
+        }
 
     @Test
-    fun `submitCheckIn returns success with already checked in true`() = runTest {
-        val payload = CheckInOut(sampleRegistration(checkedIn = true), already_checked_in = true)
-        coEvery { apiService.submitCheckIn("reg-1", any()) } returns payload
+    fun `submitCheckIn returns success with already checked in false`() =
+        runTest {
+            val payload = CheckInOut(sampleRegistration(checkedIn = true), already_checked_in = false)
+            coEvery { apiService.submitCheckIn("reg-1", any()) } returns payload
 
-        val result = repository.submitCheckIn("reg-1", "token")
+            val result = repository.submitCheckIn("reg-1", "token")
 
-        assertTrue(result.isSuccess)
-        assertEquals(true, result.getOrNull()?.already_checked_in)
-    }
+            assertTrue(result.isSuccess)
+            assertEquals(false, result.getOrNull()?.already_checked_in)
+        }
 
-    private fun httpException(code: Int): HttpException = HttpException(
-        Response.error<String>(code, "{}".toResponseBody("application/json".toMediaType())),
-    )
+    @Test
+    fun `submitCheckIn returns success with already checked in true`() =
+        runTest {
+            val payload = CheckInOut(sampleRegistration(checkedIn = true), already_checked_in = true)
+            coEvery { apiService.submitCheckIn("reg-1", any()) } returns payload
 
-    private fun sampleRegistration(checkedIn: Boolean = false) = CheckInGuestOut(
-        id = "reg-1",
-        name = "Jane Doe",
-        event_id = "event-1",
-        event_title = "Friday Tasting",
-        guest_count = 2,
-        status = "confirmed",
-        checked_in = checkedIn,
-        strap_issued = checkedIn,
-    )
+            val result = repository.submitCheckIn("reg-1", "token")
+
+            assertTrue(result.isSuccess)
+            assertEquals(true, result.getOrNull()?.already_checked_in)
+        }
+
+    private fun httpException(code: Int): HttpException =
+        HttpException(
+            Response.error<String>(code, "{}".toResponseBody("application/json".toMediaType())),
+        )
+
+    private fun sampleRegistration(checkedIn: Boolean = false) =
+        CheckInGuestOut(
+            id = "reg-1",
+            name = "Jane Doe",
+            event_id = "event-1",
+            event_title = "Friday Tasting",
+            guest_count = 2,
+            status = "confirmed",
+            checked_in = checkedIn,
+            strap_issued = checkedIn,
+        )
 }

--- a/android/app/src/test/kotlin/be/champagnefestival/android/feature/lookup/GuestLookupViewModelTest.kt
+++ b/android/app/src/test/kotlin/be/champagnefestival/android/feature/lookup/GuestLookupViewModelTest.kt
@@ -34,74 +34,80 @@ class GuestLookupViewModelTest {
     }
 
     @Test
-    fun `initial state is idle`() = runTest {
-        assertEquals(GuestLookupUiState.Idle, viewModel.uiState.value)
-    }
+    fun `initial state is idle`() =
+        runTest {
+            assertEquals(GuestLookupUiState.Idle, viewModel.uiState.value)
+        }
 
     @Test
-    fun `search results loading state`() = runTest {
-        coEvery { repository.searchRegistrations(any(), any(), any()) } returns Result.success(emptyList())
+    fun `search results loading state`() =
+        runTest {
+            coEvery { repository.searchRegistrations(any(), any(), any()) } returns Result.success(emptyList())
 
-        viewModel.uiState.test {
-            assertEquals(GuestLookupUiState.Idle, awaitItem())
-            viewModel.search("Jane", null)
-            dispatcher.scheduler.advanceTimeBy(300)
-            assertEquals(GuestLookupUiState.Loading, awaitItem())
-            cancelAndIgnoreRemainingEvents()
+            viewModel.uiState.test {
+                assertEquals(GuestLookupUiState.Idle, awaitItem())
+                viewModel.search("Jane", null)
+                dispatcher.scheduler.advanceTimeBy(300)
+                assertEquals(GuestLookupUiState.Loading, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `search results success`() = runTest {
-        val registrations = listOf(sampleRegistration())
-        coEvery { repository.searchRegistrations("Jane", null, "jwt") } returns Result.success(registrations)
+    fun `search results success`() =
+        runTest {
+            val registrations = listOf(sampleRegistration())
+            coEvery { repository.searchRegistrations("Jane", null, "jwt") } returns Result.success(registrations)
 
-        viewModel.uiState.test {
-            awaitItem()
-            viewModel.search("Jane", null)
-            dispatcher.scheduler.advanceTimeBy(300)
-            assertEquals(GuestLookupUiState.Loading, awaitItem())
-            dispatcher.scheduler.advanceUntilIdle()
-            assertEquals(GuestLookupUiState.Success(registrations), awaitItem())
+            viewModel.uiState.test {
+                awaitItem()
+                viewModel.search("Jane", null)
+                dispatcher.scheduler.advanceTimeBy(300)
+                assertEquals(GuestLookupUiState.Loading, awaitItem())
+                dispatcher.scheduler.advanceUntilIdle()
+                assertEquals(GuestLookupUiState.Success(registrations), awaitItem())
+            }
         }
-    }
 
     @Test
-    fun `search results error`() = runTest {
-        coEvery { repository.searchRegistrations("Jane", null, "jwt") } returns Result.failure(IllegalStateException("Boom"))
+    fun `search results error`() =
+        runTest {
+            coEvery { repository.searchRegistrations("Jane", null, "jwt") } returns Result.failure(IllegalStateException("Boom"))
 
-        viewModel.uiState.test {
-            awaitItem()
-            viewModel.search("Jane", null)
-            dispatcher.scheduler.advanceTimeBy(300)
-            assertEquals(GuestLookupUiState.Loading, awaitItem())
-            dispatcher.scheduler.advanceUntilIdle()
-            assertEquals(GuestLookupUiState.Error("Boom"), awaitItem())
+            viewModel.uiState.test {
+                awaitItem()
+                viewModel.search("Jane", null)
+                dispatcher.scheduler.advanceTimeBy(300)
+                assertEquals(GuestLookupUiState.Loading, awaitItem())
+                dispatcher.scheduler.advanceUntilIdle()
+                assertEquals(GuestLookupUiState.Error("Boom"), awaitItem())
+            }
         }
-    }
 
     @Test
-    fun `empty search results`() = runTest {
-        coEvery { repository.searchRegistrations("Jane", null, "jwt") } returns Result.success(emptyList())
+    fun `empty search results`() =
+        runTest {
+            coEvery { repository.searchRegistrations("Jane", null, "jwt") } returns Result.success(emptyList())
 
-        viewModel.uiState.test {
-            awaitItem()
-            viewModel.search("Jane", null)
-            dispatcher.scheduler.advanceTimeBy(300)
-            awaitItem()
-            dispatcher.scheduler.advanceUntilIdle()
-            assertEquals(GuestLookupUiState.Success(emptyList()), awaitItem())
+            viewModel.uiState.test {
+                awaitItem()
+                viewModel.search("Jane", null)
+                dispatcher.scheduler.advanceTimeBy(300)
+                awaitItem()
+                dispatcher.scheduler.advanceUntilIdle()
+                assertEquals(GuestLookupUiState.Success(emptyList()), awaitItem())
+            }
         }
-    }
 
-    private fun sampleRegistration() = CheckInGuestOut(
-        id = "reg-1",
-        name = "Jane Doe",
-        event_id = "event-1",
-        event_title = "Friday Tasting",
-        guest_count = 2,
-        status = "confirmed",
-        checked_in = false,
-        strap_issued = false,
-    )
+    private fun sampleRegistration() =
+        CheckInGuestOut(
+            id = "reg-1",
+            name = "Jane Doe",
+            event_id = "event-1",
+            event_title = "Friday Tasting",
+            guest_count = 2,
+            status = "confirmed",
+            checked_in = false,
+            strap_issued = false,
+        )
 }

--- a/android/app/src/test/kotlin/be/champagnefestival/android/feature/registration/CheckInViewModelTest.kt
+++ b/android/app/src/test/kotlin/be/champagnefestival/android/feature/registration/CheckInViewModelTest.kt
@@ -36,83 +36,92 @@ class CheckInViewModelTest {
     }
 
     @Test
-    fun `initial state is loading when registration is requested`() = runTest {
-        viewModel.uiState.test {
-            assertEquals(CheckInUiState.Loading, awaitItem())
+    fun `initial state is loading when registration is requested`() =
+        runTest {
+            viewModel.uiState.test {
+                assertEquals(CheckInUiState.Loading, awaitItem())
+            }
         }
-    }
 
     @Test
-    fun `success state on successful lookup`() = runTest {
-        val registration = sampleRegistration()
-        coEvery { repository.lookupRegistration("reg-1", "token") } returns Result.success(registration)
+    fun `success state on successful lookup`() =
+        runTest {
+            val registration = sampleRegistration()
+            coEvery { repository.lookupRegistration("reg-1", "token") } returns Result.success(registration)
 
-        viewModel.uiState.test {
-            assertEquals(CheckInUiState.Loading, awaitItem())
-            viewModel.loadRegistration("reg-1", "token")
-            dispatcher.scheduler.advanceUntilIdle()
-            assertEquals(CheckInUiState.RegistrationLoaded(registration), awaitItem())
+            viewModel.uiState.test {
+                assertEquals(CheckInUiState.Loading, awaitItem())
+                viewModel.loadRegistration("reg-1", "token")
+                dispatcher.scheduler.advanceUntilIdle()
+                assertEquals(CheckInUiState.RegistrationLoaded(registration), awaitItem())
+            }
         }
-    }
 
     @Test
-    fun `error state on network failure`() = runTest {
-        coEvery { repository.lookupRegistration("reg-1", "token") } returns Result.failure(IllegalStateException("Network down"))
+    fun `error state on network failure`() =
+        runTest {
+            coEvery { repository.lookupRegistration("reg-1", "token") } returns Result.failure(IllegalStateException("Network down"))
 
-        viewModel.uiState.test {
-            awaitItem()
-            viewModel.loadRegistration("reg-1", "token")
-            dispatcher.scheduler.advanceUntilIdle()
-            assertEquals(CheckInUiState.Error("Network down"), awaitItem())
+            viewModel.uiState.test {
+                awaitItem()
+                viewModel.loadRegistration("reg-1", "token")
+                dispatcher.scheduler.advanceUntilIdle()
+                assertEquals(CheckInUiState.Error("Network down"), awaitItem())
+            }
         }
-    }
 
     @Test
-    fun `unauthorized state on 401`() = runTest {
-        coEvery { repository.lookupRegistration("reg-1", "token") } returns Result.failure(UnauthorizedException())
+    fun `unauthorized state on 401`() =
+        runTest {
+            coEvery { repository.lookupRegistration("reg-1", "token") } returns Result.failure(UnauthorizedException())
 
-        viewModel.uiState.test {
-            awaitItem()
-            viewModel.loadRegistration("reg-1", "token")
-            dispatcher.scheduler.advanceUntilIdle()
-            assertEquals(CheckInUiState.Unauthorized, awaitItem())
+            viewModel.uiState.test {
+                awaitItem()
+                viewModel.loadRegistration("reg-1", "token")
+                dispatcher.scheduler.advanceUntilIdle()
+                assertEquals(CheckInUiState.Unauthorized, awaitItem())
+            }
         }
-    }
 
     @Test
-    fun `submit check-in success`() = runTest {
-        val registration = sampleRegistration(checkedIn = true)
-        coEvery { repository.submitCheckIn("reg-1", "token") } returns Result.success(CheckInOut(registration, already_checked_in = false))
+    fun `submit check-in success`() =
+        runTest {
+            val registration = sampleRegistration(checkedIn = true)
+            coEvery { repository.submitCheckIn("reg-1", "token") } returns
+                Result.success(CheckInOut(registration, already_checked_in = false))
 
-        viewModel.uiState.test {
-            awaitItem()
-            viewModel.submitCheckIn("reg-1", "token")
-            dispatcher.scheduler.advanceUntilIdle()
-            assertEquals(CheckInUiState.CheckInSuccess(registration, alreadyCheckedIn = false), awaitItem())
+            viewModel.uiState.test {
+                awaitItem()
+                viewModel.submitCheckIn("reg-1", "token")
+                dispatcher.scheduler.advanceUntilIdle()
+                assertEquals(CheckInUiState.CheckInSuccess(registration, alreadyCheckedIn = false), awaitItem())
+            }
         }
-    }
 
     @Test
-    fun `submit check-in already checked in state`() = runTest {
-        val registration = sampleRegistration(checkedIn = true)
-        coEvery { repository.submitCheckIn("reg-1", "token") } returns Result.success(CheckInOut(registration, already_checked_in = true))
+    fun `submit check-in already checked in state`() =
+        runTest {
+            val registration = sampleRegistration(checkedIn = true)
+            coEvery { repository.submitCheckIn("reg-1", "token") } returns
+                Result.success(CheckInOut(registration, already_checked_in = true))
 
-        viewModel.uiState.test {
-            awaitItem()
-            viewModel.submitCheckIn("reg-1", "token")
-            dispatcher.scheduler.advanceUntilIdle()
-            assertEquals(CheckInUiState.CheckInSuccess(registration, alreadyCheckedIn = true), awaitItem())
+            viewModel.uiState.test {
+                awaitItem()
+                viewModel.submitCheckIn("reg-1", "token")
+                dispatcher.scheduler.advanceUntilIdle()
+                assertEquals(CheckInUiState.CheckInSuccess(registration, alreadyCheckedIn = true), awaitItem())
+            }
         }
-    }
 
-    private fun sampleRegistration(checkedIn: Boolean = false) = CheckInGuestOut(
-        id = "reg-1",
-        name = "Jane Doe",
-        event_id = "event-1",
-        event_title = "Friday Tasting",
-        guest_count = 2,
-        status = "confirmed",
-        checked_in = checkedIn,
-        strap_issued = checkedIn,
-    )
+    private fun sampleRegistration(checkedIn: Boolean = false) =
+        CheckInGuestOut(
+            id = "reg-1",
+            name = "Jane Doe",
+            event_id = "event-1",
+            event_title = "Friday Tasting",
+            guest_count = 2,
+            status = "confirmed",
+            checked_in = checkedIn,
+            strap_issued = checkedIn,
+        )
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,4 +2,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.ktlint) apply false
 }

--- a/android/config/detekt/detekt.yml
+++ b/android/config/detekt/detekt.yml
@@ -1,0 +1,24 @@
+build:
+  maxIssues: 0
+
+complexity:
+  LongMethod:
+    active: false
+
+exceptions:
+  TooGenericExceptionCaught:
+    active: false
+
+naming:
+  ConstructorParameterNaming:
+    active: false
+  FunctionNaming:
+    active: false
+
+style:
+  MagicNumber:
+    active: false
+  MaxLineLength:
+    active: false
+  ReturnCount:
+    active: false

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ junit = "4.13.2"
 mockk = "1.14.11"
 coroutinesTest = "1.11.0"
 turbine = "1.2.1"
+detekt = "1.23.8"
+ktlintGradle = "14.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -52,8 +54,11 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver3", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }


### PR DESCRIPTION
### Motivation
- Enforce consistent Kotlin style and static analysis for the Android module. 
- Improve runtime network security by enabling certificate pinning for production API traffic. 
- Make the Retrofit/API layer testable and add coverage for repository networking behavior. 

### Description
- Add Detekt and ktlint to the Android build, include plugin aliases in the version catalog, provide an app-level configuration and an EditorConfig to opt out of naming rules for Compose usages. 
- Add a CI step to run `ktlintCheck` and `detekt` before lint, unit tests and APK assembly. 
- Introduce `CertificatePinnerProvider` and wire certificate pinning into the OkHttp client behind a `BuildConfig.CERTIFICATE_PINNING_ENABLED` flag (disabled for `debug`, enabled for `release`). 
- Factor Retrofit creation into `ApiServiceFactory` and update `NetworkModule` to use it (and to apply the pinner when enabled). 
- Add MockWebServer-based tests (`CheckInNetworkRepositoryTest`) plus test dependency and test fixes, and apply ktlint formatting across Android Kotlin sources. 

### Testing
- Ran static analysis with `./gradlew detekt ktlintCheck`, which completed successfully. 
- Ran unit tests with `./gradlew testDebugUnitTest` (using `ANDROID_HOME=/opt/android-sdk` and `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64`), which completed successfully. 
- Ran full checks with `./gradlew check`, which completed successfully. 
- Built the debug APK with `./gradlew assembleDebug`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b8088ec0832ebf5a409ae4ad72ec)