### PR TITLE
[codex] Extract admin dashboard data selectors

### DIFF
--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -17,23 +17,16 @@ import MembersManagement from "./MembersManagement";
 import VolunteersManagement from "./VolunteersManagement";
 import AdminSidebar from "./AdminSidebar";
 import AdminLoginForm from "./AdminLoginForm";
-import type { MemberFormData } from "./MemberFormModal";
-import type { PersonFormData } from "./PersonFormModal";
-import type { VolunteerFormData } from "./VolunteerFormModal";
 import type {
   Registration,
   RegistrationStatus,
-  PaymentStatus,
-  OrderItem,
 } from "@/types/registration";
-import { apiToRegistration } from "@/types/registrationMapper";
 import type { Room, FloorTable, FloorArea, TableType, Layout, Venue } from "@/types/admin";
-import { type Person, apiToPerson } from "@/types/person";
 import { activeEditionQueryKey, useActiveEdition } from "@/hooks/useActiveEdition";
 import { useAdminDashboardData } from "@/hooks/useAdminDashboardData";
+import { useAdminPeopleActions } from "@/hooks/useAdminPeopleActions";
 import { useAdminQueries } from "@/hooks/useAdminQueries";
-import { usePeopleMutations } from "@/hooks/usePeopleMutations";
-import { useRegistrationAdminMutations } from "@/hooks/useRegistrationAdminMutations";
+import { useAdminRegistrationActions } from "@/hooks/useAdminRegistrationActions";
 import { useVenueMutations } from "@/hooks/useVenueMutations";
 import { fetchJsonOrThrowWithUnauthorized } from "@/utils/adminApi";
 import { queryKeys } from "@/utils/queryKeys";
@@ -47,10 +40,6 @@ import {
   apiRoomToRoom,
   apiTableToTable,
   apiAreaToArea,
-  mergeVolunteerPerson,
-  replacePersonById,
-  replaceVolunteerById,
-  syncMembersWithPerson,
 } from "@/utils/adminApiMappers";
 import Card from "react-bootstrap/Card";
 
@@ -162,30 +151,43 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
   });
 
   const {
-    mergePeopleMutation,
-    createMemberMutation,
-    updateMemberMutation,
-    deleteMemberMutation,
-    createPersonMutation,
-    updatePersonMutation,
-    deletePersonMutation,
-    createVolunteerMutation,
-    updateVolunteerMutation,
-    deleteVolunteerMutation,
-  } = usePeopleMutations({
-    queryClient,
+    handleCreateMember,
+    handleCreatePerson,
+    handleCreateVolunteer,
+    handleDeleteMember,
+    handleDeletePerson,
+    handleDeleteVolunteer,
+    handleMergePeople,
+    handleUpdateMember,
+    handleUpdatePerson,
+    handleUpdateVolunteer,
+  } = useAdminPeopleActions({
     authHeaders,
-    peopleQueryKey,
-    membersQueryKey,
-    registrationsQueryKey,
     exhibitorsQueryKey,
+    membersQueryKey,
+    people,
+    peopleQueryKey,
+    queryClient,
+    registrationsQueryKey,
+    setDetailRegistration,
   });
 
-  const { updateRegistrationMutation } = useRegistrationAdminMutations({
-    queryClient,
+  const {
+    handleAddRegistration,
+    handleAssignTable,
+    handleCheckIn,
+    handleIssueStrap,
+    handleToggleDelivered,
+    handleUpdatePayment,
+    handleUpdateStatus,
+    handleViewDetail,
+  } = useAdminRegistrationActions({
     authHeaders,
+    queryClient,
     registrationsQueryKey,
     tablesQueryKey,
+    setDetailRegistration,
+    setRegistrationError,
   });
 
   const {
@@ -230,276 +232,6 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
     setDetailRegistration(null);
     auth.logout();
   }, [auth, queryClient]);
-
-  const handleMergePeople = useCallback(
-    async (canonicalId: string, duplicateId: string) => {
-      const updated = await mergePeopleMutation.mutateAsync({ canonicalId, duplicateId });
-      const canonicalPerson = apiToPerson(updated as Record<string, unknown>);
-      const currentPeople = peopleQuery.data ?? [];
-      const duplicate = currentPeople.find((p) => p.id === duplicateId);
-      const existingCanonical = currentPeople.find((p) => p.id === canonicalId);
-      const shouldPreserveVolunteerData =
-        canonicalPerson.roles.includes("volunteer") ||
-        existingCanonical?.roles.includes("volunteer") ||
-        duplicate?.roles.includes("volunteer");
-      const mergedCanonical = shouldPreserveVolunteerData
-        ? mergeVolunteerPerson(existingCanonical, {
-            ...canonicalPerson,
-            helpPeriods: existingCanonical?.helpPeriods ?? duplicate?.helpPeriods ?? [],
-          })
-        : canonicalPerson;
-      // Replace both the canonical and duplicate in the canonical people list.
-      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
-        prev
-          ? prev
-              .filter((p) => p.id !== duplicateId)
-              .map((p) => (p.id === canonicalId ? mergedCanonical : p))
-          : prev,
-      );
-      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
-        prev
-          ? syncMembersWithPerson(
-              prev.filter((member) => member.id !== duplicateId),
-              mergedCanonical,
-            )
-          : prev,
-      );
-      // Re-point any registrations in state that were on the duplicate;
-      // also refresh person data on any already-canonical registrations (merged fields may have changed).
-      queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
-        prev
-          ? prev.map((r) =>
-              r.personId === duplicateId
-                ? { ...r, personId: canonicalId, person: canonicalPerson }
-                : r.personId === canonicalId
-                  ? { ...r, person: canonicalPerson }
-                  : r,
-            )
-          : prev,
-      );
-      // Re-point any exhibitors in state that were linked to the duplicate contact person
-      queryClient.setQueryData<
-        { id: number; name: string; active: boolean; contactPersonId: string | null }[]
-      >(exhibitorsQueryKey, (prev) =>
-        prev
-          ? prev.map((ex) =>
-              ex.contactPersonId === duplicateId ? { ...ex, contactPersonId: canonicalId } : ex,
-            )
-          : prev,
-      );
-    },
-    [
-      exhibitorsQueryKey,
-      membersQueryKey,
-      mergePeopleMutation,
-      peopleQuery.data,
-      peopleQueryKey,
-      queryClient,
-      registrationsQueryKey,
-    ],
-  );
-
-  const handleCreateMember = useCallback(
-    async (data: MemberFormData) => {
-      const d = await createMemberMutation.mutateAsync(data);
-      const createdMember = apiToPerson(d as Record<string, unknown>);
-      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
-        prev ? [createdMember, ...prev] : [createdMember],
-      );
-      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
-        prev ? [createdMember, ...prev] : [createdMember],
-      );
-    },
-    [createMemberMutation, membersQueryKey, peopleQueryKey, queryClient],
-  );
-
-  const handleUpdateMember = useCallback(
-    async (id: string, data: MemberFormData) => {
-      const d = await updateMemberMutation.mutateAsync({ id, data });
-      const updatedMember = apiToPerson(d as Record<string, unknown>);
-      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
-        prev ? prev.map((member) => (member.id === id ? updatedMember : member)) : prev,
-      );
-      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
-        prev ? replacePersonById(prev, updatedMember) : prev,
-      );
-      queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
-        prev
-          ? prev.map((r) =>
-              r.personId === id
-                ? {
-                    ...r,
-                    person: {
-                      id: updatedMember.id,
-                      name: updatedMember.name,
-                      email: updatedMember.email,
-                      phone: updatedMember.phone,
-                    },
-                  }
-                : r,
-            )
-          : prev,
-      );
-      setDetailRegistration((prev) =>
-        prev?.person.id === id
-          ? {
-              ...prev,
-              person: {
-                id: updatedMember.id,
-                name: updatedMember.name,
-                email: updatedMember.email,
-                phone: updatedMember.phone,
-              },
-            }
-          : prev,
-      );
-    },
-    [membersQueryKey, peopleQueryKey, queryClient, registrationsQueryKey, updateMemberMutation],
-  );
-
-  const handleDeleteMember = useCallback(
-    async (id: string) => {
-      await deleteMemberMutation.mutateAsync(id);
-      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
-        prev ? prev.filter((member) => member.id !== id) : prev,
-      );
-      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
-        prev ? prev.filter((person) => person.id !== id) : prev,
-      );
-    },
-    [deleteMemberMutation, membersQueryKey, peopleQueryKey, queryClient],
-  );
-
-  const handleCreatePerson = useCallback(
-    async (data: PersonFormData) => {
-      const d = await createPersonMutation.mutateAsync(data);
-      const createdPerson = apiToPerson(d as Record<string, unknown>);
-      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
-        prev ? [createdPerson, ...prev] : [createdPerson],
-      );
-      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
-        prev ? syncMembersWithPerson(prev, createdPerson) : prev,
-      );
-    },
-    [createPersonMutation, membersQueryKey, peopleQueryKey, queryClient],
-  );
-
-  const handleUpdatePerson = useCallback(
-    async (id: string, data: PersonFormData) => {
-      const d = await updatePersonMutation.mutateAsync({ id, data });
-      const updated = apiToPerson(d as Record<string, unknown>);
-      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
-        prev ? replacePersonById(prev, updated) : prev,
-      );
-      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
-        prev ? syncMembersWithPerson(prev, updated) : prev,
-      );
-      queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
-        prev
-          ? prev.map((r) =>
-              r.personId === id
-                ? {
-                    ...r,
-                    person: {
-                      id: updated.id,
-                      name: updated.name,
-                      email: updated.email,
-                      phone: updated.phone,
-                    },
-                  }
-                : r,
-            )
-          : prev,
-      );
-      setDetailRegistration((prev) =>
-        prev?.person.id === id
-          ? {
-              ...prev,
-              person: {
-                id: updated.id,
-                name: updated.name,
-                email: updated.email,
-                phone: updated.phone,
-              },
-            }
-          : prev,
-      );
-    },
-    [membersQueryKey, peopleQueryKey, queryClient, registrationsQueryKey, updatePersonMutation],
-  );
-
-  const handleDeletePerson = useCallback(
-    async (id: string) => {
-      await deletePersonMutation.mutateAsync(id);
-      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
-        prev ? prev.filter((p) => p.id !== id) : prev,
-      );
-      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
-        prev ? prev.filter((member) => member.id !== id) : prev,
-      );
-    },
-    [deletePersonMutation, membersQueryKey, peopleQueryKey, queryClient],
-  );
-
-  const handleCreateVolunteer = useCallback(
-    async (data: VolunteerFormData) => {
-      const d = await createVolunteerMutation.mutateAsync(data);
-      const createdVolunteer = apiToPerson(d as Record<string, unknown>);
-      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
-        prev ? [mergeVolunteerPerson(undefined, createdVolunteer), ...prev] : prev,
-      );
-    },
-    [createVolunteerMutation, peopleQueryKey, queryClient],
-  );
-
-  const handleUpdateVolunteer = useCallback(
-    async (id: string, data: VolunteerFormData) => {
-      const d = await updateVolunteerMutation.mutateAsync({ id, data });
-      const updatedVolunteer = apiToPerson(d as Record<string, unknown>);
-      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
-        prev ? replaceVolunteerById(prev, updatedVolunteer) : prev,
-      );
-      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
-        prev
-          ? prev.map((member) =>
-              member.id === id
-                ? {
-                    ...member,
-                    name: updatedVolunteer.name,
-                    address: updatedVolunteer.address,
-                    active: updatedVolunteer.active,
-                    updatedAt: updatedVolunteer.updatedAt,
-                  }
-                : member,
-            )
-          : prev,
-      );
-    },
-    [membersQueryKey, peopleQueryKey, queryClient, updateVolunteerMutation],
-  );
-
-  const handleDeleteVolunteer = useCallback(
-    async (id: string) => {
-      await deleteVolunteerMutation.mutateAsync(id);
-      // The person record is preserved (soft archive); only the volunteer role
-      // and help periods are removed.  Update local state accordingly so that
-      // the person remains visible in People/Members tabs if applicable.
-      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
-        prev
-          ? prev.map((person) =>
-              person.id !== id
-                ? person
-                : {
-                    ...person,
-                    roles: person.roles.filter((r) => r !== "volunteer"),
-                    helpPeriods: [],
-                  },
-            )
-          : prev,
-      );
-    },
-    [deleteVolunteerMutation, peopleQueryKey, queryClient],
-  );
 
   const handleExhibitorSaved = useCallback(
     (item: ItemDraft) => {
@@ -610,120 +342,6 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [sidebarOpen]);
-
-  const handleUpdateStatus = useCallback(
-    async (id: string, status: RegistrationStatus) => {
-      try {
-        const updated = apiToRegistration(
-          await updateRegistrationMutation.mutateAsync({
-            id,
-            payload: { status },
-            fallbackMessage: m.admin_error_update_registration(),
-          }),
-        );
-        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
-          prev
-            ? prev.map((r) =>
-                r.id === id ? { ...r, status: updated.status, updatedAt: updated.updatedAt } : r,
-              )
-            : prev,
-        );
-        setDetailRegistration((prev) =>
-          prev?.id === id
-            ? { ...prev, status: updated.status, updatedAt: updated.updatedAt }
-            : prev,
-        );
-      } catch (err) {
-        devError("Failed to update registration status", err);
-        setRegistrationError(err instanceof Error ? err.message : m.admin_error_update_registration());
-        throw err;
-      }
-    },
-    [queryClient, registrationsQueryKey, updateRegistrationMutation],
-  );
-
-  const handleUpdatePayment = useCallback(
-    async (id: string, paymentStatus: PaymentStatus) => {
-      try {
-        const updated = apiToRegistration(
-          await updateRegistrationMutation.mutateAsync({
-            id,
-            payload: { payment_status: paymentStatus },
-            fallbackMessage: m.admin_error_update_payment(),
-          }),
-        );
-        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
-          prev
-            ? prev.map((r) =>
-                r.id === id
-                  ? { ...r, paymentStatus: updated.paymentStatus, updatedAt: updated.updatedAt }
-                  : r,
-              )
-            : prev,
-        );
-        setDetailRegistration((prev) =>
-          prev?.id === id
-            ? { ...prev, paymentStatus: updated.paymentStatus, updatedAt: updated.updatedAt }
-            : prev,
-        );
-      } catch (err) {
-        devError("Failed to update payment status", err);
-        setRegistrationError(err instanceof Error ? err.message : m.admin_error_update_payment());
-        throw err;
-      }
-    },
-    [queryClient, registrationsQueryKey, updateRegistrationMutation],
-  );
-
-  const handleAssignTable = useCallback(
-    async (registrationId: string, tableId: string | undefined) => {
-      try {
-        const updated = apiToRegistration(
-          await updateRegistrationMutation.mutateAsync({
-            id: registrationId,
-            payload: { table_id: tableId ?? null },
-            fallbackMessage: m.admin_error_assign_table(),
-          }),
-        );
-        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
-          prev
-            ? prev.map((r) =>
-                r.id === registrationId
-                  ? { ...r, tableId: updated.tableId, updatedAt: updated.updatedAt }
-                  : r,
-              )
-            : prev,
-        );
-        queryClient.setQueryData<FloorTable[]>(tablesQueryKey, (prev) =>
-          prev
-            ? prev.map((t) => {
-                const wasAssigned = t.registrationIds.includes(registrationId);
-                const shouldBeAssigned = t.id === updated.tableId;
-                if (wasAssigned && !shouldBeAssigned) {
-                  return {
-                    ...t,
-                    registrationIds: t.registrationIds.filter((id) => id !== registrationId),
-                  };
-                }
-                if (!wasAssigned && shouldBeAssigned) {
-                  return { ...t, registrationIds: [...t.registrationIds, registrationId] };
-                }
-                return t;
-              })
-            : prev,
-        );
-        setDetailRegistration((prev) =>
-          prev?.id === registrationId
-            ? { ...prev, tableId: updated.tableId, updatedAt: updated.updatedAt }
-            : prev,
-        );
-      } catch (err) {
-        devError("Failed to assign table", err);
-        setRegistrationError(err instanceof Error ? err.message : m.admin_error_assign_table());
-      }
-    },
-    [queryClient, registrationsQueryKey, tablesQueryKey, updateRegistrationMutation],
-  );
 
   const handleAddTable = useCallback(
     async (name: string, capacity: number, layoutId: string, tableTypeId: string) => {
@@ -1034,15 +652,6 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
     [areasQuery.data, layoutsQuery.data, roomsQuery.data, resizeAreaMutation],
   );
 
-  const handleAddRegistration = useCallback(
-    (registration: Registration) => {
-      queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
-        prev ? [registration, ...prev] : [registration],
-      );
-    },
-    [queryClient, registrationsQueryKey],
-  );
-
   const handleAddTableType = useCallback(
     async (data: Omit<TableType, "id">) => {
       const d = await createTableTypeMutation.mutateAsync(data);
@@ -1071,100 +680,6 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
   const handleRestoreTableType = useCallback(
     (id: string) => handleUpdateTableType(id, { active: true }),
     [handleUpdateTableType],
-  );
-
-  /** Fetch the full registration (including checkInToken) and open detail modal */
-  const handleViewDetail = useCallback(
-    async (res: Registration) => {
-      try {
-        const data = await fetchJsonOrThrowWithUnauthorized<Record<string, unknown>>(
-          `/api/registrations/${res.id}`,
-          { headers: authHeaders() },
-          m.admin_error_load_data(),
-        );
-        setDetailRegistration(apiToRegistration(data));
-      } catch (err) {
-        devError("Failed to fetch registration detail, falling back to list data", err);
-        setDetailRegistration(res);
-      }
-    },
-    [authHeaders],
-  );
-
-  const handleToggleDelivered = useCallback(
-    async (registrationId: string, updatedOrders: OrderItem[]) => {
-      try {
-        const updated = apiToRegistration(
-          await updateRegistrationMutation.mutateAsync({
-            id: registrationId,
-            payload: {
-              pre_orders: updatedOrders.map((o) => ({
-                product_id: o.productId,
-                name: o.name,
-                quantity: o.quantity,
-                delivered_quantity: o.deliveredQuantity,
-                price: o.price,
-                category: o.category,
-                delivered: o.delivered,
-              })),
-            },
-            fallbackMessage: m.admin_error_bottle_delivery(),
-          }),
-        );
-        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
-          prev ? prev.map((r) => (r.id === registrationId ? updated : r)) : prev,
-        );
-        setDetailRegistration((prev) => (prev?.id === registrationId ? updated : prev));
-      } catch (err) {
-        devError("Failed to update bottle delivery status", err);
-        setRegistrationError(err instanceof Error ? err.message : m.admin_error_bottle_delivery());
-      }
-    },
-    [queryClient, registrationsQueryKey, updateRegistrationMutation],
-  );
-
-  const handleCheckIn = useCallback(
-    async (registrationId: string) => {
-      try {
-        const updated = apiToRegistration(
-          await updateRegistrationMutation.mutateAsync({
-            id: registrationId,
-            payload: { checked_in: true },
-            fallbackMessage: m.admin_error_check_in(),
-          }),
-        );
-        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
-          prev ? prev.map((r) => (r.id === registrationId ? updated : r)) : prev,
-        );
-        setDetailRegistration((prev) => (prev?.id === registrationId ? updated : prev));
-      } catch (err) {
-        devError("Failed to check in guest", err);
-        setRegistrationError(err instanceof Error ? err.message : m.admin_error_check_in());
-      }
-    },
-    [queryClient, registrationsQueryKey, updateRegistrationMutation],
-  );
-
-  const handleIssueStrap = useCallback(
-    async (registrationId: string) => {
-      try {
-        const updated = apiToRegistration(
-          await updateRegistrationMutation.mutateAsync({
-            id: registrationId,
-            payload: { strap_issued: true },
-            fallbackMessage: m.admin_error_issue_strap(),
-          }),
-        );
-        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
-          prev ? prev.map((r) => (r.id === registrationId ? updated : r)) : prev,
-        );
-        setDetailRegistration((prev) => (prev?.id === registrationId ? updated : prev));
-      } catch (err) {
-        devError("Failed to issue strap", err);
-        setRegistrationError(err instanceof Error ? err.message : m.admin_error_issue_strap());
-      }
-    },
-    [queryClient, registrationsQueryKey, updateRegistrationMutation],
   );
 
   if (!visible) return null;

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -30,6 +30,7 @@ import { apiToRegistration } from "@/types/registrationMapper";
 import type { Room, FloorTable, FloorArea, TableType, Layout, Venue } from "@/types/admin";
 import { type Person, apiToPerson } from "@/types/person";
 import { activeEditionQueryKey, useActiveEdition } from "@/hooks/useActiveEdition";
+import { useAdminDashboardData } from "@/hooks/useAdminDashboardData";
 import { useAdminQueries } from "@/hooks/useAdminQueries";
 import { usePeopleMutations } from "@/hooks/usePeopleMutations";
 import { useRegistrationAdminMutations } from "@/hooks/useRegistrationAdminMutations";
@@ -51,8 +52,6 @@ import {
   replaceVolunteerById,
   syncMembersWithPerson,
 } from "@/utils/adminApiMappers";
-import { toLocalDateKey } from "@/utils/dateUtils";
-import { isRegistrationInEdition } from "@/utils/adminUtils";
 import Card from "react-bootstrap/Card";
 
 function activeEditionLabel(year: number): string {
@@ -124,13 +123,11 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
     areasQueryKey,
     peopleQueryKey,
     membersQueryKey,
-    layoutDayOptions,
     loadData: loadDataBase,
   } = useAdminQueries({
     visible,
     isAuthenticated,
     authHeaders,
-    activeEdition,
   });
 
   const loadData = useCallback(async () => {
@@ -140,31 +137,6 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
 
   const registrations = useMemo(() => registrationsQuery.data ?? [], [registrationsQuery.data]);
   const tables = tablesQuery.data ?? [];
-  const todayKey = useMemo(() => toLocalDateKey(new Date()), []);
-  const activeEditionDateKeys = useMemo(
-    () => activeEdition.dates.map((date) => toLocalDateKey(date)),
-    [activeEdition.dates],
-  );
-  const activeDayIndex = activeEditionDateKeys.indexOf(todayKey);
-  const isActiveEditionDay = activeDayIndex >= 0;
-  const activeEditionStats = useMemo(() => {
-    let checkedIn = 0;
-    let total = 0;
-    const eventIdsToday = new Set(
-      activeEdition.events.filter((event) => event.date === todayKey).map((event) => event.id),
-    );
-
-    for (const registration of registrations) {
-      if (registration.status === "cancelled") continue;
-      if (!isRegistrationInEdition(registration, activeEdition.id)) continue;
-      const guestCount = Math.max(0, registration.guestCount ?? 0);
-      total += guestCount;
-      if (registration.checkedIn) checkedIn += guestCount;
-    }
-
-    return { checkedIn, total, eventsToday: eventIdsToday.size };
-  }, [activeEdition.events, activeEdition.id, registrations, todayKey]);
-
   const venues = venuesQuery.data ?? [];
   const rooms = roomsQuery.data ?? [];
   const tableTypes = tableTypesQuery.data ?? [];
@@ -173,6 +145,21 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
   const areas = areasQuery.data ?? [];
   const people = peopleQuery.data ?? [];
   const members = membersQuery.data ?? [];
+  const {
+    activeDayIndex,
+    activeEditionDateKeys,
+    activeEditionStats,
+    emailDuplicates,
+    isActiveEditionDay,
+    layoutDayOptions,
+    registrationCountByPersonId,
+    volunteers,
+  } = useAdminDashboardData({
+    activeEdition,
+    detailRegistration,
+    people,
+    registrations,
+  });
 
   const {
     mergePeopleMutation,
@@ -543,11 +530,6 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
       >(exhibitorsQueryKey, (prev) => (prev ? prev.filter((e) => e.id !== id) : prev));
     },
     [exhibitorsQueryKey, queryClient],
-  );
-
-  const volunteers = useMemo(
-    () => (peopleQuery.data ?? []).filter((person) => person.roles.includes("volunteer")),
-    [peopleQuery.data],
   );
 
   useEffect(() => {
@@ -1184,28 +1166,6 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
     },
     [queryClient, registrationsQueryKey, updateRegistrationMutation],
   );
-
-  // Computed maps derived from people/registrations state — must stay above any early return
-  // to satisfy the Rules of Hooks (hooks must be called unconditionally).
-  const registrationCountByPersonId = useMemo(() => {
-    const counts: Record<string, number> = {};
-    for (const r of registrationsQuery.data ?? []) {
-      if (r.personId == null) continue;
-      counts[r.personId] = (counts[r.personId] ?? 0) + 1;
-    }
-    return Object.fromEntries((peopleQuery.data ?? []).map((p) => [p.id, counts[p.id] ?? 0]));
-  }, [peopleQuery.data, registrationsQuery.data]);
-
-  const emailDuplicates = useMemo(() => {
-    if (!detailRegistration) return [];
-    const personEmail = detailRegistration.person.email.toLowerCase();
-    return people
-      .filter(
-        (p) =>
-          p.id !== detailRegistration.personId && p.email && p.email.toLowerCase() === personEmail,
-      )
-      .map((p) => ({ id: p.id, name: p.name }));
-  }, [people, detailRegistration]);
 
   if (!visible) return null;
 

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -21,26 +21,15 @@ import type {
   Registration,
   RegistrationStatus,
 } from "@/types/registration";
-import type { Room, FloorTable, FloorArea, TableType, Layout, Venue } from "@/types/admin";
 import { activeEditionQueryKey, useActiveEdition } from "@/hooks/useActiveEdition";
 import { useAdminDashboardData } from "@/hooks/useAdminDashboardData";
 import { useAdminPeopleActions } from "@/hooks/useAdminPeopleActions";
 import { useAdminQueries } from "@/hooks/useAdminQueries";
 import { useAdminRegistrationActions } from "@/hooks/useAdminRegistrationActions";
-import { useVenueMutations } from "@/hooks/useVenueMutations";
-import { fetchJsonOrThrowWithUnauthorized } from "@/utils/adminApi";
+import { useAdminVenueActions } from "@/hooks/useAdminVenueActions";
 import { queryKeys } from "@/utils/queryKeys";
 import { invalidateAdmin } from "@/utils/queryInvalidation";
-import { getAreaSizePx, getCanvasSizePx } from "@/utils/layoutUtils";
 import { devError } from "@/utils/devLog";
-import {
-  apiVenueToVenue,
-  apiLayoutToLayout,
-  apiTableTypeToTableType,
-  apiRoomToRoom,
-  apiTableToTable,
-  apiAreaToArea,
-} from "@/utils/adminApiMappers";
 import Card from "react-bootstrap/Card";
 
 function activeEditionLabel(year: number): string {
@@ -191,38 +180,42 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
   });
 
   const {
-    createTableMutation,
-    changeTableTypeMutation,
-    updateTableNameMutation,
-    moveTableMutation,
-    rotateTableMutation,
-    deleteTableMutation,
-    createVenueMutation,
-    updateVenueMutation,
-    deleteVenueMutation,
-    createRoomMutation,
-    updateRoomMutation,
-    createLayoutMutation,
-    deleteLayoutMutation,
-    createAreaMutation,
-    updateAreaLabelMutation,
-    resizeAreaMutation,
-    assignAreaMutation,
-    moveAreaMutation,
-    rotateAreaMutation,
-    deleteAreaMutation,
-    createTableTypeMutation,
-    updateTableTypeMutation,
-  } = useVenueMutations({
-    queryClient,
-    authHeaders,
+    handleAddArea,
+    handleAddLayout,
+    handleAddRoom,
+    handleAddTable,
+    handleAddTableType,
+    handleAddVenue,
+    handleArchiveRoom,
+    handleArchiveTableType,
+    handleArchiveVenue,
+    handleAssignAreaToItem,
+    handleChangeTableType,
+    handleDeleteArea,
+    handleDeleteLayout,
+    handleDeleteTable,
+    handleDeleteVenue,
+    handleMoveArea,
+    handleMoveTable,
+    handleResizeArea,
+    handleRestoreRoom,
+    handleRestoreTableType,
+    handleRestoreVenue,
+    handleRotateArea,
+    handleRotateTable,
+    handleUpdateAreaLabel,
+    handleUpdateTable,
+    handleUpdateTableType,
+  } = useAdminVenueActions({
     activeEditionId: activeEdition.id,
-    tablesQueryKey,
-    venuesQueryKey,
+    areasQueryKey,
+    authHeaders,
+    layoutsQueryKey,
+    queryClient,
     roomsQueryKey,
     tableTypesQueryKey,
-    layoutsQueryKey,
-    areasQueryKey,
+    tablesQueryKey,
+    venuesQueryKey,
   });
 
   const handleLogout = useCallback(() => {
@@ -342,345 +335,6 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [sidebarOpen]);
-
-  const handleAddTable = useCallback(
-    async (name: string, capacity: number, layoutId: string, tableTypeId: string) => {
-      const data = await createTableMutation.mutateAsync({ name, capacity, layoutId, tableTypeId });
-      const table = (data.table ?? data) as Record<string, unknown>;
-      queryClient.setQueryData<FloorTable[]>(tablesQueryKey, (prev) =>
-        prev ? [...prev, apiTableToTable(table)] : [apiTableToTable(table)],
-      );
-    },
-    [createTableMutation, queryClient, tablesQueryKey],
-  );
-
-  const handleMoveTable = useCallback(
-    (tableId: string, x: number, y: number) => {
-      moveTableMutation.mutate({ tableId, x, y });
-    },
-    [moveTableMutation],
-  );
-
-  const handleRotateTable = useCallback(
-    (tableId: string, rotation: number) => {
-      rotateTableMutation.mutate({ tableId, rotation: ((rotation % 360) + 360) % 360 });
-    },
-    [rotateTableMutation],
-  );
-
-  const handleDeleteTable = useCallback(
-    async (tableId: string) => {
-      await deleteTableMutation.mutateAsync(tableId);
-      queryClient.setQueryData<FloorTable[]>(tablesQueryKey, (prev) =>
-        prev ? prev.filter((t) => t.id !== tableId) : prev,
-      );
-    },
-    [deleteTableMutation, queryClient, tablesQueryKey],
-  );
-
-  const handleAddVenue = useCallback(
-    async (name: string, address: string, city: string, postalCode: string, country: string) => {
-      const d = await createVenueMutation.mutateAsync({ name, address, city, postalCode, country });
-      queryClient.setQueryData<Venue[]>(venuesQueryKey, (prev) =>
-        prev ? [...prev, apiVenueToVenue(d)] : [apiVenueToVenue(d)],
-      );
-    },
-    [createVenueMutation, queryClient, venuesQueryKey],
-  );
-
-  const handleArchiveVenue = useCallback(
-    async (venueId: string) => {
-      const d = await updateVenueMutation.mutateAsync({ venueId, active: false });
-      queryClient.setQueryData<Venue[]>(venuesQueryKey, (prev) =>
-        prev ? prev.map((v) => (v.id === venueId ? apiVenueToVenue(d) : v)) : prev,
-      );
-    },
-    [queryClient, updateVenueMutation, venuesQueryKey],
-  );
-
-  const handleRestoreVenue = useCallback(
-    async (venueId: string) => {
-      const d = await updateVenueMutation.mutateAsync({ venueId, active: true });
-      queryClient.setQueryData<Venue[]>(venuesQueryKey, (prev) =>
-        prev ? prev.map((v) => (v.id === venueId ? apiVenueToVenue(d) : v)) : prev,
-      );
-    },
-    [queryClient, updateVenueMutation, venuesQueryKey],
-  );
-
-  const handleDeleteVenue = useCallback(
-    async (venueId: string) => {
-      await deleteVenueMutation.mutateAsync(venueId);
-      queryClient.setQueryData<Venue[]>(venuesQueryKey, (prev) =>
-        prev ? prev.filter((v) => v.id !== venueId) : prev,
-      );
-      // Cascade: remove rooms and their layouts/tables from local state
-      const venueRoomIds = (roomsQuery.data ?? [])
-        .filter((r) => r.venueId === venueId)
-        .map((r) => r.id);
-      queryClient.setQueryData<Room[]>(roomsQueryKey, (prev) =>
-        prev ? prev.filter((r) => r.venueId !== venueId) : prev,
-      );
-      const venueLayoutIds = (layoutsQuery.data ?? [])
-        .filter((l) => venueRoomIds.includes(l.roomId ?? ""))
-        .map((l) => l.id);
-      queryClient.setQueryData<Layout[]>(layoutsQueryKey, (prev) =>
-        prev ? prev.filter((l) => !venueRoomIds.includes(l.roomId ?? "")) : prev,
-      );
-      queryClient.setQueryData<FloorTable[]>(tablesQueryKey, (prev) =>
-        prev ? prev.filter((t) => !venueLayoutIds.includes(t.layoutId)) : prev,
-      );
-      queryClient.setQueryData<FloorArea[]>(areasQueryKey, (prev) =>
-        prev ? prev.filter((a) => !venueLayoutIds.includes(a.layoutId)) : prev,
-      );
-    },
-    [
-      areasQueryKey,
-      deleteVenueMutation,
-      layoutsQuery.data,
-      layoutsQueryKey,
-      queryClient,
-      roomsQuery.data,
-      roomsQueryKey,
-      tablesQueryKey,
-      venuesQueryKey,
-    ],
-  );
-
-  const handleAddRoom = useCallback(
-    async (venueId: string, name: string, widthM: number, lengthM: number, color: string) => {
-      const data = await createRoomMutation.mutateAsync({ venueId, name, widthM, lengthM, color });
-      queryClient.setQueryData<Room[]>(roomsQueryKey, (prev) =>
-        prev ? [...prev, apiRoomToRoom(data)] : [apiRoomToRoom(data)],
-      );
-    },
-    [createRoomMutation, queryClient, roomsQueryKey],
-  );
-
-  const handleArchiveRoom = useCallback(
-    async (roomId: string) => {
-      const data = await updateRoomMutation.mutateAsync({
-        roomId,
-        active: false,
-        fallbackMessage: m.admin_error_delete_room(),
-      });
-      queryClient.setQueryData<Room[]>(roomsQueryKey, (prev) =>
-        prev ? prev.map((r) => (r.id === roomId ? apiRoomToRoom(data) : r)) : prev,
-      );
-    },
-    [queryClient, roomsQueryKey, updateRoomMutation],
-  );
-
-  const handleRestoreRoom = useCallback(
-    async (roomId: string) => {
-      const data = await updateRoomMutation.mutateAsync({
-        roomId,
-        active: true,
-        fallbackMessage: m.admin_content_error_save(),
-      });
-      queryClient.setQueryData<Room[]>(roomsQueryKey, (prev) =>
-        prev ? prev.map((r) => (r.id === roomId ? apiRoomToRoom(data) : r)) : prev,
-      );
-    },
-    [queryClient, roomsQueryKey, updateRoomMutation],
-  );
-
-  const handleAddLayout = useCallback(
-    async (
-      roomId: string,
-      date: string,
-      label?: string,
-      copyFromLayoutId?: string | null,
-      copyOptions?: { tables: boolean; areas: boolean },
-    ) => {
-      if (copyFromLayoutId) {
-        const shouldCopyTables = copyOptions?.tables ?? true;
-        const shouldCopyAreas = copyOptions?.areas ?? true;
-        const copied = await fetchJsonOrThrowWithUnauthorized<Record<string, unknown>>(
-          `/api/layouts/${copyFromLayoutId}/copy`,
-          {
-            method: "POST",
-            headers: authHeaders(),
-            body: JSON.stringify({
-              edition_id: activeEdition.id,
-              room_id: roomId,
-              date,
-              ...(label?.trim() ? { label: label.trim() } : {}),
-              copy_tables: shouldCopyTables,
-              copy_areas: shouldCopyAreas,
-            }),
-          },
-          m.admin_error_add_layout(),
-        );
-        const createdLayout = apiLayoutToLayout(copied);
-        queryClient.setQueryData<Layout[]>(layoutsQueryKey, (prev) =>
-          prev ? [...prev, createdLayout] : [createdLayout],
-        );
-        await invalidateAdmin(queryClient, [layoutsQueryKey, tablesQueryKey, areasQueryKey]);
-        return;
-      }
-
-      const d = await createLayoutMutation.mutateAsync({ roomId, date, label });
-      queryClient.setQueryData<Layout[]>(layoutsQueryKey, (prev) =>
-        prev ? [...prev, apiLayoutToLayout(d)] : [apiLayoutToLayout(d)],
-      );
-    },
-    [
-      activeEdition.id,
-      areasQueryKey,
-      authHeaders,
-      createLayoutMutation,
-      layoutsQueryKey,
-      queryClient,
-      tablesQueryKey,
-    ],
-  );
-
-  const handleDeleteLayout = useCallback(
-    async (layoutId: string) => {
-      await deleteLayoutMutation.mutateAsync(layoutId);
-      queryClient.setQueryData<Layout[]>(layoutsQueryKey, (prev) =>
-        prev ? prev.filter((l) => l.id !== layoutId) : prev,
-      );
-      queryClient.setQueryData<FloorTable[]>(tablesQueryKey, (prev) =>
-        prev ? prev.filter((t) => t.layoutId !== layoutId) : prev,
-      );
-      queryClient.setQueryData<FloorArea[]>(areasQueryKey, (prev) =>
-        prev ? prev.filter((a) => a.layoutId !== layoutId) : prev,
-      );
-    },
-    [areasQueryKey, deleteLayoutMutation, layoutsQueryKey, queryClient, tablesQueryKey],
-  );
-
-  const handleAddArea = useCallback(
-    async (
-      label: string,
-      icon: string,
-      layoutId: string,
-      widthM: number,
-      lengthM: number,
-      exhibitorId?: number,
-    ) => {
-      const data = await createAreaMutation.mutateAsync({
-        label,
-        icon,
-        layoutId,
-        widthM,
-        lengthM,
-        exhibitorId,
-      });
-      queryClient.setQueryData<FloorArea[]>(areasQueryKey, (prev) =>
-        prev ? [...prev, apiAreaToArea(data)] : [apiAreaToArea(data)],
-      );
-    },
-    [areasQueryKey, createAreaMutation, queryClient],
-  );
-
-  const handleMoveArea = useCallback(
-    (areaId: string, x: number, y: number) => {
-      moveAreaMutation.mutate({ areaId, x, y });
-    },
-    [moveAreaMutation],
-  );
-
-  const handleRotateArea = useCallback(
-    (areaId: string, rotation: number) => {
-      rotateAreaMutation.mutate({ areaId, rotation: ((rotation % 360) + 360) % 360 });
-    },
-    [rotateAreaMutation],
-  );
-
-  const handleDeleteArea = useCallback(
-    async (areaId: string) => {
-      await deleteAreaMutation.mutateAsync(areaId);
-      queryClient.setQueryData<FloorArea[]>(areasQueryKey, (prev) =>
-        prev ? prev.filter((a) => a.id !== areaId) : prev,
-      );
-    },
-    [areasQueryKey, deleteAreaMutation, queryClient],
-  );
-
-  const handleAssignAreaToItem = useCallback(
-    async (areaId: string, exhibitorId: number | null, label?: string, icon?: string) => {
-      const body: Record<string, unknown> = { exhibitor_id: exhibitorId };
-      if (label !== undefined) body.label = label;
-      if (icon !== undefined) body.icon = icon;
-      await assignAreaMutation.mutateAsync({ areaId, body });
-    },
-    [assignAreaMutation],
-  );
-
-  const handleUpdateAreaLabel = useCallback(
-    (areaId: string, label: string) => {
-      updateAreaLabelMutation.mutate({ areaId, label });
-    },
-    [updateAreaLabelMutation],
-  );
-
-  const handleChangeTableType = useCallback(
-    async (tableId: string, tableTypeId: string) => {
-      await changeTableTypeMutation.mutateAsync({ tableId, tableTypeId });
-    },
-    [changeTableTypeMutation],
-  );
-
-  const handleUpdateTable = useCallback(
-    async (tableId: string, name: string) => {
-      await updateTableNameMutation.mutateAsync({ tableId, name });
-    },
-    [updateTableNameMutation],
-  );
-
-  const handleResizeArea = useCallback(
-    async (areaId: string, widthM: number, lengthM: number) => {
-      const area = (areasQuery.data ?? []).find((a) => a.id === areaId);
-      const layout = (layoutsQuery.data ?? []).find((l) => l.id === area?.layoutId);
-      const room = (roomsQuery.data ?? []).find((r) => r.id === layout?.roomId);
-
-      // Clamp the area's position so it stays within the canvas after resize.
-      let x = area?.x ?? 0;
-      let y = area?.y ?? 0;
-      if (area && room) {
-        const { width: canvasW, height: canvasH } = getCanvasSizePx(room.widthM, room.lengthM);
-        const { width: areaW, height: areaH } = getAreaSizePx(widthM, lengthM);
-        x = (Math.max(0, Math.min((area.x / 100) * canvasW, canvasW - areaW)) / canvasW) * 100;
-        y = (Math.max(0, Math.min((area.y / 100) * canvasH, canvasH - areaH)) / canvasH) * 100;
-      }
-
-      await resizeAreaMutation.mutateAsync({ areaId, widthM, lengthM, x, y });
-    },
-    [areasQuery.data, layoutsQuery.data, roomsQuery.data, resizeAreaMutation],
-  );
-
-  const handleAddTableType = useCallback(
-    async (data: Omit<TableType, "id">) => {
-      const d = await createTableTypeMutation.mutateAsync(data);
-      queryClient.setQueryData<TableType[]>(tableTypesQueryKey, (prev) =>
-        prev ? [...prev, apiTableTypeToTableType(d)] : [apiTableTypeToTableType(d)],
-      );
-    },
-    [createTableTypeMutation, queryClient, tableTypesQueryKey],
-  );
-
-  const handleUpdateTableType = useCallback(
-    async (id: string, data: Partial<Omit<TableType, "id">>) => {
-      const d = await updateTableTypeMutation.mutateAsync({ id, data });
-      queryClient.setQueryData<TableType[]>(tableTypesQueryKey, (prev) =>
-        prev ? prev.map((tt) => (tt.id === id ? apiTableTypeToTableType(d) : tt)) : prev,
-      );
-    },
-    [queryClient, tableTypesQueryKey, updateTableTypeMutation],
-  );
-
-  const handleArchiveTableType = useCallback(
-    (id: string) => handleUpdateTableType(id, { active: false }),
-    [handleUpdateTableType],
-  );
-
-  const handleRestoreTableType = useCallback(
-    (id: string) => handleUpdateTableType(id, { active: true }),
-    [handleUpdateTableType],
-  );
 
   if (!visible) return null;
 

--- a/frontend/src/components/admin/PeopleManagement.tsx
+++ b/frontend/src/components/admin/PeopleManagement.tsx
@@ -102,7 +102,10 @@ export default function PeopleManagement({
     staleTime: 30 * 1000,
     retry: false,
   });
-  const displayedPeople = debouncedQ ? (peopleSearchQuery.data ?? []) : people;
+  const displayedPeople = useMemo(
+    () => (debouncedQ ? (peopleSearchQuery.data ?? []) : people),
+    [debouncedQ, people, peopleSearchQuery.data],
+  );
 
   const preFiltered = useMemo(
     () =>

--- a/frontend/src/hooks/useAdminDashboardData.ts
+++ b/frontend/src/hooks/useAdminDashboardData.ts
@@ -74,7 +74,7 @@ export function useAdminDashboardData({
   );
 
   const emailDuplicates = useMemo(() => {
-    if (!detailRegistration) return [];
+    if (!detailRegistration || !detailRegistration.person.email) return [];
     const personEmail = detailRegistration.person.email.toLowerCase();
     return people
       .filter(

--- a/frontend/src/hooks/useAdminDashboardData.ts
+++ b/frontend/src/hooks/useAdminDashboardData.ts
@@ -1,0 +1,100 @@
+import { useMemo } from "react";
+import type { ActiveEdition } from "@/hooks/useActiveEdition";
+import type { Person } from "@/types/person";
+import type { Registration } from "@/types/registration";
+import { isRegistrationInEdition } from "@/utils/adminUtils";
+import { toLocalDateKey } from "@/utils/dateUtils";
+
+interface UseAdminDashboardDataOptions {
+  activeEdition: ActiveEdition;
+  detailRegistration: Registration | null;
+  people: Person[];
+  registrations: Registration[];
+}
+
+export function useAdminDashboardData({
+  activeEdition,
+  detailRegistration,
+  people,
+  registrations,
+}: UseAdminDashboardDataOptions) {
+  const todayKey = useMemo(() => toLocalDateKey(new Date()), []);
+  const activeEditionDateKeys = useMemo(
+    () => activeEdition.dates.map((date) => toLocalDateKey(date)),
+    [activeEdition.dates],
+  );
+  const activeDayIndex = activeEditionDateKeys.indexOf(todayKey);
+  const isActiveEditionDay = activeDayIndex >= 0;
+
+  const activeEditionStats = useMemo(() => {
+    let checkedIn = 0;
+    let total = 0;
+    const eventIdsToday = new Set(
+      activeEdition.events.filter((event) => event.date === todayKey).map((event) => event.id),
+    );
+
+    for (const registration of registrations) {
+      if (registration.status === "cancelled") continue;
+      if (!isRegistrationInEdition(registration, activeEdition.id)) continue;
+      const guestCount = Math.max(0, registration.guestCount ?? 0);
+      total += guestCount;
+      if (registration.checkedIn) checkedIn += guestCount;
+    }
+
+    return { checkedIn, total, eventsToday: eventIdsToday.size };
+  }, [activeEdition.events, activeEdition.id, registrations, todayKey]);
+
+  const layoutDayOptions = useMemo(() => {
+    const uniqueDates = [...new Set(activeEdition.events.map((event) => event.date))]
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b));
+
+    return uniqueDates.map((date) => ({
+      date,
+      label: new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
+        weekday: "long",
+        month: "short",
+        day: "numeric",
+      }),
+    }));
+  }, [activeEdition.events]);
+
+  const registrationCountByPersonId = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const registration of registrations) {
+      if (registration.personId == null) continue;
+      counts[registration.personId] = (counts[registration.personId] ?? 0) + 1;
+    }
+    return Object.fromEntries(people.map((person) => [person.id, counts[person.id] ?? 0]));
+  }, [people, registrations]);
+
+  const volunteers = useMemo(
+    () => people.filter((person) => person.roles.includes("volunteer")),
+    [people],
+  );
+
+  const emailDuplicates = useMemo(() => {
+    if (!detailRegistration) return [];
+    const personEmail = detailRegistration.person.email.toLowerCase();
+    return people
+      .filter(
+        (person) =>
+          person.id !== detailRegistration.personId &&
+          person.email &&
+          person.email.toLowerCase() === personEmail,
+      )
+      .map((person) => ({ id: person.id, name: person.name }));
+  }, [detailRegistration, people]);
+
+  return {
+    activeDayIndex,
+    activeEditionDateKeys,
+    activeEditionStats,
+    emailDuplicates,
+    isActiveEditionDay,
+    layoutDayOptions,
+    registrationCountByPersonId,
+    todayKey,
+    volunteers,
+  };
+}

--- a/frontend/src/hooks/useAdminPeopleActions.ts
+++ b/frontend/src/hooks/useAdminPeopleActions.ts
@@ -1,0 +1,348 @@
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+import { type QueryClient, type QueryKey } from "@tanstack/react-query";
+import type { MemberFormData } from "@/components/admin/MemberFormModal";
+import type { PersonFormData } from "@/components/admin/PersonFormModal";
+import type { VolunteerFormData } from "@/components/admin/VolunteerFormModal";
+import type { Registration } from "@/types/registration";
+import { type Person, apiToPerson } from "@/types/person";
+import { usePeopleMutations } from "@/hooks/usePeopleMutations";
+import {
+  mergeVolunteerPerson,
+  replacePersonById,
+  replaceVolunteerById,
+  syncMembersWithPerson,
+} from "@/utils/adminApiMappers";
+
+interface UseAdminPeopleActionsOptions {
+  authHeaders: () => Record<string, string>;
+  exhibitorsQueryKey: QueryKey;
+  membersQueryKey: QueryKey;
+  people: Person[];
+  peopleQueryKey: QueryKey;
+  queryClient: QueryClient;
+  registrationsQueryKey: QueryKey;
+  setDetailRegistration: Dispatch<SetStateAction<Registration | null>>;
+}
+
+export function useAdminPeopleActions({
+  authHeaders,
+  exhibitorsQueryKey,
+  membersQueryKey,
+  people,
+  peopleQueryKey,
+  queryClient,
+  registrationsQueryKey,
+  setDetailRegistration,
+}: UseAdminPeopleActionsOptions) {
+  const {
+    mergePeopleMutation,
+    createMemberMutation,
+    updateMemberMutation,
+    deleteMemberMutation,
+    createPersonMutation,
+    updatePersonMutation,
+    deletePersonMutation,
+    createVolunteerMutation,
+    updateVolunteerMutation,
+    deleteVolunteerMutation,
+  } = usePeopleMutations({
+    queryClient,
+    authHeaders,
+    peopleQueryKey,
+    membersQueryKey,
+    registrationsQueryKey,
+    exhibitorsQueryKey,
+  });
+
+  const handleMergePeople = useCallback(
+    async (canonicalId: string, duplicateId: string) => {
+      const updated = await mergePeopleMutation.mutateAsync({ canonicalId, duplicateId });
+      const canonicalPerson = apiToPerson(updated as Record<string, unknown>);
+      const duplicate = people.find((person) => person.id === duplicateId);
+      const existingCanonical = people.find((person) => person.id === canonicalId);
+      const shouldPreserveVolunteerData =
+        canonicalPerson.roles.includes("volunteer") ||
+        existingCanonical?.roles.includes("volunteer") ||
+        duplicate?.roles.includes("volunteer");
+      const mergedCanonical = shouldPreserveVolunteerData
+        ? mergeVolunteerPerson(existingCanonical, {
+            ...canonicalPerson,
+            helpPeriods: existingCanonical?.helpPeriods ?? duplicate?.helpPeriods ?? [],
+          })
+        : canonicalPerson;
+
+      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
+        prev
+          ? prev
+              .filter((person) => person.id !== duplicateId)
+              .map((person) => (person.id === canonicalId ? mergedCanonical : person))
+          : prev,
+      );
+      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
+        prev
+          ? syncMembersWithPerson(
+              prev.filter((member) => member.id !== duplicateId),
+              mergedCanonical,
+            )
+          : prev,
+      );
+      queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
+        prev
+          ? prev.map((registration) =>
+              registration.personId === duplicateId
+                ? { ...registration, personId: canonicalId, person: canonicalPerson }
+                : registration.personId === canonicalId
+                  ? { ...registration, person: canonicalPerson }
+                  : registration,
+            )
+          : prev,
+      );
+      queryClient.setQueryData<
+        { id: number; name: string; active: boolean; contactPersonId: string | null }[]
+      >(exhibitorsQueryKey, (prev) =>
+        prev
+          ? prev.map((exhibitor) =>
+              exhibitor.contactPersonId === duplicateId
+                ? { ...exhibitor, contactPersonId: canonicalId }
+                : exhibitor,
+            )
+          : prev,
+      );
+    },
+    [
+      exhibitorsQueryKey,
+      membersQueryKey,
+      mergePeopleMutation,
+      people,
+      peopleQueryKey,
+      queryClient,
+      registrationsQueryKey,
+    ],
+  );
+
+  const handleCreateMember = useCallback(
+    async (data: MemberFormData) => {
+      const response = await createMemberMutation.mutateAsync(data);
+      const createdMember = apiToPerson(response as Record<string, unknown>);
+      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
+        prev ? [createdMember, ...prev] : [createdMember],
+      );
+      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
+        prev ? [createdMember, ...prev] : [createdMember],
+      );
+    },
+    [createMemberMutation, membersQueryKey, peopleQueryKey, queryClient],
+  );
+
+  const handleUpdateMember = useCallback(
+    async (id: string, data: MemberFormData) => {
+      const response = await updateMemberMutation.mutateAsync({ id, data });
+      const updatedMember = apiToPerson(response as Record<string, unknown>);
+      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
+        prev ? prev.map((member) => (member.id === id ? updatedMember : member)) : prev,
+      );
+      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
+        prev ? replacePersonById(prev, updatedMember) : prev,
+      );
+      queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
+        prev
+          ? prev.map((registration) =>
+              registration.personId === id
+                ? {
+                    ...registration,
+                    person: {
+                      id: updatedMember.id,
+                      name: updatedMember.name,
+                      email: updatedMember.email,
+                      phone: updatedMember.phone,
+                    },
+                  }
+                : registration,
+            )
+          : prev,
+      );
+      setDetailRegistration((prev) =>
+        prev?.person.id === id
+          ? {
+              ...prev,
+              person: {
+                id: updatedMember.id,
+                name: updatedMember.name,
+                email: updatedMember.email,
+                phone: updatedMember.phone,
+              },
+            }
+          : prev,
+      );
+    },
+    [
+      membersQueryKey,
+      peopleQueryKey,
+      queryClient,
+      registrationsQueryKey,
+      setDetailRegistration,
+      updateMemberMutation,
+    ],
+  );
+
+  const handleDeleteMember = useCallback(
+    async (id: string) => {
+      await deleteMemberMutation.mutateAsync(id);
+      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
+        prev ? prev.filter((member) => member.id !== id) : prev,
+      );
+      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
+        prev ? prev.filter((person) => person.id !== id) : prev,
+      );
+    },
+    [deleteMemberMutation, membersQueryKey, peopleQueryKey, queryClient],
+  );
+
+  const handleCreatePerson = useCallback(
+    async (data: PersonFormData) => {
+      const response = await createPersonMutation.mutateAsync(data);
+      const createdPerson = apiToPerson(response as Record<string, unknown>);
+      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
+        prev ? [createdPerson, ...prev] : [createdPerson],
+      );
+      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
+        prev ? syncMembersWithPerson(prev, createdPerson) : prev,
+      );
+    },
+    [createPersonMutation, membersQueryKey, peopleQueryKey, queryClient],
+  );
+
+  const handleUpdatePerson = useCallback(
+    async (id: string, data: PersonFormData) => {
+      const response = await updatePersonMutation.mutateAsync({ id, data });
+      const updated = apiToPerson(response as Record<string, unknown>);
+      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
+        prev ? replacePersonById(prev, updated) : prev,
+      );
+      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
+        prev ? syncMembersWithPerson(prev, updated) : prev,
+      );
+      queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
+        prev
+          ? prev.map((registration) =>
+              registration.personId === id
+                ? {
+                    ...registration,
+                    person: {
+                      id: updated.id,
+                      name: updated.name,
+                      email: updated.email,
+                      phone: updated.phone,
+                    },
+                  }
+                : registration,
+            )
+          : prev,
+      );
+      setDetailRegistration((prev) =>
+        prev?.person.id === id
+          ? {
+              ...prev,
+              person: {
+                id: updated.id,
+                name: updated.name,
+                email: updated.email,
+                phone: updated.phone,
+              },
+            }
+          : prev,
+      );
+    },
+    [
+      membersQueryKey,
+      peopleQueryKey,
+      queryClient,
+      registrationsQueryKey,
+      setDetailRegistration,
+      updatePersonMutation,
+    ],
+  );
+
+  const handleDeletePerson = useCallback(
+    async (id: string) => {
+      await deletePersonMutation.mutateAsync(id);
+      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
+        prev ? prev.filter((person) => person.id !== id) : prev,
+      );
+      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
+        prev ? prev.filter((member) => member.id !== id) : prev,
+      );
+    },
+    [deletePersonMutation, membersQueryKey, peopleQueryKey, queryClient],
+  );
+
+  const handleCreateVolunteer = useCallback(
+    async (data: VolunteerFormData) => {
+      const response = await createVolunteerMutation.mutateAsync(data);
+      const createdVolunteer = apiToPerson(response as Record<string, unknown>);
+      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
+        prev ? [mergeVolunteerPerson(undefined, createdVolunteer), ...prev] : prev,
+      );
+    },
+    [createVolunteerMutation, peopleQueryKey, queryClient],
+  );
+
+  const handleUpdateVolunteer = useCallback(
+    async (id: string, data: VolunteerFormData) => {
+      const response = await updateVolunteerMutation.mutateAsync({ id, data });
+      const updatedVolunteer = apiToPerson(response as Record<string, unknown>);
+      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
+        prev ? replaceVolunteerById(prev, updatedVolunteer) : prev,
+      );
+      queryClient.setQueryData<Person[]>(membersQueryKey, (prev) =>
+        prev
+          ? prev.map((member) =>
+              member.id === id
+                ? {
+                    ...member,
+                    name: updatedVolunteer.name,
+                    address: updatedVolunteer.address,
+                    active: updatedVolunteer.active,
+                    updatedAt: updatedVolunteer.updatedAt,
+                  }
+                : member,
+            )
+          : prev,
+      );
+    },
+    [membersQueryKey, peopleQueryKey, queryClient, updateVolunteerMutation],
+  );
+
+  const handleDeleteVolunteer = useCallback(
+    async (id: string) => {
+      await deleteVolunteerMutation.mutateAsync(id);
+      queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>
+        prev
+          ? prev.map((person) =>
+              person.id !== id
+                ? person
+                : {
+                    ...person,
+                    roles: person.roles.filter((role) => role !== "volunteer"),
+                    helpPeriods: [],
+                  },
+            )
+          : prev,
+      );
+    },
+    [deleteVolunteerMutation, peopleQueryKey, queryClient],
+  );
+
+  return {
+    handleCreateMember,
+    handleCreatePerson,
+    handleCreateVolunteer,
+    handleDeleteMember,
+    handleDeletePerson,
+    handleDeleteVolunteer,
+    handleMergePeople,
+    handleUpdateMember,
+    handleUpdatePerson,
+    handleUpdateVolunteer,
+  };
+}

--- a/frontend/src/hooks/useAdminQueries.ts
+++ b/frontend/src/hooks/useAdminQueries.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import type { ActiveEdition } from "@/hooks/useActiveEdition";
 import {
   createAdminRegistrationsCollection,
   registerAdminRegistrationsCollection,
@@ -24,7 +23,6 @@ interface UseAdminQueriesOptions {
   visible: boolean;
   isAuthenticated: boolean;
   authHeaders: () => Record<string, string>;
-  activeEdition: ActiveEdition;
 }
 
 export const ADMIN_RESOURCE_KEYS = [
@@ -53,7 +51,6 @@ export function useAdminQueries({
   visible,
   isAuthenticated,
   authHeaders,
-  activeEdition,
 }: UseAdminQueriesOptions) {
   const queryClient = useQueryClient();
 
@@ -167,21 +164,6 @@ export function useAdminQueries({
     membersQuery,
   ];
 
-  const layoutDayOptions = useMemo(() => {
-    const uniqueDates = [...new Set(activeEdition.events.map((event) => event.date))]
-      .filter(Boolean)
-      .sort((a, b) => a.localeCompare(b));
-
-    return uniqueDates.map((date) => ({
-      date,
-      label: new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
-        weekday: "long",
-        month: "short",
-        day: "numeric",
-      }),
-    }));
-  }, [activeEdition.events]);
-
   const loadData = useCallback(async () => {
     await queryClient.refetchQueries({
       predicate: (query) => shouldRefetchAdminResourceQuery(query.queryKey),
@@ -214,8 +196,6 @@ export function useAdminQueries({
     areasQueryKey,
     peopleQueryKey,
     membersQueryKey,
-    // Layout helper
-    layoutDayOptions,
     // Refetch all
     loadData,
   };

--- a/frontend/src/hooks/useAdminRegistrationActions.ts
+++ b/frontend/src/hooks/useAdminRegistrationActions.ts
@@ -152,7 +152,6 @@ export function useAdminRegistrationActions({
       } catch (err) {
         devError("Failed to assign table", err);
         setRegistrationError(err instanceof Error ? err.message : m.admin_error_assign_table());
-        throw err;
       }
     },
     [
@@ -222,7 +221,6 @@ export function useAdminRegistrationActions({
       } catch (err) {
         devError("Failed to update bottle delivery status", err);
         setRegistrationError(err instanceof Error ? err.message : m.admin_error_bottle_delivery());
-        throw err;
       }
     },
     [queryClient, registrationsQueryKey, setDetailRegistration, setRegistrationError, updateRegistrationMutation],
@@ -249,7 +247,6 @@ export function useAdminRegistrationActions({
       } catch (err) {
         devError("Failed to check in guest", err);
         setRegistrationError(err instanceof Error ? err.message : m.admin_error_check_in());
-        throw err;
       }
     },
     [queryClient, registrationsQueryKey, setDetailRegistration, setRegistrationError, updateRegistrationMutation],
@@ -276,7 +273,6 @@ export function useAdminRegistrationActions({
       } catch (err) {
         devError("Failed to issue strap", err);
         setRegistrationError(err instanceof Error ? err.message : m.admin_error_issue_strap());
-        throw err;
       }
     },
     [queryClient, registrationsQueryKey, setDetailRegistration, setRegistrationError, updateRegistrationMutation],

--- a/frontend/src/hooks/useAdminRegistrationActions.ts
+++ b/frontend/src/hooks/useAdminRegistrationActions.ts
@@ -1,0 +1,295 @@
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+import { type QueryClient, type QueryKey } from "@tanstack/react-query";
+import { m } from "@/paraglide/messages";
+import type {
+  OrderItem,
+  PaymentStatus,
+  Registration,
+  RegistrationStatus,
+} from "@/types/registration";
+import { apiToRegistration } from "@/types/registrationMapper";
+import type { FloorTable } from "@/types/admin";
+import { useRegistrationAdminMutations } from "@/hooks/useRegistrationAdminMutations";
+import { fetchJsonOrThrowWithUnauthorized } from "@/utils/adminApi";
+import { devError } from "@/utils/devLog";
+
+interface UseAdminRegistrationActionsOptions {
+  authHeaders: () => Record<string, string>;
+  queryClient: QueryClient;
+  registrationsQueryKey: QueryKey;
+  tablesQueryKey: QueryKey;
+  setDetailRegistration: Dispatch<SetStateAction<Registration | null>>;
+  setRegistrationError: Dispatch<SetStateAction<string>>;
+}
+
+export function useAdminRegistrationActions({
+  authHeaders,
+  queryClient,
+  registrationsQueryKey,
+  tablesQueryKey,
+  setDetailRegistration,
+  setRegistrationError,
+}: UseAdminRegistrationActionsOptions) {
+  const { updateRegistrationMutation } = useRegistrationAdminMutations({
+    queryClient,
+    authHeaders,
+    registrationsQueryKey,
+    tablesQueryKey,
+  });
+
+  const handleUpdateStatus = useCallback(
+    async (id: string, status: RegistrationStatus) => {
+      try {
+        const updated = apiToRegistration(
+          await updateRegistrationMutation.mutateAsync({
+            id,
+            payload: { status },
+            fallbackMessage: m.admin_error_update_registration(),
+          }),
+        );
+        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
+          prev
+            ? prev.map((registration) =>
+                registration.id === id
+                  ? { ...registration, status: updated.status, updatedAt: updated.updatedAt }
+                  : registration,
+              )
+            : prev,
+        );
+        setDetailRegistration((prev) =>
+          prev?.id === id
+            ? { ...prev, status: updated.status, updatedAt: updated.updatedAt }
+            : prev,
+        );
+      } catch (err) {
+        devError("Failed to update registration status", err);
+        setRegistrationError(err instanceof Error ? err.message : m.admin_error_update_registration());
+        throw err;
+      }
+    },
+    [queryClient, registrationsQueryKey, setDetailRegistration, setRegistrationError, updateRegistrationMutation],
+  );
+
+  const handleUpdatePayment = useCallback(
+    async (id: string, paymentStatus: PaymentStatus) => {
+      try {
+        const updated = apiToRegistration(
+          await updateRegistrationMutation.mutateAsync({
+            id,
+            payload: { payment_status: paymentStatus },
+            fallbackMessage: m.admin_error_update_payment(),
+          }),
+        );
+        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
+          prev
+            ? prev.map((registration) =>
+                registration.id === id
+                  ? {
+                      ...registration,
+                      paymentStatus: updated.paymentStatus,
+                      updatedAt: updated.updatedAt,
+                    }
+                  : registration,
+              )
+            : prev,
+        );
+        setDetailRegistration((prev) =>
+          prev?.id === id
+            ? { ...prev, paymentStatus: updated.paymentStatus, updatedAt: updated.updatedAt }
+            : prev,
+        );
+      } catch (err) {
+        devError("Failed to update payment status", err);
+        setRegistrationError(err instanceof Error ? err.message : m.admin_error_update_payment());
+        throw err;
+      }
+    },
+    [queryClient, registrationsQueryKey, setDetailRegistration, setRegistrationError, updateRegistrationMutation],
+  );
+
+  const handleAssignTable = useCallback(
+    async (registrationId: string, tableId: string | undefined) => {
+      try {
+        const updated = apiToRegistration(
+          await updateRegistrationMutation.mutateAsync({
+            id: registrationId,
+            payload: { table_id: tableId ?? null },
+            fallbackMessage: m.admin_error_assign_table(),
+          }),
+        );
+        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
+          prev
+            ? prev.map((registration) =>
+                registration.id === registrationId
+                  ? { ...registration, tableId: updated.tableId, updatedAt: updated.updatedAt }
+                  : registration,
+              )
+            : prev,
+        );
+        queryClient.setQueryData<FloorTable[]>(tablesQueryKey, (prev) =>
+          prev
+            ? prev.map((table) => {
+                const wasAssigned = table.registrationIds.includes(registrationId);
+                const shouldBeAssigned = table.id === updated.tableId;
+                if (wasAssigned && !shouldBeAssigned) {
+                  return {
+                    ...table,
+                    registrationIds: table.registrationIds.filter((id) => id !== registrationId),
+                  };
+                }
+                if (!wasAssigned && shouldBeAssigned) {
+                  return { ...table, registrationIds: [...table.registrationIds, registrationId] };
+                }
+                return table;
+              })
+            : prev,
+        );
+        setDetailRegistration((prev) =>
+          prev?.id === registrationId
+            ? { ...prev, tableId: updated.tableId, updatedAt: updated.updatedAt }
+            : prev,
+        );
+      } catch (err) {
+        devError("Failed to assign table", err);
+        setRegistrationError(err instanceof Error ? err.message : m.admin_error_assign_table());
+        throw err;
+      }
+    },
+    [
+      queryClient,
+      registrationsQueryKey,
+      setDetailRegistration,
+      setRegistrationError,
+      tablesQueryKey,
+      updateRegistrationMutation,
+    ],
+  );
+
+  const handleAddRegistration = useCallback(
+    (registration: Registration) => {
+      queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
+        prev ? [registration, ...prev] : [registration],
+      );
+    },
+    [queryClient, registrationsQueryKey],
+  );
+
+  const handleViewDetail = useCallback(
+    async (registration: Registration) => {
+      try {
+        const data = await fetchJsonOrThrowWithUnauthorized<Record<string, unknown>>(
+          `/api/registrations/${registration.id}`,
+          { headers: authHeaders() },
+          m.admin_error_load_data(),
+        );
+        setDetailRegistration(apiToRegistration(data));
+      } catch (err) {
+        devError("Failed to fetch registration detail, falling back to list data", err);
+        setDetailRegistration(registration);
+      }
+    },
+    [authHeaders, setDetailRegistration],
+  );
+
+  const handleToggleDelivered = useCallback(
+    async (registrationId: string, updatedOrders: OrderItem[]) => {
+      try {
+        const updated = apiToRegistration(
+          await updateRegistrationMutation.mutateAsync({
+            id: registrationId,
+            payload: {
+              pre_orders: updatedOrders.map((order) => ({
+                product_id: order.productId,
+                name: order.name,
+                quantity: order.quantity,
+                delivered_quantity: order.deliveredQuantity,
+                price: order.price,
+                category: order.category,
+                delivered: order.delivered,
+              })),
+            },
+            fallbackMessage: m.admin_error_bottle_delivery(),
+          }),
+        );
+        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
+          prev
+            ? prev.map((registration) =>
+                registration.id === registrationId ? updated : registration,
+              )
+            : prev,
+        );
+        setDetailRegistration((prev) => (prev?.id === registrationId ? updated : prev));
+      } catch (err) {
+        devError("Failed to update bottle delivery status", err);
+        setRegistrationError(err instanceof Error ? err.message : m.admin_error_bottle_delivery());
+        throw err;
+      }
+    },
+    [queryClient, registrationsQueryKey, setDetailRegistration, setRegistrationError, updateRegistrationMutation],
+  );
+
+  const handleCheckIn = useCallback(
+    async (registrationId: string) => {
+      try {
+        const updated = apiToRegistration(
+          await updateRegistrationMutation.mutateAsync({
+            id: registrationId,
+            payload: { checked_in: true },
+            fallbackMessage: m.admin_error_check_in(),
+          }),
+        );
+        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
+          prev
+            ? prev.map((registration) =>
+                registration.id === registrationId ? updated : registration,
+              )
+            : prev,
+        );
+        setDetailRegistration((prev) => (prev?.id === registrationId ? updated : prev));
+      } catch (err) {
+        devError("Failed to check in guest", err);
+        setRegistrationError(err instanceof Error ? err.message : m.admin_error_check_in());
+        throw err;
+      }
+    },
+    [queryClient, registrationsQueryKey, setDetailRegistration, setRegistrationError, updateRegistrationMutation],
+  );
+
+  const handleIssueStrap = useCallback(
+    async (registrationId: string) => {
+      try {
+        const updated = apiToRegistration(
+          await updateRegistrationMutation.mutateAsync({
+            id: registrationId,
+            payload: { strap_issued: true },
+            fallbackMessage: m.admin_error_issue_strap(),
+          }),
+        );
+        queryClient.setQueryData<Registration[]>(registrationsQueryKey, (prev) =>
+          prev
+            ? prev.map((registration) =>
+                registration.id === registrationId ? updated : registration,
+              )
+            : prev,
+        );
+        setDetailRegistration((prev) => (prev?.id === registrationId ? updated : prev));
+      } catch (err) {
+        devError("Failed to issue strap", err);
+        setRegistrationError(err instanceof Error ? err.message : m.admin_error_issue_strap());
+        throw err;
+      }
+    },
+    [queryClient, registrationsQueryKey, setDetailRegistration, setRegistrationError, updateRegistrationMutation],
+  );
+
+  return {
+    handleAddRegistration,
+    handleAssignTable,
+    handleCheckIn,
+    handleIssueStrap,
+    handleToggleDelivered,
+    handleUpdatePayment,
+    handleUpdateStatus,
+    handleViewDetail,
+  };
+}

--- a/frontend/src/hooks/useAdminVenueActions.ts
+++ b/frontend/src/hooks/useAdminVenueActions.ts
@@ -1,0 +1,445 @@
+import { useCallback } from "react";
+import { type QueryClient, type QueryKey } from "@tanstack/react-query";
+import { m } from "@/paraglide/messages";
+import type { FloorArea, FloorTable, Layout, Room, TableType, Venue } from "@/types/admin";
+import { useVenueMutations } from "@/hooks/useVenueMutations";
+import { fetchJsonOrThrowWithUnauthorized } from "@/utils/adminApi";
+import { invalidateAdmin } from "@/utils/queryInvalidation";
+import { getAreaSizePx, getCanvasSizePx } from "@/utils/layoutUtils";
+import {
+  apiAreaToArea,
+  apiLayoutToLayout,
+  apiRoomToRoom,
+  apiTableToTable,
+  apiTableTypeToTableType,
+  apiVenueToVenue,
+} from "@/utils/adminApiMappers";
+
+interface UseAdminVenueActionsOptions {
+  activeEditionId: string;
+  areasQueryKey: QueryKey;
+  authHeaders: () => Record<string, string>;
+  layoutsQueryKey: QueryKey;
+  queryClient: QueryClient;
+  roomsQueryKey: QueryKey;
+  tableTypesQueryKey: QueryKey;
+  tablesQueryKey: QueryKey;
+  venuesQueryKey: QueryKey;
+}
+
+export function useAdminVenueActions({
+  activeEditionId,
+  areasQueryKey,
+  authHeaders,
+  layoutsQueryKey,
+  queryClient,
+  roomsQueryKey,
+  tableTypesQueryKey,
+  tablesQueryKey,
+  venuesQueryKey,
+}: UseAdminVenueActionsOptions) {
+  const {
+    assignAreaMutation,
+    changeTableTypeMutation,
+    createAreaMutation,
+    createLayoutMutation,
+    createRoomMutation,
+    createTableMutation,
+    createTableTypeMutation,
+    createVenueMutation,
+    deleteAreaMutation,
+    deleteLayoutMutation,
+    deleteTableMutation,
+    deleteVenueMutation,
+    moveAreaMutation,
+    moveTableMutation,
+    resizeAreaMutation,
+    rotateAreaMutation,
+    rotateTableMutation,
+    updateAreaLabelMutation,
+    updateRoomMutation,
+    updateTableNameMutation,
+    updateTableTypeMutation,
+    updateVenueMutation,
+  } = useVenueMutations({
+    queryClient,
+    authHeaders,
+    activeEditionId,
+    tablesQueryKey,
+    venuesQueryKey,
+    roomsQueryKey,
+    tableTypesQueryKey,
+    layoutsQueryKey,
+    areasQueryKey,
+  });
+
+  const handleAddTable = useCallback(
+    async (name: string, capacity: number, layoutId: string, tableTypeId: string) => {
+      const data = await createTableMutation.mutateAsync({ name, capacity, layoutId, tableTypeId });
+      const table = (data.table ?? data) as Record<string, unknown>;
+      queryClient.setQueryData<FloorTable[]>(tablesQueryKey, (prev) =>
+        prev ? [...prev, apiTableToTable(table)] : [apiTableToTable(table)],
+      );
+    },
+    [createTableMutation, queryClient, tablesQueryKey],
+  );
+
+  const handleMoveTable = useCallback(
+    (tableId: string, x: number, y: number) => {
+      moveTableMutation.mutate({ tableId, x, y });
+    },
+    [moveTableMutation],
+  );
+
+  const handleRotateTable = useCallback(
+    (tableId: string, rotation: number) => {
+      rotateTableMutation.mutate({ tableId, rotation: ((rotation % 360) + 360) % 360 });
+    },
+    [rotateTableMutation],
+  );
+
+  const handleDeleteTable = useCallback(
+    async (tableId: string) => {
+      await deleteTableMutation.mutateAsync(tableId);
+      queryClient.setQueryData<FloorTable[]>(tablesQueryKey, (prev) =>
+        prev ? prev.filter((t) => t.id !== tableId) : prev,
+      );
+    },
+    [deleteTableMutation, queryClient, tablesQueryKey],
+  );
+
+  const handleChangeTableType = useCallback(
+    async (tableId: string, tableTypeId: string) => {
+      await changeTableTypeMutation.mutateAsync({ tableId, tableTypeId });
+    },
+    [changeTableTypeMutation],
+  );
+
+  const handleUpdateTable = useCallback(
+    async (tableId: string, name: string) => {
+      await updateTableNameMutation.mutateAsync({ tableId, name });
+    },
+    [updateTableNameMutation],
+  );
+
+  const handleAddVenue = useCallback(
+    async (name: string, address: string, city: string, postalCode: string, country: string) => {
+      const d = await createVenueMutation.mutateAsync({ name, address, city, postalCode, country });
+      queryClient.setQueryData<Venue[]>(venuesQueryKey, (prev) =>
+        prev ? [...prev, apiVenueToVenue(d)] : [apiVenueToVenue(d)],
+      );
+    },
+    [createVenueMutation, queryClient, venuesQueryKey],
+  );
+
+  const handleArchiveVenue = useCallback(
+    async (venueId: string) => {
+      const d = await updateVenueMutation.mutateAsync({ venueId, active: false });
+      queryClient.setQueryData<Venue[]>(venuesQueryKey, (prev) =>
+        prev ? prev.map((v) => (v.id === venueId ? apiVenueToVenue(d) : v)) : prev,
+      );
+    },
+    [queryClient, updateVenueMutation, venuesQueryKey],
+  );
+
+  const handleRestoreVenue = useCallback(
+    async (venueId: string) => {
+      const d = await updateVenueMutation.mutateAsync({ venueId, active: true });
+      queryClient.setQueryData<Venue[]>(venuesQueryKey, (prev) =>
+        prev ? prev.map((v) => (v.id === venueId ? apiVenueToVenue(d) : v)) : prev,
+      );
+    },
+    [queryClient, updateVenueMutation, venuesQueryKey],
+  );
+
+  const handleDeleteVenue = useCallback(
+    async (venueId: string) => {
+      await deleteVenueMutation.mutateAsync(venueId);
+      queryClient.setQueryData<Venue[]>(venuesQueryKey, (prev) =>
+        prev ? prev.filter((v) => v.id !== venueId) : prev,
+      );
+      // Cascade: remove rooms and their layouts/tables/areas from local state
+      const allRooms = queryClient.getQueryData<Room[]>(roomsQueryKey) ?? [];
+      const venueRoomIds = allRooms.filter((r) => r.venueId === venueId).map((r) => r.id);
+      queryClient.setQueryData<Room[]>(roomsQueryKey, (prev) =>
+        prev ? prev.filter((r) => r.venueId !== venueId) : prev,
+      );
+      const allLayouts = queryClient.getQueryData<Layout[]>(layoutsQueryKey) ?? [];
+      const venueLayoutIds = allLayouts
+        .filter((l) => venueRoomIds.includes(l.roomId ?? ""))
+        .map((l) => l.id);
+      queryClient.setQueryData<Layout[]>(layoutsQueryKey, (prev) =>
+        prev ? prev.filter((l) => !venueRoomIds.includes(l.roomId ?? "")) : prev,
+      );
+      queryClient.setQueryData<FloorTable[]>(tablesQueryKey, (prev) =>
+        prev ? prev.filter((t) => !venueLayoutIds.includes(t.layoutId)) : prev,
+      );
+      queryClient.setQueryData<FloorArea[]>(areasQueryKey, (prev) =>
+        prev ? prev.filter((a) => !venueLayoutIds.includes(a.layoutId)) : prev,
+      );
+    },
+    [
+      areasQueryKey,
+      deleteVenueMutation,
+      layoutsQueryKey,
+      queryClient,
+      roomsQueryKey,
+      tablesQueryKey,
+      venuesQueryKey,
+    ],
+  );
+
+  const handleAddRoom = useCallback(
+    async (venueId: string, name: string, widthM: number, lengthM: number, color: string) => {
+      const data = await createRoomMutation.mutateAsync({ venueId, name, widthM, lengthM, color });
+      queryClient.setQueryData<Room[]>(roomsQueryKey, (prev) =>
+        prev ? [...prev, apiRoomToRoom(data)] : [apiRoomToRoom(data)],
+      );
+    },
+    [createRoomMutation, queryClient, roomsQueryKey],
+  );
+
+  const handleArchiveRoom = useCallback(
+    async (roomId: string) => {
+      const data = await updateRoomMutation.mutateAsync({
+        roomId,
+        active: false,
+        fallbackMessage: m.admin_error_delete_room(),
+      });
+      queryClient.setQueryData<Room[]>(roomsQueryKey, (prev) =>
+        prev ? prev.map((r) => (r.id === roomId ? apiRoomToRoom(data) : r)) : prev,
+      );
+    },
+    [queryClient, roomsQueryKey, updateRoomMutation],
+  );
+
+  const handleRestoreRoom = useCallback(
+    async (roomId: string) => {
+      const data = await updateRoomMutation.mutateAsync({
+        roomId,
+        active: true,
+        fallbackMessage: m.admin_content_error_save(),
+      });
+      queryClient.setQueryData<Room[]>(roomsQueryKey, (prev) =>
+        prev ? prev.map((r) => (r.id === roomId ? apiRoomToRoom(data) : r)) : prev,
+      );
+    },
+    [queryClient, roomsQueryKey, updateRoomMutation],
+  );
+
+  const handleAddLayout = useCallback(
+    async (
+      roomId: string,
+      date: string,
+      label?: string,
+      copyFromLayoutId?: string | null,
+      copyOptions?: { tables: boolean; areas: boolean },
+    ) => {
+      if (copyFromLayoutId) {
+        const shouldCopyTables = copyOptions?.tables ?? true;
+        const shouldCopyAreas = copyOptions?.areas ?? true;
+        const copied = await fetchJsonOrThrowWithUnauthorized<Record<string, unknown>>(
+          `/api/layouts/${copyFromLayoutId}/copy`,
+          {
+            method: "POST",
+            headers: authHeaders(),
+            body: JSON.stringify({
+              edition_id: activeEditionId,
+              room_id: roomId,
+              date,
+              ...(label?.trim() ? { label: label.trim() } : {}),
+              copy_tables: shouldCopyTables,
+              copy_areas: shouldCopyAreas,
+            }),
+          },
+          m.admin_error_add_layout(),
+        );
+        const createdLayout = apiLayoutToLayout(copied);
+        queryClient.setQueryData<Layout[]>(layoutsQueryKey, (prev) =>
+          prev ? [...prev, createdLayout] : [createdLayout],
+        );
+        await invalidateAdmin(queryClient, [layoutsQueryKey, tablesQueryKey, areasQueryKey]);
+        return;
+      }
+
+      const d = await createLayoutMutation.mutateAsync({ roomId, date, label });
+      queryClient.setQueryData<Layout[]>(layoutsQueryKey, (prev) =>
+        prev ? [...prev, apiLayoutToLayout(d)] : [apiLayoutToLayout(d)],
+      );
+    },
+    [
+      activeEditionId,
+      areasQueryKey,
+      authHeaders,
+      createLayoutMutation,
+      layoutsQueryKey,
+      queryClient,
+      tablesQueryKey,
+    ],
+  );
+
+  const handleDeleteLayout = useCallback(
+    async (layoutId: string) => {
+      await deleteLayoutMutation.mutateAsync(layoutId);
+      queryClient.setQueryData<Layout[]>(layoutsQueryKey, (prev) =>
+        prev ? prev.filter((l) => l.id !== layoutId) : prev,
+      );
+      queryClient.setQueryData<FloorTable[]>(tablesQueryKey, (prev) =>
+        prev ? prev.filter((t) => t.layoutId !== layoutId) : prev,
+      );
+      queryClient.setQueryData<FloorArea[]>(areasQueryKey, (prev) =>
+        prev ? prev.filter((a) => a.layoutId !== layoutId) : prev,
+      );
+    },
+    [areasQueryKey, deleteLayoutMutation, layoutsQueryKey, queryClient, tablesQueryKey],
+  );
+
+  const handleAddArea = useCallback(
+    async (
+      label: string,
+      icon: string,
+      layoutId: string,
+      widthM: number,
+      lengthM: number,
+      exhibitorId?: number,
+    ) => {
+      const data = await createAreaMutation.mutateAsync({
+        label,
+        icon,
+        layoutId,
+        widthM,
+        lengthM,
+        exhibitorId,
+      });
+      queryClient.setQueryData<FloorArea[]>(areasQueryKey, (prev) =>
+        prev ? [...prev, apiAreaToArea(data)] : [apiAreaToArea(data)],
+      );
+    },
+    [areasQueryKey, createAreaMutation, queryClient],
+  );
+
+  const handleMoveArea = useCallback(
+    (areaId: string, x: number, y: number) => {
+      moveAreaMutation.mutate({ areaId, x, y });
+    },
+    [moveAreaMutation],
+  );
+
+  const handleRotateArea = useCallback(
+    (areaId: string, rotation: number) => {
+      rotateAreaMutation.mutate({ areaId, rotation: ((rotation % 360) + 360) % 360 });
+    },
+    [rotateAreaMutation],
+  );
+
+  const handleDeleteArea = useCallback(
+    async (areaId: string) => {
+      await deleteAreaMutation.mutateAsync(areaId);
+      queryClient.setQueryData<FloorArea[]>(areasQueryKey, (prev) =>
+        prev ? prev.filter((a) => a.id !== areaId) : prev,
+      );
+    },
+    [areasQueryKey, deleteAreaMutation, queryClient],
+  );
+
+  const handleAssignAreaToItem = useCallback(
+    async (areaId: string, exhibitorId: number | null, label?: string, icon?: string) => {
+      const body: Record<string, unknown> = { exhibitor_id: exhibitorId };
+      if (label !== undefined) body.label = label;
+      if (icon !== undefined) body.icon = icon;
+      await assignAreaMutation.mutateAsync({ areaId, body });
+    },
+    [assignAreaMutation],
+  );
+
+  const handleUpdateAreaLabel = useCallback(
+    (areaId: string, label: string) => {
+      updateAreaLabelMutation.mutate({ areaId, label });
+    },
+    [updateAreaLabelMutation],
+  );
+
+  const handleResizeArea = useCallback(
+    async (areaId: string, widthM: number, lengthM: number) => {
+      const area = queryClient.getQueryData<FloorArea[]>(areasQueryKey)?.find((a) => a.id === areaId);
+      const layout = queryClient
+        .getQueryData<Layout[]>(layoutsQueryKey)
+        ?.find((l) => l.id === area?.layoutId);
+      const room = queryClient
+        .getQueryData<Room[]>(roomsQueryKey)
+        ?.find((r) => r.id === layout?.roomId);
+
+      // Clamp the area's position so it stays within the canvas after resize.
+      let x = area?.x ?? 0;
+      let y = area?.y ?? 0;
+      if (area && room) {
+        const { width: canvasW, height: canvasH } = getCanvasSizePx(room.widthM, room.lengthM);
+        const { width: areaW, height: areaH } = getAreaSizePx(widthM, lengthM);
+        x = (Math.max(0, Math.min((area.x / 100) * canvasW, canvasW - areaW)) / canvasW) * 100;
+        y = (Math.max(0, Math.min((area.y / 100) * canvasH, canvasH - areaH)) / canvasH) * 100;
+      }
+
+      await resizeAreaMutation.mutateAsync({ areaId, widthM, lengthM, x, y });
+    },
+    [areasQueryKey, layoutsQueryKey, queryClient, resizeAreaMutation, roomsQueryKey],
+  );
+
+  const handleAddTableType = useCallback(
+    async (data: Omit<TableType, "id">) => {
+      const d = await createTableTypeMutation.mutateAsync(data);
+      queryClient.setQueryData<TableType[]>(tableTypesQueryKey, (prev) =>
+        prev ? [...prev, apiTableTypeToTableType(d)] : [apiTableTypeToTableType(d)],
+      );
+    },
+    [createTableTypeMutation, queryClient, tableTypesQueryKey],
+  );
+
+  const handleUpdateTableType = useCallback(
+    async (id: string, data: Partial<Omit<TableType, "id">>) => {
+      const d = await updateTableTypeMutation.mutateAsync({ id, data });
+      queryClient.setQueryData<TableType[]>(tableTypesQueryKey, (prev) =>
+        prev ? prev.map((tt) => (tt.id === id ? apiTableTypeToTableType(d) : tt)) : prev,
+      );
+    },
+    [queryClient, tableTypesQueryKey, updateTableTypeMutation],
+  );
+
+  const handleArchiveTableType = useCallback(
+    (id: string) => handleUpdateTableType(id, { active: false }),
+    [handleUpdateTableType],
+  );
+
+  const handleRestoreTableType = useCallback(
+    (id: string) => handleUpdateTableType(id, { active: true }),
+    [handleUpdateTableType],
+  );
+
+  return {
+    handleAddArea,
+    handleAddLayout,
+    handleAddRoom,
+    handleAddTable,
+    handleAddTableType,
+    handleAddVenue,
+    handleArchiveRoom,
+    handleArchiveTableType,
+    handleArchiveVenue,
+    handleAssignAreaToItem,
+    handleChangeTableType,
+    handleDeleteArea,
+    handleDeleteLayout,
+    handleDeleteTable,
+    handleDeleteVenue,
+    handleMoveArea,
+    handleMoveTable,
+    handleResizeArea,
+    handleRestoreRoom,
+    handleRestoreTableType,
+    handleRestoreVenue,
+    handleRotateArea,
+    handleRotateTable,
+    handleUpdateAreaLabel,
+    handleUpdateTable,
+    handleUpdateTableType,
+  };
+}


### PR DESCRIPTION
## Summary

- Extract AdminDashboard data derivations into `useAdminDashboardData`
- Move active-edition stats, layout day options, volunteer filtering, duplicate-email detection, and registration counts out of the dashboard component
- Memoize `PeopleManagement` search results to satisfy the hook dependency lint rule

## Why

`AdminDashboard.tsx` was still doing selector-style data shaping after the previous migration steps. Keeping those derivations in a dedicated hook makes the dashboard render path easier to follow and leaves the remaining orchestration work available for smaller domain-specific follow-ups.

## Validation

- `pnpm run lint`
- `pnpm run typecheck`