### PR TITLE
fix(table): update useAdminTable to @tanstack/react-table v9 API

### DIFF
--- a/frontend/src/hooks/useAdminTable.ts
+++ b/frontend/src/hooks/useAdminTable.ts
@@ -2,6 +2,7 @@ import {
   createTableHook,
   tableFeatures,
   columnVisibilityFeature,
+  columnFilteringFeature,
   globalFilteringFeature,
   rowSortingFeature,
   createFilteredRowModel,
@@ -15,11 +16,16 @@ export const {
   createAppColumnHelper,
   appFeatures,
 } = createTableHook({
-  features: tableFeatures({ columnVisibilityFeature, globalFilteringFeature, rowSortingFeature }),
-  rowModels: {
-    filteredRowModel: createFilteredRowModel(filterFns),
-    sortedRowModel: createSortedRowModel(sortFns),
-  },
+  features: tableFeatures({
+    columnVisibilityFeature,
+    columnFilteringFeature,
+    globalFilteringFeature,
+    rowSortingFeature,
+    filteredRowModel: createFilteredRowModel(),
+    sortedRowModel: createSortedRowModel(),
+    filterFns,
+    sortFns,
+  }),
 });
 
 export type AdminTableFeatures = typeof appFeatures;


### PR DESCRIPTION
## Summary

- `globalFilteringFeature` now requires `columnFilteringFeature` to be present (enforced via TypeScript conditional type)
- Row models (`filteredRowModel`, `sortedRowModel`) and filter/sort fns (`filterFns`, `sortFns`) are now passed inside `tableFeatures()` instead of a separate `rowModels` option
- `createFilteredRowModel()` and `createSortedRowModel()` no longer accept arguments in v9-beta

## Test plan

- [x] `pnpm typecheck` passes with no errors
- [x] `pnpm lint` clean (pre-existing warnings only, unrelated to this change)
- [x] `pnpm test` — all 284 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pm8V4Sra8tt8BzfFgKES7K)_