### PR TITLE
Gate admin UI by Keycloak roles

### DIFF
--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -245,16 +245,13 @@ export default function CheckInPage() {
   const hasQrCredentials = Boolean(registrationId && checkInToken);
   const checkInQueryKey = queryKeys.checkInRegistration(registrationId ?? "", checkInToken ?? "");
 
-  const authHeaders = useCallback(
-    (): Record<string, string> => {
-      const token = auth.getAccessToken();
-      return {
-        "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      };
-    },
-    [auth],
-  );
+  const authHeaders = useCallback((): Record<string, string> => {
+    const token = auth.getAccessToken();
+    return {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
+  }, [auth]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -371,7 +368,7 @@ export default function CheckInPage() {
   const registration = manualRegistration ?? registrationQuery.data ?? null;
   const isLoading = hasQrCredentials ? registrationQuery.isPending : false;
   const isCheckingIn = checkInMutation.isPending || volunteerCheckInMutation.isPending;
-  const canManageEntranceActions = auth.isAuthenticated;
+  const canManageEntranceActions = auth.hasRole("admin") || auth.hasRole("volunteer");
   const isUpdatingRegistration = updateRegistrationMutation.isPending;
   const queryError = registrationQuery.isError ? registrationQuery.error.message : "";
   const mutationError = checkInMutation.isError
@@ -387,7 +384,8 @@ export default function CheckInPage() {
         : "";
   const isAlreadyCheckedIn = success ? alreadyCheckedIn : (registration?.checkedIn ?? false);
   const searchResults = debouncedSearchTerm.length >= 2 ? (volunteerSearchQuery.data ?? []) : [];
-  const showSearchHint = !hasQrCredentials && searchTerm.trim().length > 0 && searchTerm.trim().length < 2;
+  const showSearchHint =
+    !hasQrCredentials && searchTerm.trim().length > 0 && searchTerm.trim().length < 2;
 
   const handleCheckIn = useCallback(() => {
     if (hasQrCredentials) {

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -244,6 +244,7 @@ export default function CheckInPage() {
   const [manualRegistration, setManualRegistration] = useState<CheckInData | null>(null);
   const hasQrCredentials = Boolean(registrationId && checkInToken);
   const checkInQueryKey = queryKeys.checkInRegistration(registrationId ?? "", checkInToken ?? "");
+  const canManageEntranceActions = auth.hasRole("admin") || auth.hasRole("volunteer");
 
   const authHeaders = useCallback((): Record<string, string> => {
     const token = auth.getAccessToken();
@@ -281,7 +282,7 @@ export default function CheckInPage() {
   const volunteerSearchQuery = useQuery({
     queryKey: queryKeys.volunteerRegistrationSearch(debouncedSearchTerm),
     queryFn: ({ signal }) => searchVolunteerRegistrations(debouncedSearchTerm, authHeaders, signal),
-    enabled: !hasQrCredentials && auth.isAuthenticated && debouncedSearchTerm.length >= 2,
+    enabled: !hasQrCredentials && canManageEntranceActions && debouncedSearchTerm.length >= 2,
     retry: false,
     staleTime: 15 * 1000,
   });
@@ -368,7 +369,6 @@ export default function CheckInPage() {
   const registration = manualRegistration ?? registrationQuery.data ?? null;
   const isLoading = hasQrCredentials ? registrationQuery.isPending : false;
   const isCheckingIn = checkInMutation.isPending || volunteerCheckInMutation.isPending;
-  const canManageEntranceActions = auth.hasRole("admin") || auth.hasRole("volunteer");
   const isUpdatingRegistration = updateRegistrationMutation.isPending;
   const queryError = registrationQuery.isError ? registrationQuery.error.message : "";
   const mutationError = checkInMutation.isError
@@ -481,6 +481,9 @@ export default function CheckInPage() {
                           </Button>
                         </Alert>
                       )}
+                      {auth.isAuthenticated && !canManageEntranceActions && (
+                        <Alert variant="warning">{m.checkin_manual_search_unauthorized()}</Alert>
+                      )}
 
                       <Form.Group controlId="manual-checkin-query">
                         <Form.Label>{m.checkin_manual_search_label()}</Form.Label>
@@ -494,7 +497,7 @@ export default function CheckInPage() {
                             setAlreadyCheckedIn(false);
                           }}
                           placeholder={m.checkin_manual_search_placeholder()}
-                          disabled={!auth.isAuthenticated}
+                          disabled={!canManageEntranceActions}
                         />
                         <Form.Text className="text-secondary">
                           {m.checkin_manual_search_help()}

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -64,7 +64,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
   useEffect(() => {
     if (canManageAdminSections || activeKey === "registrations") return;
     setActiveKey("registrations");
-  }, [activeKey, canManageAdminSections]);
+  }, [activeKey, canManageAdminSections, setActiveKey]);
 
   const toggleGroup = useCallback((group: string) => {
     setExpandedGroups((prev) => {
@@ -110,6 +110,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
   } = useAdminQueries({
     visible,
     isAuthenticated,
+    canManageAdminSections,
     authHeaders,
   });
 

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -19,10 +19,7 @@ import AnalyticsDashboard from "./AnalyticsDashboard";
 import AuditLogViewer from "./AuditLogViewer";
 import AdminSidebar from "./AdminSidebar";
 import AdminLoginForm from "./AdminLoginForm";
-import type {
-  Registration,
-  RegistrationStatus,
-} from "@/types/registration";
+import type { Registration, RegistrationStatus } from "@/types/registration";
 import { activeEditionQueryKey, useActiveEdition } from "@/hooks/useActiveEdition";
 import { useAdminDashboardData } from "@/hooks/useAdminDashboardData";
 import { useAdminPeopleActions } from "@/hooks/useAdminPeopleActions";
@@ -49,6 +46,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
   const navRef = useRef<HTMLElement>(null);
 
   const isAuthenticated = auth.isAuthenticated;
+  const canManageAdminSections = auth.hasRole("admin");
   const [globalError, setGlobalError] = useState("");
   const [registrationError, setRegistrationError] = useState("");
   const [filter, setFilter] = useState<"all" | RegistrationStatus>("all");
@@ -62,6 +60,11 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
     () => new Set(["events", "content", "venue", "people", "insights"]),
   );
   const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    if (canManageAdminSections || activeKey === "registrations") return;
+    setActiveKey("registrations");
+  }, [activeKey, canManageAdminSections]);
 
   const toggleGroup = useCallback((group: string) => {
     setExpandedGroups((prev) => {
@@ -387,6 +390,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
             isAnyFetching={isAnyFetching}
             onLoadData={loadData}
             onLogout={handleLogout}
+            canManageAdminSections={canManageAdminSections}
           />
 
           {/* Main content */}
@@ -424,7 +428,12 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
               </button>
             )}
             {globalError && (
-              <Alert variant="danger" className="mb-4" dismissible onClose={() => setGlobalError("")}>
+              <Alert
+                variant="danger"
+                className="mb-4"
+                dismissible
+                onClose={() => setGlobalError("")}
+              >
                 {globalError}
               </Alert>
             )}
@@ -458,7 +467,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
                     onClearSectionError={() => setRegistrationError("")}
                   />
                 )}
-                {activeKey === "exhibitors" && (
+                {canManageAdminSections && activeKey === "exhibitors" && (
                   <Card bg="dark" text="white" border="secondary" className="mb-3">
                     <Card.Body>
                       <ContentSection
@@ -471,7 +480,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
                     </Card.Body>
                   </Card>
                 )}
-                {activeKey === "editions" && (
+                {canManageAdminSections && activeKey === "editions" && (
                   <Card bg="dark" text="white" border="secondary" className="mb-3">
                     <Card.Body>
                       <EditionsSection
@@ -488,7 +497,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
                     </Card.Body>
                   </Card>
                 )}
-                {activeKey === "floor-plans" && (
+                {canManageAdminSections && activeKey === "floor-plans" && (
                   <LayoutEditor
                     dayOptions={layoutDayOptions}
                     tables={tables}
@@ -515,7 +524,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
                     onResizeArea={handleResizeArea}
                   />
                 )}
-                {activeKey === "venues" && (
+                {canManageAdminSections && activeKey === "venues" && (
                   <VenueManagement
                     venues={venues}
                     rooms={rooms}
@@ -528,7 +537,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
                     onRestoreRoom={handleRestoreRoom}
                   />
                 )}
-                {activeKey === "table-types" && (
+                {canManageAdminSections && activeKey === "table-types" && (
                   <TableTypeManagement
                     tableTypes={tableTypes}
                     onAdd={handleAddTableType}
@@ -537,7 +546,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
                     onRestore={handleRestoreTableType}
                   />
                 )}
-                {activeKey === "directory" && (
+                {canManageAdminSections && activeKey === "directory" && (
                   <PeopleManagement
                     people={people}
                     registrationCountByPersonId={registrationCountByPersonId}
@@ -549,7 +558,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
                     onDelete={handleDeletePerson}
                   />
                 )}
-                {activeKey === "members" && (
+                {canManageAdminSections && activeKey === "members" && (
                   <MembersManagement
                     members={members}
                     registrationCountByPersonId={registrationCountByPersonId}
@@ -559,7 +568,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
                     onDelete={handleDeleteMember}
                   />
                 )}
-                {activeKey === "volunteers" && (
+                {canManageAdminSections && activeKey === "volunteers" && (
                   <VolunteersManagement
                     volunteers={volunteers}
                     isLoading={isAnyFetching}
@@ -569,8 +578,12 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
                     onDelete={handleDeleteVolunteer}
                   />
                 )}
-                {activeKey === "analytics" && <AnalyticsDashboard authHeaders={authHeaders} />}
-                {activeKey === "audit-log" && <AuditLogViewer authHeaders={authHeaders} />}
+                {canManageAdminSections && activeKey === "analytics" && (
+                  <AnalyticsDashboard authHeaders={authHeaders} />
+                )}
+                {canManageAdminSections && activeKey === "audit-log" && (
+                  <AuditLogViewer authHeaders={authHeaders} />
+                )}
               </div>
             )}
           </div>
@@ -595,7 +608,9 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
               setDetailRegistration(null);
             } catch (err) {
               devError("Failed to merge people", err);
-              setRegistrationError(err instanceof Error ? err.message : m.admin_people_merge_error());
+              setRegistrationError(
+                err instanceof Error ? err.message : m.admin_people_merge_error(),
+              );
             }
           }}
         />

--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -104,6 +104,7 @@ export interface AdminSidebarProps {
   isAnyFetching: boolean;
   onLoadData: () => void;
   onLogout: () => void;
+  canManageAdminSections: boolean;
 }
 
 export default function AdminSidebar({
@@ -122,6 +123,7 @@ export default function AdminSidebar({
   isAnyFetching,
   onLoadData,
   onLogout,
+  canManageAdminSections,
 }: AdminSidebarProps) {
   const itemProps = { activeKey, setActiveKey, setSidebarOpen };
   const groupProps = { activeKey, expandedGroups, toggleGroup };
@@ -151,103 +153,119 @@ export default function AdminSidebar({
             {...itemProps}
           />
 
-          <SidebarGroup
-            groupKey="events"
-            icon="bi-calendar-event"
-            label={m.admin_events_group()}
-            itemKeys={["editions"]}
-            {...groupProps}
-          >
-            <SidebarItem
-              itemKey="editions"
-              icon="bi-calendar3"
-              label={m.admin_content_editions_section()}
-              {...itemProps}
-            />
-          </SidebarGroup>
+          {canManageAdminSections && (
+            <>
+              <SidebarGroup
+                groupKey="events"
+                icon="bi-calendar-event"
+                label={m.admin_events_group()}
+                itemKeys={["editions"]}
+                {...groupProps}
+              >
+                <SidebarItem
+                  itemKey="editions"
+                  icon="bi-calendar3"
+                  label={m.admin_content_editions_section()}
+                  {...itemProps}
+                />
+              </SidebarGroup>
 
-          <SidebarGroup
-            groupKey="content"
-            icon="bi-collection"
-            label={m.admin_content_tab()}
-            itemKeys={["exhibitors"]}
-            {...groupProps}
-          >
-            <SidebarItem
-              itemKey="exhibitors"
-              icon="bi-shop"
-              label={m.admin_content_exhibitors_section()}
-              {...itemProps}
-            />
-          </SidebarGroup>
+              <SidebarGroup
+                groupKey="content"
+                icon="bi-collection"
+                label={m.admin_content_tab()}
+                itemKeys={["exhibitors"]}
+                {...groupProps}
+              >
+                <SidebarItem
+                  itemKey="exhibitors"
+                  icon="bi-shop"
+                  label={m.admin_content_exhibitors_section()}
+                  {...itemProps}
+                />
+              </SidebarGroup>
 
-          <SidebarGroup
-            groupKey="venue"
-            icon="bi-geo-alt"
-            label={m.admin_venue_group()}
-            itemKeys={["venues", "table-types", "floor-plans"]}
-            {...groupProps}
-          >
-            <SidebarItem itemKey="venues" icon="bi-building" label={m.admin_venues_rooms_tab()} {...itemProps} />
-            <SidebarItem itemKey="table-types" icon="bi-grid" label={m.admin_table_types_tab()} {...itemProps} />
-            <SidebarItem
-              itemKey="floor-plans"
-              icon="bi-grid-3x3-gap"
-              label={m.admin_floor_plans_tab()}
-              {...itemProps}
-            />
-          </SidebarGroup>
+              <SidebarGroup
+                groupKey="venue"
+                icon="bi-geo-alt"
+                label={m.admin_venue_group()}
+                itemKeys={["venues", "table-types", "floor-plans"]}
+                {...groupProps}
+              >
+                <SidebarItem
+                  itemKey="venues"
+                  icon="bi-building"
+                  label={m.admin_venues_rooms_tab()}
+                  {...itemProps}
+                />
+                <SidebarItem
+                  itemKey="table-types"
+                  icon="bi-grid"
+                  label={m.admin_table_types_tab()}
+                  {...itemProps}
+                />
+                <SidebarItem
+                  itemKey="floor-plans"
+                  icon="bi-grid-3x3-gap"
+                  label={m.admin_floor_plans_tab()}
+                  {...itemProps}
+                />
+              </SidebarGroup>
 
-          <SidebarGroup
-            groupKey="people"
-            icon="bi-people"
-            label={m.admin_people_tab()}
-            itemKeys={["directory", "members", "volunteers"]}
-            {...groupProps}
-          >
-            <SidebarItem
-              itemKey="directory"
-              icon="bi-person"
-              label={m.admin_directory_tab()}
-              count={peopleCount}
-              {...itemProps}
-            />
-            <SidebarItem
-              itemKey="members"
-              icon="bi-person-badge"
-              label={m.admin_members_tab()}
-              count={membersCount}
-              {...itemProps}
-            />
-            <SidebarItem
-              itemKey="volunteers"
-              icon="bi-hand-thumbs-up"
-              label={m.admin_volunteers_tab()}
-              count={volunteerCount}
-              {...itemProps}
-            />
-          </SidebarGroup>
+              <SidebarGroup
+                groupKey="people"
+                icon="bi-people"
+                label={m.admin_people_tab()}
+                itemKeys={["directory", "members", "volunteers"]}
+                {...groupProps}
+              >
+                <SidebarItem
+                  itemKey="directory"
+                  icon="bi-person"
+                  label={m.admin_directory_tab()}
+                  count={peopleCount}
+                  {...itemProps}
+                />
+                <SidebarItem
+                  itemKey="members"
+                  icon="bi-person-badge"
+                  label={m.admin_members_tab()}
+                  count={membersCount}
+                  {...itemProps}
+                />
+                <SidebarItem
+                  itemKey="volunteers"
+                  icon="bi-hand-thumbs-up"
+                  label={m.admin_volunteers_tab()}
+                  count={volunteerCount}
+                  {...itemProps}
+                />
+              </SidebarGroup>
+            </>
+          )}
 
-          <SidebarGroup
-            groupKey="insights"
-            icon="bi-graph-up"
-            label={m.admin_insights_group()}
-            itemKeys={["analytics", "audit-log"]}
-            {...groupProps}
-          >
-            <SidebarItem
-              itemKey="analytics"
-              icon="bi-bar-chart"
-              label={m.admin_analytics_tab()}
-              {...itemProps}
-            />
-            <SidebarItem
-              itemKey="audit-log"
-              icon="bi-journal-text"
-              label={m.admin_audit_log_tab()}
-              {...itemProps}
-            />
-          </SidebarGroup>
+          {canManageAdminSections && (
+            <SidebarGroup
+              groupKey="insights"
+              icon="bi-graph-up"
+              label={m.admin_insights_group()}
+              itemKeys={["analytics", "audit-log"]}
+              {...groupProps}
+            >
+              <SidebarItem
+                itemKey="analytics"
+                icon="bi-bar-chart"
+                label={m.admin_analytics_tab()}
+                {...itemProps}
+              />
+              <SidebarItem
+                itemKey="audit-log"
+                icon="bi-journal-text"
+                label={m.admin_audit_log_tab()}
+                {...itemProps}
+              />
+            </SidebarGroup>
+          )}
         </nav>
 
         {/* Footer: status + actions */}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -6,6 +6,8 @@ import { devError } from "@/utils/devLog";
 export interface AuthContextType {
   isAuthenticated: boolean;
   isLoading: boolean;
+  roles: string[];
+  hasRole: (role: string) => boolean;
   /** Returns the current OIDC access token, or null when not authenticated. */
   getAccessToken: () => string | null;
   login: () => void;
@@ -13,6 +15,42 @@ export interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
+
+interface TokenClaims {
+  realm_access?: {
+    roles?: unknown;
+  };
+}
+
+function decodeTokenClaims(token: string | undefined): TokenClaims | null {
+  if (!token) return null;
+
+  const [, payload] = token.split(".");
+  if (!payload) return null;
+
+  try {
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    return JSON.parse(atob(padded)) as TokenClaims;
+  } catch {
+    return null;
+  }
+}
+
+function extractRealmRoles(...claims: Array<TokenClaims | null | undefined>): string[] {
+  const roles = new Set<string>();
+
+  for (const claim of claims) {
+    const claimRoles = claim?.realm_access?.roles;
+    if (!Array.isArray(claimRoles)) continue;
+
+    for (const role of claimRoles) {
+      if (typeof role === "string") roles.add(role);
+    }
+  }
+
+  return [...roles];
+}
 
 export function useAuth(): AuthContextType {
   const context = useContext(AuthContext);
@@ -33,6 +71,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return oidcAuth.user?.access_token ?? null;
   }, [oidcAuth.user]);
 
+  const roles = useMemo(() => {
+    const accessTokenClaims = decodeTokenClaims(oidcAuth.user?.access_token);
+    return extractRealmRoles(oidcAuth.user?.profile as TokenClaims | undefined, accessTokenClaims);
+  }, [oidcAuth.user]);
+
+  const hasRole = useCallback((role: string) => roles.includes(role), [roles]);
+
   const login = useCallback(() => {
     oidcAuth.signinRedirect({ state: { returnTo: "/admin" } }).catch((error: unknown) => {
       devError("signinRedirect failed:", error);
@@ -49,11 +94,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
     () => ({
       isAuthenticated: oidcAuth.isAuthenticated,
       isLoading: oidcAuth.isLoading,
+      roles,
+      hasRole,
       getAccessToken,
       login,
       logout,
     }),
-    [oidcAuth.isAuthenticated, oidcAuth.isLoading, getAccessToken, login, logout],
+    [oidcAuth.isAuthenticated, oidcAuth.isLoading, roles, hasRole, getAccessToken, login, logout],
   );
 
   return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;

--- a/frontend/src/hooks/useAdminQueries.ts
+++ b/frontend/src/hooks/useAdminQueries.ts
@@ -22,6 +22,7 @@ import {
 interface UseAdminQueriesOptions {
   visible: boolean;
   isAuthenticated: boolean;
+  canManageAdminSections: boolean;
   authHeaders: () => Record<string, string>;
 }
 
@@ -38,18 +39,46 @@ export const ADMIN_RESOURCE_KEYS = [
   "members",
 ] as const;
 
-export function shouldRefetchAdminResourceQuery(queryKey: readonly unknown[]): boolean {
+export const ADMIN_ONLY_RESOURCE_KEYS = ADMIN_RESOURCE_KEYS.filter(
+  (resource) => resource !== "registrations",
+);
+
+interface ShouldRefetchAdminResourceQueryOptions {
+  includeAdminOnly?: boolean;
+}
+
+export function shouldRefetchAdminResourceQuery(
+  queryKey: readonly unknown[],
+  { includeAdminOnly = true }: ShouldRefetchAdminResourceQueryOptions = {},
+): boolean {
+  if (
+    !(
+      queryKey.length === 2 &&
+      queryKey[0] === "admin" &&
+      typeof queryKey[1] === "string" &&
+      (ADMIN_RESOURCE_KEYS as readonly string[]).includes(queryKey[1])
+    )
+  ) {
+    return false;
+  }
+
+  if (includeAdminOnly) return true;
+  return !(ADMIN_ONLY_RESOURCE_KEYS as readonly string[]).includes(queryKey[1]);
+}
+
+export function shouldRefetchAdminOnlyResourceQuery(queryKey: readonly unknown[]): boolean {
   return (
     queryKey.length === 2 &&
     queryKey[0] === "admin" &&
     typeof queryKey[1] === "string" &&
-    (ADMIN_RESOURCE_KEYS as readonly string[]).includes(queryKey[1])
+    (ADMIN_ONLY_RESOURCE_KEYS as readonly string[]).includes(queryKey[1])
   );
 }
 
 export function useAdminQueries({
   visible,
   isAuthenticated,
+  canManageAdminSections,
   authHeaders,
 }: UseAdminQueriesOptions) {
   const queryClient = useQueryClient();
@@ -66,10 +95,14 @@ export function useAdminQueries({
   const peopleQueryKey = queryKeys.admin.people;
   const membersQueryKey = queryKeys.admin.members;
 
-  const adminQueryOptions = {
+  const registrationsQueryOptions = {
     enabled: visible && isAuthenticated,
     staleTime: 60 * 1000,
     retry: false as const,
+  };
+  const adminQueryOptions = {
+    ...registrationsQueryOptions,
+    enabled: visible && isAuthenticated && canManageAdminSections,
   };
 
   const registrationsCollection = useMemo(
@@ -77,9 +110,9 @@ export function useAdminQueries({
       createAdminRegistrationsCollection({
         queryClient,
         authHeaders,
-        enabled: adminQueryOptions.enabled,
+        enabled: registrationsQueryOptions.enabled,
       }),
-    [adminQueryOptions.enabled, authHeaders, queryClient],
+    [registrationsQueryOptions.enabled, authHeaders, queryClient],
   );
   const registrationsLiveQuery = useLiveQuery(
     () => registrationsCollection,
@@ -153,22 +186,29 @@ export function useAdminQueries({
 
   const allQueries = [
     registrationsQuery,
-    tablesQuery,
-    venuesQuery,
-    roomsQuery,
-    tableTypesQuery,
-    layoutsQuery,
-    exhibitorsQuery,
-    areasQuery,
-    peopleQuery,
-    membersQuery,
+    ...(canManageAdminSections
+      ? [
+          tablesQuery,
+          venuesQuery,
+          roomsQuery,
+          tableTypesQuery,
+          layoutsQuery,
+          exhibitorsQuery,
+          areasQuery,
+          peopleQuery,
+          membersQuery,
+        ]
+      : []),
   ];
 
   const loadData = useCallback(async () => {
     await queryClient.refetchQueries({
-      predicate: (query) => shouldRefetchAdminResourceQuery(query.queryKey),
+      predicate: (query) =>
+        shouldRefetchAdminResourceQuery(query.queryKey, {
+          includeAdminOnly: canManageAdminSections,
+        }),
     });
-  }, [queryClient]);
+  }, [canManageAdminSections, queryClient]);
 
   return {
     // Query objects (for error/loading state access)

--- a/frontend/tests/components/CheckInPage.test.tsx
+++ b/frontend/tests/components/CheckInPage.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { axe } from "jest-axe";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMemoryHistory,
   createRootRoute,
@@ -10,6 +10,7 @@ import {
 } from "@tanstack/react-router";
 import { http, HttpResponse } from "msw";
 import CheckInPage from "@/components/CheckInPage";
+import { useAuth } from "@/contexts/AuthContext";
 import { server } from "@/mocks/server";
 import { seedRegistrations } from "@/mocks/data/registrations";
 import { validateCheckInSearch } from "@/router";
@@ -64,6 +65,18 @@ vi.mock("@/paraglide/messages", () => ({
 }));
 
 describe("CheckInPage", () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      roles: ["admin"],
+      hasRole: vi.fn((role: string) => role === "admin"),
+      getAccessToken: vi.fn().mockReturnValue("mock-access-token"),
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+  });
+
   async function renderPage(initialEntry = `/check-in?id=${SEED_REG_ID}&token=${SEED_REG_TOKEN}`) {
     const rootRoute = createRootRoute();
     const checkInRoute = createRoute({
@@ -155,6 +168,24 @@ describe("CheckInPage", () => {
     fireEvent.click(screen.getByText(SEED_REG_NAME));
 
     expect(screen.getByRole("button", { name: /check in now/i })).toBeInTheDocument();
+  });
+
+  it("does not search manually for authenticated users without entrance roles", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      roles: [],
+      hasRole: vi.fn().mockReturnValue(false),
+      getAccessToken: vi.fn().mockReturnValue("mock-access-token"),
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    await renderPage("/check-in");
+
+    const searchInput = screen.getByLabelText("Guest name or email");
+    expect(searchInput).toBeDisabled();
+    expect(screen.getByText("Sign in as a volunteer or admin.")).toBeInTheDocument();
   });
 
   it("submits manual check-in for a selected volunteer search result", async () => {

--- a/frontend/tests/components/admin.AdminSidebar.test.tsx
+++ b/frontend/tests/components/admin.AdminSidebar.test.tsx
@@ -31,7 +31,7 @@ vi.mock("@/paraglide/messages", () => ({
 
 const expandedGroups = new Set(["events", "content", "venue", "people"]);
 
-function renderSidebar(setActiveKey = vi.fn()) {
+function renderSidebar(setActiveKey = vi.fn(), canManageAdminSections = true) {
   render(
     <AdminSidebar
       activeKey="registrations"
@@ -49,6 +49,7 @@ function renderSidebar(setActiveKey = vi.fn()) {
       isAnyFetching={false}
       onLoadData={vi.fn()}
       onLogout={vi.fn()}
+      canManageAdminSections={canManageAdminSections}
     />,
   );
 }
@@ -78,6 +79,17 @@ describe("AdminSidebar", () => {
       "Volunteers5",
       "Insights",
     ]);
+  });
+
+  it("shows only registrations to non-admin roles", () => {
+    renderSidebar(vi.fn(), false);
+
+    const navigation = screen.getByRole("navigation", { name: "Administration" });
+    expect(
+      within(navigation)
+        .getAllByRole("button")
+        .map((button) => button.textContent),
+    ).toEqual(["Registrations2"]);
   });
 
   it("selects a leaf destination directly from the sidebar", () => {

--- a/frontend/tests/hooks/useAdminQueries.test.ts
+++ b/frontend/tests/hooks/useAdminQueries.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { ADMIN_RESOURCE_KEYS, shouldRefetchAdminResourceQuery } from "@/hooks/useAdminQueries";
+import {
+  ADMIN_ONLY_RESOURCE_KEYS,
+  ADMIN_RESOURCE_KEYS,
+  shouldRefetchAdminOnlyResourceQuery,
+  shouldRefetchAdminResourceQuery,
+} from "@/hooks/useAdminQueries";
 import { queryKeys } from "@/utils/queryKeys";
 
 describe("useAdminQueries invalidation rules", () => {
@@ -9,10 +14,25 @@ describe("useAdminQueries invalidation rules", () => {
     }
   });
 
+  it("can limit refetches to registration resources for non-admin users", () => {
+    expect(
+      shouldRefetchAdminResourceQuery(queryKeys.admin.registrations, { includeAdminOnly: false }),
+    ).toBe(true);
+
+    for (const resource of ADMIN_ONLY_RESOURCE_KEYS) {
+      expect(
+        shouldRefetchAdminResourceQuery(["admin", resource], { includeAdminOnly: false }),
+      ).toBe(false);
+      expect(shouldRefetchAdminOnlyResourceQuery(["admin", resource])).toBe(true);
+    }
+  });
+
   it("does not refetch non-resource admin keys", () => {
     expect(shouldRefetchAdminResourceQuery(queryKeys.admin.personOptions("ali"))).toBe(false);
     expect(shouldRefetchAdminResourceQuery(queryKeys.admin.editionEvents("ed-01"))).toBe(false);
-    expect(shouldRefetchAdminResourceQuery(queryKeys.admin.peopleRegistrations("person-1"))).toBe(false);
+    expect(shouldRefetchAdminResourceQuery(queryKeys.admin.peopleRegistrations("person-1"))).toBe(
+      false,
+    );
   });
 
   it("does not refetch public keys", () => {

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -9,9 +9,7 @@ expect.extend(toHaveNoViolations);
 // Suppress non-critical axe rules that don't apply to dark-themed SPAs served
 // over HTTPS (color-contrast false positives from happy-dom's CSS support).
 configureAxe({
-  rules: [
-    { id: "color-contrast", enabled: false },
-  ],
+  rules: [{ id: "color-contrast", enabled: false }],
 });
 import { server } from "@/mocks/server";
 import { resetAdminStore } from "@/mocks/handlers/admin";
@@ -37,6 +35,8 @@ vi.mock("@/contexts/AuthContext", () => ({
   useAuth: vi.fn().mockReturnValue({
     isAuthenticated: true,
     isLoading: false,
+    roles: ["admin"],
+    hasRole: vi.fn((role: string) => role === "admin"),
     getAccessToken: vi.fn().mockReturnValue("mock-access-token"),
     login: vi.fn(),
     logout: vi.fn(),

--- a/frontend/tests/state/LiveUpdatesProvider.test.tsx
+++ b/frontend/tests/state/LiveUpdatesProvider.test.tsx
@@ -46,6 +46,8 @@ describe("LiveUpdatesProvider", () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
+      roles: ["admin"],
+      hasRole: vi.fn((role: string) => role === "admin"),
       getAccessToken: vi.fn().mockReturnValue("mock-access-token"),
       login: vi.fn(),
       logout: vi.fn(),
@@ -67,6 +69,8 @@ describe("LiveUpdatesProvider", () => {
     vi.mocked(useAuth).mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
+      roles: [],
+      hasRole: vi.fn().mockReturnValue(false),
       getAccessToken: vi.fn().mockReturnValue(null),
       login: vi.fn(),
       logout: vi.fn(),
@@ -87,7 +91,12 @@ describe("LiveUpdatesProvider", () => {
     render(<LiveUpdatesProvider />, { wrapper: Wrapper });
     await waitFor(() => expect(capturedOptions).not.toBeNull());
 
-    const envelope = makeEnvelope({ keys: [["admin", "registrations"], ["admin", "tables"]] });
+    const envelope = makeEnvelope({
+      keys: [
+        ["admin", "registrations"],
+        ["admin", "tables"],
+      ],
+    });
     act(() => capturedOptions!.onInvalidate(envelope));
 
     expect(spy).toHaveBeenCalledWith({ queryKey: ["admin", "registrations"] });


### PR DESCRIPTION
### Motivation

- Make the frontend aware of Keycloak realm roles so UI and actions can be restricted by role rather than just authentication state. 
- Hide sensitive admin sections from authenticated users who lack the `admin` role while keeping registration/check-in flows available. 
- Ensure entrance check-in actions require appropriate roles (`admin` or `volunteer`) instead of any authenticated session.

### Description

- Add `roles` and `hasRole()` to the `AuthContext` by decoding realm roles from the OIDC `user.profile` and the access token payload, implemented in `frontend/src/contexts/AuthContext.tsx`. 
- Gate sidebar groups and insights in `AdminSidebar` behind a `canManageAdminSections` flag so only users with the `admin` role see those entries, while the `registrations` entry remains visible to all authenticated users. 
- Compute `canManageAdminSections = auth.hasRole("admin")` in `AdminDashboard`, reset non-admin users back to the `registrations` pane if they end up on a hidden section, and wrap dashboard panes so only admin users can access them. 
- Restrict entrance/check-in management in `CheckInPage` to users who have either the `admin` or `volunteer` role by switching to `auth.hasRole("admin") || auth.hasRole("volunteer")`. 
- Update unit tests to be role-aware and add a test asserting non-admins only see the registrations entry; updated tests are `frontend/tests/components/admin.AdminSidebar.test.tsx` and `frontend/tests/state/LiveUpdatesProvider.test.tsx`.

### Testing

- Ran typecheck with `pnpm -C frontend typecheck` and it completed successfully. 
- Ran lint with `pnpm -C frontend lint` and it completed successfully. 
- Ran unit tests for the touched specs with `pnpm -C frontend test tests/components/admin.AdminSidebar.test.tsx tests/state/LiveUpdatesProvider.test.tsx` and all tests passed (both test files and their assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52227fc018832ebd6ae73dc3a69b89)