### PR TITLE
ci(deps): group @dnd-kit/* packages in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,10 @@ updates:
         patterns:
           - "@tanstack/react-db"
           - "@tanstack/query-db-collection"
+      # Group dnd-kit packages (share internal deps; mismatched versions cause type errors)
+      dnd-kit:
+        patterns:
+          - "@dnd-kit/*"
 
   # Monitor uv-managed Python dependencies for backend API
   - package-ecosystem: "uv"


### PR DESCRIPTION
## Summary

- Adds a `dnd-kit` group to Dependabot config so `@dnd-kit/dom`, `@dnd-kit/react`, and any other `@dnd-kit/*` packages are always bumped together in a single PR
- Fixes the root cause of PRs #573 and #574 failing: when only one package is at 0.5.0 and the other stays at 0.4.0, TypeScript sees two conflicting copies of shared internal packages (`@dnd-kit/abstract`, `@dnd-kit/state`, etc.) and errors out with private-property type mismatches

## Next steps

Close the separate PRs #573 and #574 (they'll conflict with each other regardless, and neither can pass CI on its own). Dependabot will open a single combined PR on the next Friday run.

## Test plan

- [ ] Verify `.github/dependabot.yml` parses correctly (no YAML errors)
- [ ] After merging, close #573 and #574 manually and let Dependabot re-open a grouped PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FXpAEr8nFFjQv2Egjf4kT

---
_Generated by [Claude Code](https://claude.ai/code/session_019FXpAEr8nFFjQv2Egjf4kT)_