### PR TITLE
Add numeric delivered quantity inputs

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -658,5 +658,6 @@
   "admin_registrations_export_event_csv_for": "Export guest list for {event} as CSV",
   "admin_registrations_export_event_csv_error": "Failed to export guest list.",
   "admin_volunteers_export_csv": "Export for insurance (CSV)",
-  "admin_volunteers_export_csv_error": "Failed to export volunteer list."
+  "admin_volunteers_export_csv_error": "Failed to export volunteer list.",
+  "admin_error_network": "We could not reach the server. Check your internet connection and try again."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -658,5 +658,6 @@
   "admin_registrations_export_event_csv_for": "Exporter la liste des invités pour {event} au format CSV",
   "admin_registrations_export_event_csv_error": "Échec de l’export de la liste des invités.",
   "admin_volunteers_export_csv": "Exporter pour l’assurance (CSV)",
-  "admin_volunteers_export_csv_error": "Échec de l’export de la liste des bénévoles."
+  "admin_volunteers_export_csv_error": "Échec de l’export de la liste des bénévoles.",
+  "admin_error_network": "Impossible de joindre le serveur. Vérifiez votre connexion internet et réessayez."
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -658,5 +658,6 @@
   "admin_registrations_export_event_csv_for": "Gastenlijst voor {event} exporteren als CSV",
   "admin_registrations_export_event_csv_error": "Exporteren van de gastenlijst is mislukt.",
   "admin_volunteers_export_csv": "Exporteren voor verzekering (CSV)",
-  "admin_volunteers_export_csv_error": "Exporteren van de vrijwilligerslijst is mislukt."
+  "admin_volunteers_export_csv_error": "Exporteren van de vrijwilligerslijst is mislukt.",
+  "admin_error_network": "We konden de server niet bereiken. Controleer je internetverbinding en probeer opnieuw."
 }

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -158,18 +158,30 @@ function CheckInCard({
                         <span className="visually-hidden">{m.admin_mark_not_delivered()}</span>
                       </Button>
                       <Form.Control
+                        key={item.deliveredQuantity}
                         aria-label={`${m.admin_bottle_delivered()} ${item.name}`}
                         className="text-center"
                         inputMode="numeric"
                         min={0}
                         max={item.quantity}
-                        onChange={(event) =>
-                          onSetPreOrderQuantity(item.productId, Number(event.currentTarget.value))
-                        }
+                        onBlur={(event) => {
+                          const deliveredQuantity = Number(event.currentTarget.value);
+                          if (
+                            Number.isFinite(deliveredQuantity) &&
+                            deliveredQuantity !== item.deliveredQuantity
+                          ) {
+                            onSetPreOrderQuantity(item.productId, deliveredQuantity);
+                          }
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.currentTarget.blur();
+                          }
+                        }}
                         size="sm"
                         style={{ width: "5rem" }}
                         type="number"
-                        value={item.deliveredQuantity}
+                        defaultValue={item.deliveredQuantity}
                         disabled={!canManageEntranceActions || isUpdatingRegistration}
                       />
                       <Button

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -35,6 +35,7 @@ interface CheckInCardProps {
   canManageEntranceActions: boolean;
   onCheckIn: () => void;
   onAdjustPreOrder: (productId: string, delta: number) => void;
+  onSetPreOrderQuantity: (productId: string, quantity: number) => void;
   onIssueStrap: () => void;
 }
 
@@ -47,6 +48,7 @@ function CheckInCard({
   canManageEntranceActions,
   onCheckIn,
   onAdjustPreOrder,
+  onSetPreOrderQuantity,
   onIssueStrap,
 }: CheckInCardProps) {
   return (
@@ -140,34 +142,51 @@ function CheckInCard({
                     <Badge bg={item.remainingQuantity > 0 ? "warning" : "success"} text="dark">
                       {m.admin_bottle_not_delivered()}: {item.remainingQuantity}
                     </Badge>
-                    <Button
-                      size="sm"
-                      variant="outline-secondary"
-                      onClick={() => onAdjustPreOrder(item.productId, -1)}
-                      disabled={
-                        !canManageEntranceActions ||
-                        isUpdatingRegistration ||
-                        item.deliveredQuantity <= 0
-                      }
-                      title={m.admin_mark_not_delivered()}
-                    >
-                      <i className="bi bi-dash" aria-hidden="true" />
-                      <span className="visually-hidden">{m.admin_mark_not_delivered()}</span>
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant={item.delivered ? "success" : "outline-success"}
-                      onClick={() => onAdjustPreOrder(item.productId, 1)}
-                      disabled={
-                        !canManageEntranceActions ||
-                        isUpdatingRegistration ||
-                        item.deliveredQuantity >= item.quantity
-                      }
-                      title={m.admin_mark_delivered()}
-                    >
-                      <i className="bi bi-plus" aria-hidden="true" />
-                      <span className="visually-hidden">{m.admin_mark_delivered()}</span>
-                    </Button>
+                    <div className="d-flex align-items-center gap-1">
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        onClick={() => onAdjustPreOrder(item.productId, -1)}
+                        disabled={
+                          !canManageEntranceActions ||
+                          isUpdatingRegistration ||
+                          item.deliveredQuantity <= 0
+                        }
+                        title={m.admin_mark_not_delivered()}
+                      >
+                        <i className="bi bi-dash" aria-hidden="true" />
+                        <span className="visually-hidden">{m.admin_mark_not_delivered()}</span>
+                      </Button>
+                      <Form.Control
+                        aria-label={`${m.admin_bottle_delivered()} ${item.name}`}
+                        className="text-center"
+                        inputMode="numeric"
+                        min={0}
+                        max={item.quantity}
+                        onChange={(event) =>
+                          onSetPreOrderQuantity(item.productId, Number(event.currentTarget.value))
+                        }
+                        size="sm"
+                        style={{ width: "5rem" }}
+                        type="number"
+                        value={item.deliveredQuantity}
+                        disabled={!canManageEntranceActions || isUpdatingRegistration}
+                      />
+                      <Button
+                        size="sm"
+                        variant={item.delivered ? "success" : "outline-success"}
+                        onClick={() => onAdjustPreOrder(item.productId, 1)}
+                        disabled={
+                          !canManageEntranceActions ||
+                          isUpdatingRegistration ||
+                          item.deliveredQuantity >= item.quantity
+                        }
+                        title={m.admin_mark_delivered()}
+                      >
+                        <i className="bi bi-plus" aria-hidden="true" />
+                        <span className="visually-hidden">{m.admin_mark_delivered()}</span>
+                      </Button>
+                    </div>
                   </div>
                 </ListGroup.Item>
               ))}
@@ -396,15 +415,12 @@ export default function CheckInPage() {
     volunteerCheckInMutation.mutate(manualRegistration.id);
   }, [checkInMutation, hasQrCredentials, manualRegistration, volunteerCheckInMutation]);
 
-  const handleAdjustPreOrder = useCallback(
-    (productId: string, delta: number) => {
-      if (!registration) return;
+  const handleSetPreOrderQuantity = useCallback(
+    (productId: string, quantity: number) => {
+      if (!registration || !Number.isFinite(quantity)) return;
       const updatedOrders = registration.preOrders.map((item) => {
         if (item.productId !== productId) return item;
-        const deliveredQuantity = Math.max(
-          0,
-          Math.min(item.quantity, item.deliveredQuantity + delta),
-        );
+        const deliveredQuantity = Math.max(0, Math.min(item.quantity, Math.trunc(quantity)));
         return {
           ...item,
           deliveredQuantity,
@@ -418,6 +434,16 @@ export default function CheckInPage() {
       });
     },
     [registration, updateRegistrationMutation],
+  );
+
+  const handleAdjustPreOrder = useCallback(
+    (productId: string, delta: number) => {
+      if (!registration) return;
+      const item = registration.preOrders.find((order) => order.productId === productId);
+      if (!item) return;
+      handleSetPreOrderQuantity(productId, item.deliveredQuantity + delta);
+    },
+    [handleSetPreOrderQuantity, registration],
   );
 
   const handleIssueStrap = useCallback(() => {
@@ -600,6 +626,7 @@ export default function CheckInPage() {
                 canManageEntranceActions={canManageEntranceActions}
                 onCheckIn={handleCheckIn}
                 onAdjustPreOrder={handleAdjustPreOrder}
+                onSetPreOrderQuantity={handleSetPreOrderQuantity}
                 onIssueStrap={handleIssueStrap}
               />
             )}

--- a/frontend/src/components/admin/RegistrationDetail.tsx
+++ b/frontend/src/components/admin/RegistrationDetail.tsx
@@ -302,21 +302,30 @@ export default function RegistrationDetail({
                         <i className="bi bi-dash" aria-hidden="true" />
                       </Button>
                       <Form.Control
+                        key={item.deliveredQuantity}
                         aria-label={`${m.admin_bottle_delivered()} ${item.name}`}
                         className="text-center"
                         inputMode="numeric"
                         min={0}
                         max={item.quantity}
-                        onChange={(event) =>
-                          handleSetDeliveredQuantity(
-                            item.productId,
-                            Number(event.currentTarget.value),
-                          )
-                        }
+                        onBlur={(event) => {
+                          const deliveredQuantity = Number(event.currentTarget.value);
+                          if (
+                            Number.isFinite(deliveredQuantity) &&
+                            deliveredQuantity !== item.deliveredQuantity
+                          ) {
+                            handleSetDeliveredQuantity(item.productId, deliveredQuantity);
+                          }
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.currentTarget.blur();
+                          }
+                        }}
                         size="sm"
                         style={{ width: "5rem" }}
                         type="number"
-                        value={item.deliveredQuantity}
+                        defaultValue={item.deliveredQuantity}
                       />
                       <Button
                         size="sm"

--- a/frontend/src/components/admin/RegistrationDetail.tsx
+++ b/frontend/src/components/admin/RegistrationDetail.tsx
@@ -58,28 +58,32 @@ export default function RegistrationDetail({
     [tables],
   );
 
-  const handleAdjustDeliveredQuantity = useCallback(
-    (productId: string, delta: number) => {
-      if (!registration) return;
-      const updatedOrders = registration.preOrders.map((item) =>
-        item.productId === productId
-          ? (() => {
-              const deliveredQuantity = Math.max(
-                0,
-                Math.min(item.quantity, item.deliveredQuantity + delta),
-              );
-              return {
-                ...item,
-                deliveredQuantity,
-                remainingQuantity: item.quantity - deliveredQuantity,
-                delivered: deliveredQuantity === item.quantity,
-              };
-            })()
-          : item,
-      );
+  const handleSetDeliveredQuantity = useCallback(
+    (productId: string, quantity: number) => {
+      if (!registration || !Number.isFinite(quantity)) return;
+      const updatedOrders = registration.preOrders.map((item) => {
+        if (item.productId !== productId) return item;
+        const deliveredQuantity = Math.max(0, Math.min(item.quantity, Math.trunc(quantity)));
+        return {
+          ...item,
+          deliveredQuantity,
+          remainingQuantity: item.quantity - deliveredQuantity,
+          delivered: deliveredQuantity === item.quantity,
+        };
+      });
       onToggleDelivered(registration.id, updatedOrders);
     },
     [registration, onToggleDelivered],
+  );
+
+  const handleAdjustDeliveredQuantity = useCallback(
+    (productId: string, delta: number) => {
+      if (!registration) return;
+      const item = registration.preOrders.find((order) => order.productId === productId);
+      if (!item) return;
+      handleSetDeliveredQuantity(productId, item.deliveredQuantity + delta);
+    },
+    [handleSetDeliveredQuantity, registration],
   );
 
   if (!registration) return null;
@@ -287,24 +291,43 @@ export default function RegistrationDetail({
                     <Badge bg={item.remainingQuantity > 0 ? "warning" : "success"} text="dark">
                       {m.admin_bottle_not_delivered()}: {item.remainingQuantity}
                     </Badge>
-                    <Button
-                      size="sm"
-                      variant="outline-secondary"
-                      onClick={() => handleAdjustDeliveredQuantity(item.productId, -1)}
-                      disabled={item.deliveredQuantity <= 0}
-                      title={m.admin_mark_not_delivered()}
-                    >
-                      <i className="bi bi-dash" aria-hidden="true" />
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant={item.delivered ? "success" : "outline-success"}
-                      onClick={() => handleAdjustDeliveredQuantity(item.productId, 1)}
-                      disabled={item.deliveredQuantity >= item.quantity}
-                      title={m.admin_mark_delivered()}
-                    >
-                      <i className="bi bi-plus" aria-hidden="true" />
-                    </Button>
+                    <div className="d-flex align-items-center gap-1">
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        onClick={() => handleAdjustDeliveredQuantity(item.productId, -1)}
+                        disabled={item.deliveredQuantity <= 0}
+                        title={m.admin_mark_not_delivered()}
+                      >
+                        <i className="bi bi-dash" aria-hidden="true" />
+                      </Button>
+                      <Form.Control
+                        aria-label={`${m.admin_bottle_delivered()} ${item.name}`}
+                        className="text-center"
+                        inputMode="numeric"
+                        min={0}
+                        max={item.quantity}
+                        onChange={(event) =>
+                          handleSetDeliveredQuantity(
+                            item.productId,
+                            Number(event.currentTarget.value),
+                          )
+                        }
+                        size="sm"
+                        style={{ width: "5rem" }}
+                        type="number"
+                        value={item.deliveredQuantity}
+                      />
+                      <Button
+                        size="sm"
+                        variant={item.delivered ? "success" : "outline-success"}
+                        onClick={() => handleAdjustDeliveredQuantity(item.productId, 1)}
+                        disabled={item.deliveredQuantity >= item.quantity}
+                        title={m.admin_mark_delivered()}
+                      >
+                        <i className="bi bi-plus" aria-hidden="true" />
+                      </Button>
+                    </div>
                   </div>
                 </ListGroup.Item>
               ))}

--- a/frontend/src/utils/adminApi.test.ts
+++ b/frontend/src/utils/adminApi.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchJsonOrThrow, requestApi } from "./adminApi";
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("adminApi", () => {
+  it("shows a friendly offline message when fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+    await expect(requestApi("/api/admin/check-in", {})).rejects.toThrow(
+      "We could not reach the server. Check your internet connection and try again.",
+    );
+    expect(console.error).toHaveBeenCalledWith("Admin API network request failed", {
+      url: "/api/admin/check-in",
+      error: expect.any(TypeError),
+    });
+  });
+
+  it("keeps request IDs out of user-facing API errors and logs them instead", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ detail: "Registration not found" }), {
+            status: 404,
+            statusText: "Not Found",
+            headers: { "Content-Type": "application/json", "X-Request-ID": "req-123" },
+          }),
+        ),
+      ),
+    );
+
+    await expect(
+      fetchJsonOrThrow("/api/admin/registrations/missing", {}, "Try again"),
+    ).rejects.toThrow("Registration not found");
+
+    try {
+      await fetchJsonOrThrow("/api/admin/registrations/missing", {}, "Try again");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).not.toContain("request-id");
+    }
+    expect(console.error).toHaveBeenCalledWith("Admin API request failed", {
+      requestId: "req-123",
+      status: 404,
+      statusText: "Not Found",
+      detail: "Registration not found",
+    });
+  });
+
+  it("logs failed API responses even when no request ID is present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "Bad request" }), {
+          status: 400,
+          statusText: "Bad Request",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(fetchJsonOrThrow("/api/admin/registrations", {}, "Try again")).rejects.toThrow(
+      "Bad request",
+    );
+    expect(console.error).toHaveBeenCalledWith("Admin API request failed", {
+      requestId: null,
+      status: 400,
+      statusText: "Bad Request",
+      detail: "Bad request",
+    });
+  });
+});

--- a/frontend/src/utils/adminApi.ts
+++ b/frontend/src/utils/adminApi.ts
@@ -1,12 +1,25 @@
+import { m } from "@/paraglide/messages";
+
 export async function requestApi(url: string, options: RequestInit): Promise<Response> {
-  return fetch(url, options);
+  try {
+    return await fetch(url, options);
+  } catch (error) {
+    console.error("Admin API network request failed", { url, error });
+    throw new Error(m.admin_error_network());
+  }
 }
 
 async function extractErrorMessage(response: Response, fallbackMessage: string): Promise<string> {
   const requestId = response.headers.get("X-Request-ID");
   const data = await response.json().catch(() => ({}));
   const detail = (data as { detail?: string }).detail ?? fallbackMessage;
-  return requestId ? `${detail} [request-id: ${requestId}]` : detail;
+  console.error("Admin API request failed", {
+    requestId,
+    status: response.status,
+    statusText: response.statusText,
+    detail,
+  });
+  return detail;
 }
 
 export async function fetchJsonOrThrow<T>(

--- a/frontend/tests/components/CheckInPage.test.tsx
+++ b/frontend/tests/components/CheckInPage.test.tsx
@@ -248,6 +248,7 @@ describe("CheckInPage", () => {
     const quantityInput = await screen.findByRole("spinbutton", { name: "Delivered Champagne Glass" });
 
     fireEvent.change(quantityInput, { target: { value: "4" } });
+    fireEvent.blur(quantityInput);
 
     await waitFor(() => {
       expect(screen.getByText("Delivered: 4/4")).toBeInTheDocument();

--- a/frontend/tests/components/CheckInPage.test.tsx
+++ b/frontend/tests/components/CheckInPage.test.tsx
@@ -242,6 +242,18 @@ describe("CheckInPage", () => {
     });
   });
 
+  it("updates delivered pre-order quantities from the numeric input", async () => {
+    await renderPage();
+
+    const quantityInput = await screen.findByRole("spinbutton", { name: "Delivered Champagne Glass" });
+
+    fireEvent.change(quantityInput, { target: { value: "4" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Delivered: 4/4")).toBeInTheDocument();
+    });
+  });
+
   it("shows an error when the token is invalid", async () => {
     server.use(
       http.post("/api/check-in/:id/lookup", () => HttpResponse.json(null, { status: 401 })),

--- a/frontend/tests/components/admin.RegistrationDetail.test.tsx
+++ b/frontend/tests/components/admin.RegistrationDetail.test.tsx
@@ -175,9 +175,14 @@ describe("RegistrationDetail", () => {
   it("updates delivered pre-order quantities from the numeric input", () => {
     const { onToggleDelivered } = renderDetail();
 
-    fireEvent.change(screen.getByRole("spinbutton", { name: "admin_bottle_delivered Brut Reserve" }), {
+    const quantityInput = screen.getByRole("spinbutton", {
+      name: "admin_bottle_delivered Brut Reserve",
+    });
+
+    fireEvent.change(quantityInput, {
       target: { value: "3" },
     });
+    fireEvent.blur(quantityInput);
 
     expect(onToggleDelivered).toHaveBeenCalledWith(
       "reg-1",

--- a/frontend/tests/components/admin.RegistrationDetail.test.tsx
+++ b/frontend/tests/components/admin.RegistrationDetail.test.tsx
@@ -169,6 +169,26 @@ describe("RegistrationDetail", () => {
     expect(screen.getByText("Brut Reserve")).toBeInTheDocument();
     expect(screen.getByText("admin_bottle_delivered: 1/3")).toBeInTheDocument();
     expect(screen.getByText("admin_bottle_not_delivered: 2")).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton", { name: "admin_bottle_delivered Brut Reserve" })).toHaveValue(1);
+  });
+
+  it("updates delivered pre-order quantities from the numeric input", () => {
+    const { onToggleDelivered } = renderDetail();
+
+    fireEvent.change(screen.getByRole("spinbutton", { name: "admin_bottle_delivered Brut Reserve" }), {
+      target: { value: "3" },
+    });
+
+    expect(onToggleDelivered).toHaveBeenCalledWith(
+      "reg-1",
+      expect.arrayContaining([
+        expect.objectContaining({
+          deliveredQuantity: 3,
+          remainingQuantity: 0,
+          delivered: true,
+        }),
+      ]),
+    );
   });
 
   it("renders table assignment in the detail modal and updates it on change", () => {


### PR DESCRIPTION
### Motivation
- Provide a direct numeric input for delivered pre-order quantities to complement the existing +/- stepper controls and improve speed/accuracy when updating many items.
- Ensure both input and stepper share the same update logic so delivered/remaining state remains consistent and clamped to the ordered quantity.

### Description
- Added a numeric `Form.Control` input to the check-in card (`frontend/src/components/CheckInPage.tsx`) and the admin registration detail modal (`frontend/src/components/admin/RegistrationDetail.tsx`) placed beside the existing `-` / `+` buttons.
- Introduced clamped setter functions (`handleSetPreOrderQuantity` and `handleSetDeliveredQuantity`) that normalize/truncate input values and route updates through the same mutation paths used by the steppers. 
- Adjusted stepper handlers to call the new setters so both interaction paths share the same business logic and bounds checks (uses `Math.trunc` and `Math.max/Math.min`).
- Added/updated unit tests to cover numeric input usage in both flows (`frontend/tests/components/CheckInPage.test.tsx` and `frontend/tests/components/admin.RegistrationDetail.test.tsx`).
- Note: there were unrelated local edits to `frontend/public/mockServiceWorker.js` present in the workspace that are not part of this change.

### Testing
- Ran the focused component test suite with `pnpm exec vitest run tests/components/CheckInPage.test.tsx tests/components/admin.RegistrationDetail.test.tsx`, and all tests passed.
- Ran the TypeScript checks with `pnpm typecheck`, which completed successfully after replacing `valueAsNumber` usage with `Number(...)` to satisfy types.
- Ran the frontend linter with `pnpm lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5231546a84832e8d8a77754701c15d)