### PR TITLE
fix(android): add missing fr/nl translations for error_no_active_edition

### DIFF
--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -11,6 +11,7 @@
     <string name="error_network_unavailable">Impossible de joindre le serveur. Vérifiez votre connexion et réessayez.</string>
     <string name="error_certificate_untrusted">Le certificat du serveur n\'a pas pu être vérifié. Veuillez mettre à jour l\'application.</string>
     <string name="error_unauthorized">Le code d\'enregistrement n\'est plus valide.</string>
+    <string name="error_no_active_edition">Aucune édition du festival n\'est active ou à venir pour le moment.</string>
     <string name="error_server">Le serveur a rejeté la demande. Veuillez réessayer.</string>
     <string name="error_unknown">Une erreur s\'est produite. Veuillez réessayer.</string>
 

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -11,6 +11,7 @@
     <string name="error_network_unavailable">Kan de server niet bereiken. Controleer je verbinding en probeer het opnieuw.</string>
     <string name="error_certificate_untrusted">Het certificaat van de server kon niet worden geverifieerd. Werk de app bij.</string>
     <string name="error_unauthorized">De check-in code is niet meer geldig.</string>
+    <string name="error_no_active_edition">Er is momenteel geen actieve of aankomende festivaleditie.</string>
     <string name="error_server">De server heeft het verzoek geweigerd. Probeer het opnieuw.</string>
     <string name="error_unknown">Er is een fout opgetreden. Probeer het opnieuw.</string>
 


### PR DESCRIPTION
## Summary
- The `Android CI / Lint, Unit Test & Build` job (e.g. failing in [PR #667](https://github.com/tjorim/champagnefestival/pull/667)) was failing at `./gradlew lintDebug` with a `MissingTranslation` error: `error_no_active_edition` existed only in `android/app/src/main/res/values/strings.xml` and had no French or Dutch translation.
- Added the missing `error_no_active_edition` string to `values-fr/strings.xml` and `values-nl/strings.xml`, matching the existing translation style/tone of the surrounding `error_*` strings.

This is unrelated to the actual content of PR #667 (a Dependabot `actions/setup-java` bump) — the lint check just happened to surface a pre-existing missing-translation bug on that PR's CI run.

## Test plan
- [x] Verified all string keys now match exactly across `values/`, `values-fr/`, and `values-nl/strings.xml`
- [x] Validated XML well-formedness of the modified files
- [ ] Confirm `./gradlew lintDebug` passes in CI (no local Android SDK available in this environment to run it directly)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fi3yLYhkxfXATwWZ9kcGft)_