### PR TITLE
Show registration action errors inside detail modal

### DIFF
--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -598,7 +598,10 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
           baseUrl={window.location.origin + import.meta.env.BASE_URL.replace(/\/$/, "")}
           emailDuplicates={emailDuplicates}
           tables={tables}
-          onClose={() => setDetailRegistration(null)}
+          onClose={() => {
+            setDetailRegistration(null);
+            setRegistrationError("");
+          }}
           onToggleDelivered={handleToggleDelivered}
           onCheckIn={handleCheckIn}
           onIssueStrap={handleIssueStrap}

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -603,6 +603,8 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
           onCheckIn={handleCheckIn}
           onIssueStrap={handleIssueStrap}
           onAssignTable={handleAssignTable}
+          actionError={registrationError}
+          onClearActionError={() => setRegistrationError("")}
           onMergeDuplicate={async (canonicalId, duplicateId) => {
             try {
               await handleMergePeople(canonicalId, duplicateId);

--- a/frontend/src/components/admin/RegistrationDetail.tsx
+++ b/frontend/src/components/admin/RegistrationDetail.tsx
@@ -23,6 +23,8 @@ interface RegistrationDetailProps {
   onIssueStrap: (registrationId: string) => void;
   onAssignTable: (registrationId: string, tableId: string | undefined) => void;
   onMergeDuplicate?: (canonicalId: string, duplicateId: string) => void;
+  actionError?: string;
+  onClearActionError?: () => void;
 }
 
 function isSimpleRsvp(registration: Registration) {
@@ -41,6 +43,8 @@ export default function RegistrationDetail({
   onIssueStrap,
   onAssignTable,
   onMergeDuplicate,
+  actionError,
+  onClearActionError,
 }: RegistrationDetailProps) {
   const checkInUrl = registration
     ? `${baseUrl}/check-in?id=${encodeURIComponent(registration.id)}&token=${encodeURIComponent(registration.checkInToken ?? "")}`
@@ -98,6 +102,18 @@ export default function RegistrationDetail({
       </Modal.Header>
 
       <Modal.Body className="bg-dark text-light">
+        {actionError && (
+          <Alert
+            variant="danger"
+            dismissible={Boolean(onClearActionError)}
+            onClose={onClearActionError}
+            className="mb-3"
+            role="alert"
+          >
+            {actionError}
+          </Alert>
+        )}
+
         <div className="d-flex flex-wrap gap-2 mb-3">
           <Badge
             bg={


### PR DESCRIPTION
### Motivation

- Ensure admin actions that fail while the registration detail modal is open surface their error messages above the modal backdrop so they are visible to the user.
- Reuse the shared registration error state so failures triggered from modal actions remain consistent with the rest of the admin UI.

### Description

- Added optional `actionError?: string` and `onClearActionError?: () => void` props to `RegistrationDetail` and wired them into the component props.
- Render a dismissible danger `<Alert>` at the top of the modal body when `actionError` is present and make dismissal conditional on `onClearActionError` being provided.
- Passed the dashboard's `registrationError` state and a clear handler into `RegistrationDetail` from `AdminDashboard` so modal actions show the shared error message.

### Testing

- Ran `pnpm paraglide:compile && tsc -b --noEmit` as part of `pnpm typecheck`, which completed successfully (paraglide compilation succeeded).
- Ran `pnpm lint` which completed successfully; both commands emitted the existing Node engine warning because the environment uses Node `v22.22.2` while the frontend requests `>=24.0.0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a522e10c9dc832ea4d4093ab3ff81dc)