### PR TITLE
fix(android): release APK silently used placeholder API/OIDC URLs

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -56,6 +56,8 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+          CHAMPAGNEFESTIVAL_ANDROID_RELEASE_API_BASE_URL: ${{ secrets.CHAMPAGNEFESTIVAL_ANDROID_RELEASE_API_BASE_URL }}
+          CHAMPAGNEFESTIVAL_ANDROID_RELEASE_OIDC_ISSUER_URL: ${{ secrets.CHAMPAGNEFESTIVAL_ANDROID_RELEASE_OIDC_ISSUER_URL }}
         run: ./gradlew :app:assembleRelease
 
       - name: Upload release APK

--- a/android/README.md
+++ b/android/README.md
@@ -55,6 +55,18 @@ CI can build a distributable staging APK without production signing secrets via
 the manual **Android Staging APK** workflow (`.github/workflows/android-staging.yml`),
 which accepts both URLs as optional inputs.
 
+### Release variant
+
+The manual **Android Release APK** workflow (`.github/workflows/android-release.yml`)
+builds a signed release APK and requires these repository secrets:
+
+- `KEYSTORE_BASE64`, `KEY_ALIAS`, `KEY_PASSWORD`, `STORE_PASSWORD` — release signing
+- `CHAMPAGNEFESTIVAL_ANDROID_RELEASE_API_BASE_URL` — e.g. `https://api.champagnefestival.tjor.im/`
+- `CHAMPAGNEFESTIVAL_ANDROID_RELEASE_OIDC_ISSUER_URL` — e.g. `https://auth.tjor.im/realms/champagnefestival`
+
+If the two URL secrets are unset, `assembleRelease` fails fast rather than
+silently shipping an APK pointed at a placeholder host.
+
 ## Getting Started
 
 ### Prerequisites

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -34,15 +34,15 @@ fun resolveConfigValue(
     required: Boolean,
     defaultValue: String = "",
 ): String {
-    val value =
+    val explicitValue =
         sequenceOf(
             providers.gradleProperty(name).orNull,
             providers.environmentVariable(name).orNull,
-        ).firstOrNull { !it.isNullOrBlank() } ?: defaultValue.takeIf { it.isNotBlank() }
-    if (required && value.isNullOrBlank()) {
+        ).firstOrNull { !it.isNullOrBlank() }
+    if (required && explicitValue.isNullOrBlank()) {
         error("Missing required build property '$name'. Set it as a Gradle property or env var.")
     }
-    return value.orEmpty()
+    return explicitValue ?: defaultValue
 }
 
 // No staging backend is deployed yet; unlike release, a missing staging value


### PR DESCRIPTION
## Summary

- Installing the APK from the "Android Release APK" workflow worked, but sign-in failed with "Network error." The release build was silently pointed at `release.placeholder.invalid` instead of production.
- `resolveConfigValue()` in `android/app/build.gradle.kts` was supposed to fail the build when a `required` value (release API base URL / OIDC issuer URL) was missing, but it fell back to `defaultValue` *before* checking `required`, so the check never tripped as long as a non-blank placeholder default existed.
- `android-release.yml` never passed `CHAMPAGNEFESTIVAL_ANDROID_RELEASE_API_BASE_URL` / `CHAMPAGNEFESTIVAL_ANDROID_RELEASE_OIDC_ISSUER_URL` to the `assembleRelease` step, so the placeholder default was always used.

## Changes

- Fix `resolveConfigValue()` to check the required condition against the explicit (gradle property / env var) value only, before falling back to the default — so a missing required value now fails the build instead of silently shipping a broken APK.
- Wire `CHAMPAGNEFESTIVAL_ANDROID_RELEASE_API_BASE_URL` and `CHAMPAGNEFESTIVAL_ANDROID_RELEASE_OIDC_ISSUER_URL` into `android-release.yml` from repository secrets.
- Document the required release secrets in `android/README.md`.

**Note:** the repo secrets `CHAMPAGNEFESTIVAL_ANDROID_RELEASE_API_BASE_URL` (e.g. `https://api.champagnefestival.tjor.im/`) and `CHAMPAGNEFESTIVAL_ANDROID_RELEASE_OIDC_ISSUER_URL` (e.g. `https://auth.tjor.im/realms/champagnefestival`) still need to be added in repo settings before the next release build — I don't have access to set them.

## Test plan

- [ ] Add the two secrets in repo settings
- [ ] Re-run the "Android Release APK" workflow
- [ ] Verify the workflow fails fast if either secret is unset (confirms the fix)
- [ ] Install the resulting APK and confirm OIDC sign-in succeeds against production


---
_Generated by [Claude Code](https://claude.ai/code/session_01FC4baQzNzkzSJ5m95biDmz)_