### PR TITLE
Show check-in status on tablet widths

### DIFF
--- a/frontend/src/components/admin/RegistrationList.tsx
+++ b/frontend/src/components/admin/RegistrationList.tsx
@@ -468,7 +468,7 @@ export default function RegistrationList({
             </>
           );
         },
-        meta: { tdClassName: "d-none d-xl-table-cell" },
+        meta: { tdClassName: "d-none d-md-table-cell" },
       }),
       columnHelper.display({
         id: "table",


### PR DESCRIPTION
### Motivation
- The checked-in/not-checked-in badge in the admin registration list was hidden until the `xl` breakpoint, which caused the status to be invisible on tablet and many laptop widths.

### Description
- Update the `checkedIn` column meta in `frontend/src/components/admin/RegistrationList.tsx` from `meta: { tdClassName: "d-none d-xl-table-cell" }` to `meta: { tdClassName: "d-none d-md-table-cell" }` so the badge is visible at `md` and larger widths while remaining hidden on small mobile screens.

### Testing
- Ran `pnpm typecheck` in `frontend` and the typecheck completed successfully.
- Ran `pnpm lint` in `frontend` and linting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a482d034832e8c5c12086787cebe)