### PR TITLE
docs(android): update README OIDC redirect URI to tjor.im applicationId

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -123,7 +123,8 @@ cd android
 
 The app uses OpenID Connect (Keycloak / authentik) via [AppAuth for Android](https://github.com/openid/AppAuth-Android).
 
-OIDC redirect URI: `be.champagnefestival.android://oauth2redirect`
+OIDC redirect URI: `im.tjor.champagnefestival://oauth2redirect`
+(debug builds use `im.tjor.champagnefestival.debug://oauth2redirect`, from the `applicationIdSuffix`)
 
 Register this redirect URI with your OIDC provider.
 


### PR DESCRIPTION
## Summary

Fixes #651.

Investigation showed the applicationId rename from `be.champagnefestival.android` to `im.tjor.champagnefestival` (the conventional reverse-DNS of `champagnefestival.tjor.im`) had already landed in `android/app/build.gradle.kts`, and the OAuth redirect scheme already resolves correctly at runtime via `BuildConfig.APPLICATION_ID` (`OidcConfig.kt`) and the `${applicationId}` manifest placeholder (`AndroidManifest.xml`) — so no code changes were needed there.

The one thing left stale was `android/README.md`, which still documented the old redirect URI (`be.champagnefestival.android://oauth2redirect`). Since this doc is the reference used when registering the redirect URI with an OIDC provider (e.g. Keycloak), an out-of-date value here could lead to misconfiguration.

- Updated the documented OIDC redirect URI to `im.tjor.champagnefestival://oauth2redirect`
- Added a note for the debug variant's suffixed redirect URI (`im.tjor.champagnefestival.debug://oauth2redirect`), since `applicationIdSuffix = ".debug"` changes it for debug builds

Note: the Kotlin source package (`be.champagnefestival.android`) and `namespace` in `build.gradle.kts` were intentionally left unchanged in the earlier applicationId rename (per that commit's message) — only the Play Store package identity and OAuth scheme change with applicationId, not the namespace. This PR doesn't touch that.

Out of scope for this repo: the issue also notes the registered redirect URI needs updating on this app's Keycloak client — that configuration lives in the separate infra stack (`/opt/apps/infra`), not in this repository.

## Test plan
- [x] Verified `applicationId` in `android/app/build.gradle.kts` is already `im.tjor.champagnefestival`
- [x] Verified `AndroidManifest.xml`'s redirect activity uses the `${applicationId}` placeholder (not a hardcoded old scheme)
- [x] Verified `OidcConfig.kt` builds its redirect URI from `BuildConfig.APPLICATION_ID`
- [x] Grepped the repo for remaining stale `be.champagnefestival.android` references outside the (intentionally unchanged) Kotlin package/namespace — only the README was stale


---
_Generated by [Claude Code](https://claude.ai/code/session_01DTtBCUw2Wq8CjsVGwj28MW)_