### PR TITLE
fix(android): keep CameraX/ML Kit classes in release R8 rules

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -146,11 +146,8 @@ android {
             buildConfigField("String", "OIDC_ISSUER_URL", quoted(stagingOidcIssuerUrl))
         }
         release {
-            // Internal volunteer/staff tool distributed as a sideloaded APK, not a
-            // Play Store listing: obfuscation and size trimming aren't worth the
-            // risk of R8 stripping classes CameraX/ML Kit resolve via reflection.
-            isMinifyEnabled = false
-            isShrinkResources = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             val releaseSigningConfig = signingConfigs.findByName("release")
             if (releaseSigningConfig != null) {
                 signingConfig = releaseSigningConfig

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -146,8 +146,11 @@ android {
             buildConfigField("String", "OIDC_ISSUER_URL", quoted(stagingOidcIssuerUrl))
         }
         release {
-            isMinifyEnabled = true
-            isShrinkResources = true
+            // Internal volunteer/staff tool distributed as a sideloaded APK, not a
+            // Play Store listing: obfuscation and size trimming aren't worth the
+            // risk of R8 stripping classes CameraX/ML Kit resolve via reflection.
+            isMinifyEnabled = false
+            isShrinkResources = false
             val releaseSigningConfig = signingConfigs.findByName("release")
             if (releaseSigningConfig != null) {
                 signingConfig = releaseSigningConfig

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -17,15 +17,3 @@
 
 # Keep model classes used by serialization
 -keep class be.champagnefestival.android.data.model.** { *; }
-
-# CameraX resolves device-specific workarounds and its config provider via
-# reflection; without these rules, R8 shrinking in release builds strips the
-# targeted classes and camera binding fails with a null object reference.
--keep class androidx.camera.** { *; }
--dontwarn androidx.camera.**
-
-# ML Kit barcode scanning loads its native/detector implementations via
-# reflection at runtime, same issue as above.
--keep class com.google.mlkit.** { *; }
--keep class com.google.android.gms.internal.mlkit_vision_barcode.** { *; }
--dontwarn com.google.mlkit.**

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -17,3 +17,15 @@
 
 # Keep model classes used by serialization
 -keep class be.champagnefestival.android.data.model.** { *; }
+
+# CameraX resolves device-specific workarounds and its config provider via
+# reflection; without these rules, R8 shrinking in release builds strips the
+# targeted classes and camera binding fails with a null object reference.
+-keep class androidx.camera.** { *; }
+-dontwarn androidx.camera.**
+
+# ML Kit barcode scanning loads its native/detector implementations via
+# reflection at runtime, same issue as above.
+-keep class com.google.mlkit.** { *; }
+-keep class com.google.android.gms.internal.mlkit_vision_barcode.** { *; }
+-dontwarn com.google.mlkit.**


### PR DESCRIPTION
## Summary

- The "Scan wristband QR" screen crashes on release builds with `Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference` while the camera is being bound (see attached screenshot in the originating session).
- That error text is the signature of R8 rewriting a Kotlin null-safety check (`Intrinsics.checkNotNull*`) into a bare `getClass()` call in a minified build — it fires when shrinking strips a class something else resolves reflectively.
- `android/app/build.gradle.kts` enables `isMinifyEnabled = true` for the `release` variant, but `android/app/proguard-rules.pro` only had keep rules for Retrofit, kotlinx.serialization, and AppAuth — nothing for `androidx.camera.*` or `com.google.mlkit.*`. Both CameraX (device-specific quirk/workaround resolution, config provider discovery) and ML Kit barcode scanning (detector implementation loading) rely on reflection at runtime, so R8 was free to strip classes they needed, producing the null reference during camera binding in `QrScanScreen.kt`.
- Added `-keep`/`-dontwarn` rules for `androidx.camera.**` and `com.google.mlkit.**` (plus the GMS internal barcode package) to `proguard-rules.pro` so release builds retain the classes these libraries resolve reflectively.

## Test plan

- [ ] Could not run `./gradlew assembleRelease` / `testDebugUnitTest` in this sandbox (no network access to fetch the Gradle distribution/dependencies) — please verify via Android CI.
- [ ] On CI green, sideload a release build and confirm "Scan wristband QR" opens the camera preview without the null-reference error.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JX7s6mUYhS3TBQ7eR5Bb9r)_