### PR TITLE
Add a staging Android build type

### DIFF
--- a/.github/workflows/android-staging.yml
+++ b/.github/workflows/android-staging.yml
@@ -1,28 +1,23 @@
-name: Android CI
+name: Android Staging APK
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - "android/**"
-      - ".github/workflows/android.yml"
-  push:
-    branches: [main]
-    paths:
-      - "android/**"
-      - ".github/workflows/android.yml"
   workflow_dispatch:
-
-concurrency:
-  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
-  cancel-in-progress: true
+    inputs:
+      api_base_url:
+        description: "Staging API base URL (defaults to the build's placeholder when empty)"
+        required: false
+        type: string
+      oidc_issuer_url:
+        description: "Staging OIDC issuer URL (defaults to the build's placeholder when empty)"
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 jobs:
-  android:
-    name: Lint, Unit Test & Build
+  staging-apk:
+    name: Assemble Staging APK
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -44,26 +39,10 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      - name: Static analysis
-        run: ./gradlew ktlintCheck detekt
-
-      - name: Lint
-        run: ./gradlew lintDebug
-
-      - name: Run unit tests
-        run: ./gradlew testDebugUnitTest
-
-      - name: Assemble debug APK
-        run: ./gradlew assembleDebug
-
-      - name: Upload debug APK
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: debug-apk
-          path: android/app/build/outputs/apk/debug/app-debug.apk
-          retention-days: 7
-
       - name: Assemble staging APK
+        env:
+          CHAMPAGNEFESTIVAL_ANDROID_STAGING_API_BASE_URL: ${{ inputs.api_base_url }}
+          CHAMPAGNEFESTIVAL_ANDROID_STAGING_OIDC_ISSUER_URL: ${{ inputs.oidc_issuer_url }}
         run: ./gradlew assembleStaging
 
       - name: Upload staging APK

--- a/android/README.md
+++ b/android/README.md
@@ -31,9 +31,29 @@ be.champagnefestival.android/
 | Variant | API base URL | OIDC issuer |
 |---------|-------------|-------------|
 | `debug` | `http://10.0.2.2:8000/` (emulator → localhost) | `http://10.0.2.2:9000/…` |
+| `staging` | `https://staging.champagnefestival.tjor.im/` (placeholder, configurable) | `https://staging-auth.tjor.im/…` (placeholder, configurable) |
 | `release` | `https://api.champagnefestival.tjor.im/` | `https://auth.tjor.im/…` |
 
 The API base URL can be overridden at runtime via **Settings → API base URL**.
+
+### Staging variant
+
+`staging` is a debug-signed, debuggable variant with its own application ID
+(`be.champagnefestival.android.staging`), so it installs alongside the debug and
+release apps. Its backend URLs resolve from a Gradle property or environment
+variable of the same name, falling back to the placeholders above:
+
+- `CHAMPAGNEFESTIVAL_ANDROID_STAGING_API_BASE_URL`
+- `CHAMPAGNEFESTIVAL_ANDROID_STAGING_OIDC_ISSUER_URL`
+
+```bash
+./gradlew assembleStaging \
+  -PCHAMPAGNEFESTIVAL_ANDROID_STAGING_API_BASE_URL=https://staging.example.com/
+```
+
+CI can build a distributable staging APK without production signing secrets via
+the manual **Android Staging APK** workflow (`.github/workflows/android-staging.yml`),
+which accepts both URLs as optional inputs.
 
 ## Getting Started
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,6 +8,28 @@ plugins {
 
 fun quoted(value: String) = "\"$value\""
 
+// Resolves a config value from a Gradle property or environment variable of the
+// same name, treating blank values as unset (e.g. an empty workflow input).
+fun resolveConfigValue(
+    name: String,
+    defaultValue: String,
+): String =
+    sequenceOf(
+        providers.gradleProperty(name).orNull,
+        providers.environmentVariable(name).orNull,
+    ).firstOrNull { !it.isNullOrBlank() } ?: defaultValue
+
+val stagingApiBaseUrl =
+    resolveConfigValue(
+        "CHAMPAGNEFESTIVAL_ANDROID_STAGING_API_BASE_URL",
+        "https://staging.champagnefestival.tjor.im/",
+    )
+val stagingOidcIssuerUrl =
+    resolveConfigValue(
+        "CHAMPAGNEFESTIVAL_ANDROID_STAGING_OIDC_ISSUER_URL",
+        "https://staging-auth.tjor.im/realms/champagnefestival",
+    )
+
 val prodCertificatePinHost =
     providers
         .gradleProperty("CHAMPAGNEFESTIVAL_ANDROID_PROD_CERTIFICATE_PIN_HOST")
@@ -41,6 +63,19 @@ android {
             isDebuggable = true
             buildConfigField("String", "API_BASE_URL", "\"http://10.0.2.2:8000/\"")
             buildConfigField("String", "OIDC_ISSUER_URL", "\"http://10.0.2.2:8080/realms/champagnefestival\"")
+            buildConfigField("String", "OIDC_CLIENT_ID", "\"champagnefestival\"")
+            buildConfigField("Boolean", "CERTIFICATE_PINNING_ENABLED", "false")
+            buildConfigField("String", "CERTIFICATE_PIN_HOST", quoted(""))
+            buildConfigField("String", "CERTIFICATE_PINS", quoted(""))
+        }
+        create("staging") {
+            initWith(getByName("debug"))
+            matchingFallbacks += listOf("debug")
+            applicationIdSuffix = ".staging"
+            versionNameSuffix = "-staging"
+            signingConfig = signingConfigs.getByName("debug")
+            buildConfigField("String", "API_BASE_URL", quoted(stagingApiBaseUrl))
+            buildConfigField("String", "OIDC_ISSUER_URL", quoted(stagingOidcIssuerUrl))
             buildConfigField("String", "OIDC_CLIENT_ID", "\"champagnefestival\"")
             buildConfigField("Boolean", "CERTIFICATE_PINNING_ENABLED", "false")
             buildConfigField("String", "CERTIFICATE_PIN_HOST", quoted(""))

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -73,13 +73,8 @@ android {
             matchingFallbacks += listOf("debug")
             applicationIdSuffix = ".staging"
             versionNameSuffix = "-staging"
-            signingConfig = signingConfigs.getByName("debug")
             buildConfigField("String", "API_BASE_URL", quoted(stagingApiBaseUrl))
             buildConfigField("String", "OIDC_ISSUER_URL", quoted(stagingOidcIssuerUrl))
-            buildConfigField("String", "OIDC_CLIENT_ID", "\"champagnefestival\"")
-            buildConfigField("Boolean", "CERTIFICATE_PINNING_ENABLED", "false")
-            buildConfigField("String", "CERTIFICATE_PIN_HOST", quoted(""))
-            buildConfigField("String", "CERTIFICATE_PINS", quoted(""))
         }
         release {
             isMinifyEnabled = true


### PR DESCRIPTION
Closes #626

## What

- Adds a `staging` build type to `android/app/build.gradle.kts`, initialized from `debug` (debug-signed, debuggable) with `matchingFallbacks += "debug"`, following daynest's pattern.
  - Distinct application ID (`be.champagnefestival.android.staging`) and `-staging` version name suffix, so it installs alongside debug and release builds.
  - `API_BASE_URL` and `OIDC_ISSUER_URL` resolve from a Gradle property or environment variable of the same name — `CHAMPAGNEFESTIVAL_ANDROID_STAGING_API_BASE_URL` / `CHAMPAGNEFESTIVAL_ANDROID_STAGING_OIDC_ISSUER_URL` — with blank values treated as unset, defaulting to placeholders.
  - Certificate pinning stays disabled for staging, matching debug.
- Android CI now runs `assembleStaging` and uploads the staging APK alongside the debug one.
- New manual `Android Staging APK` workflow (`.github/workflows/android-staging.yml`, `workflow_dispatch`) builds and uploads a distributable staging APK with both URLs as optional inputs — no production signing secrets involved. Actions are pinned to the same commit SHAs as the existing Android CI workflow.
- Documents the staging variant in `android/README.md`.

## Acceptance criteria

- `./gradlew assembleStaging` builds a distinct, installable (debug-signed) APK whose application ID collides with neither debug nor release.
- Staging backend URLs are configurable independently of debug/release via Gradle property or env var.
- CI builds the staging variant without production signing secrets.

The existing runtime API base URL override (Settings screen) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSGUh1PrnLcxM4UWf887MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSGUh1PrnLcxM4UWf887MH)_