### PR TITLE
Align Android applicationId with tjor.im domain convention

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -141,7 +141,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "be.champagnefestival.android"
+        applicationId = "im.tjor.champagnefestival"
         minSdk = 26
         targetSdk = 37
         // versionCode = MAJOR * 1000000 + MINOR * 1000 + PATCH (e.g. v1.2.3 → 1002003)
@@ -149,7 +149,7 @@ android {
         versionName = appVersion
         buildConfigField("String", "BUILD_COMMIT", quoted(gitCommit))
 
-        manifestPlaceholders["appAuthRedirectScheme"] = "be.champagnefestival.android"
+        manifestPlaceholders["appAuthRedirectScheme"] = "im.tjor.champagnefestival"
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
 
                 <data
                     android:host="oauth2redirect"
-                    android:scheme="im.tjor.champagnefestival" />
+                    android:scheme="${appAuthRedirectScheme}" />
             </intent-filter>
         </activity>
     </application>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
 
                 <data
                     android:host="oauth2redirect"
-                    android:scheme="be.champagnefestival.android" />
+                    android:scheme="im.tjor.champagnefestival" />
             </intent-filter>
         </activity>
     </application>

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/OidcConfig.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/OidcConfig.kt
@@ -6,5 +6,5 @@ import be.champagnefestival.android.BuildConfig
 data class OidcConfig(
     val apiBaseUrl: String = BuildConfig.API_BASE_URL,
     val clientId: String = BuildConfig.OIDC_CLIENT_ID,
-    val redirectUri: Uri = Uri.parse("be.champagnefestival.android://oauth2redirect"),
+    val redirectUri: Uri = Uri.parse("im.tjor.champagnefestival://oauth2redirect"),
 )


### PR DESCRIPTION
## Summary
- \`applicationId\`: \`be.champagnefestival.android\` → \`im.tjor.champagnefestival\`
- OAuth redirect scheme (manifest + \`OidcConfig.kt\`) updated to match
- \`namespace\` (Kotlin source package) is untouched — no source files move

Closes #651

**Depends on:** tjorim/apps's Keycloak redirect URI update landing first, or logins on this build will fail.

## Test plan
- [ ] CI run on this branch builds successfully
- [ ] After merge + Keycloak update, verify OIDC login still works on a fresh install