### PR TITLE
Distinguish filtered registration empty state

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -189,6 +189,7 @@
   "admin_action_mark_paid": "Mark as Paid",
   "admin_action_assign_table": "Assign Table",
   "admin_no_registrations": "No registrations found",
+  "admin_no_registration_filter_matches": "No registrations match the current filters.",
   "admin_filter_all": "All",
   "admin_filter_pending": "Pending",
   "admin_filter_confirmed": "Confirmed",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -189,6 +189,7 @@
   "admin_action_mark_paid": "Marquer comme payé",
   "admin_action_assign_table": "Assigner une table",
   "admin_no_registrations": "Aucune inscription trouvée",
+  "admin_no_registration_filter_matches": "Aucune inscription ne correspond aux filtres actuels.",
   "admin_filter_all": "Tous",
   "admin_filter_pending": "En attente",
   "admin_filter_confirmed": "Confirmé",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -189,6 +189,7 @@
   "admin_action_mark_paid": "Betaald markeren",
   "admin_action_assign_table": "Tafel toewijzen",
   "admin_no_registrations": "Geen registraties gevonden",
+  "admin_no_registration_filter_matches": "Geen registraties komen overeen met de huidige filters.",
   "admin_filter_all": "Alle",
   "admin_filter_pending": "In behandeling",
   "admin_filter_confirmed": "Bevestigd",

--- a/frontend/src/components/admin/RegistrationList.tsx
+++ b/frontend/src/components/admin/RegistrationList.tsx
@@ -603,6 +603,24 @@ export default function RegistrationList({
     [selectColumn, dataColumns],
   );
 
+  const hasActiveRegistrationFilters =
+    q.trim().length > 0 ||
+    filter !== "all" ||
+    allocationFilter !== "" ||
+    activeEditionOnly ||
+    dateFilter !== "all" ||
+    editionFilter !== "all";
+
+  const handleClearRegistrationFilters = useCallback(() => {
+    setQ("");
+    setDebouncedQ("");
+    onFilterChange("all");
+    setAllocationFilter("");
+    setActiveEditionOnly(false);
+    setDateFilter("all");
+    setEditionFilter("all");
+  }, [onFilterChange]);
+
   const table = useAppTable(
     {
       data: preFiltered,
@@ -969,7 +987,20 @@ export default function RegistrationList({
           ) : registrationSearchQuery.isError ? (
             <p className="text-danger text-center py-4 mb-0">{m.admin_error_load_data()}</p>
           ) : table.getRowModel().rows.length === 0 ? (
-            <p className="text-secondary text-center py-4 mb-0">{m.admin_no_registrations()}</p>
+            hasActiveRegistrationFilters ? (
+              <div className="text-secondary text-center py-4 px-3">
+                <p className="mb-2">{m.admin_no_registration_filter_matches()}</p>
+                <Button
+                  variant="outline-secondary"
+                  size="sm"
+                  onClick={handleClearRegistrationFilters}
+                >
+                  {m.admin_content_clear_filters()}
+                </Button>
+              </div>
+            ) : (
+              <p className="text-secondary text-center py-4 mb-0">{m.admin_no_registrations()}</p>
+            )
           ) : (
             <div className="table-responsive">
               <Table variant="dark" hover striped className="mb-0" size="sm">


### PR DESCRIPTION
### Motivation
- Improve the admin registrations UX by distinguishing an empty list caused by active filters from a genuinely empty dataset and provide a quick "clear filters" action.

### Description
- Add `hasActiveRegistrationFilters` detection based on `q.trim().length`, `filter`, `allocationFilter`, `activeEditionOnly`, `dateFilter`, and `editionFilter`.
- Add `handleClearRegistrationFilters` which resets `q`, `debouncedQ`, calls `onFilterChange("all")`, and clears allocation/edition/date/active flags.
- Update `RegistrationList.tsx` empty-state rendering to show `m.admin_no_registration_filter_matches()` with a button that calls `handleClearRegistrationFilters`, while preserving the original `m.admin_no_registrations()` for genuinely empty data.
- Add localized `admin_no_registration_filter_matches` strings to `frontend/messages/en.json`, `frontend/messages/nl.json`, and `frontend/messages/fr.json`, and compile the translations with the `paraglide` compile step.

### Testing
- Ran `pnpm --dir frontend paraglide:compile` and `pnpm --dir frontend typecheck`, both of which completed successfully.
- Ran `pnpm --dir frontend lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a529bb06184832ea5afcbc4d652ab09)