### PR TITLE
Fix check-in page route test harness and improve MSW service worker SSE handling

### DIFF
--- a/frontend/tests/components/CheckInPage.test.tsx
+++ b/frontend/tests/components/CheckInPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  Outlet,
   createMemoryHistory,
   createRootRoute,
   createRoute,
@@ -79,13 +80,18 @@ describe("CheckInPage", () => {
 
   async function renderPage(initialEntry = `/check-in?id=${SEED_REG_ID}&token=${SEED_REG_TOKEN}`) {
     const rootRoute = createRootRoute();
-    const checkInRoute = createRoute({
+    const adminLayoutRoute = createRoute({
       getParentRoute: () => rootRoute,
+      id: "admin-layout",
+      component: () => <Outlet />,
+    });
+    const checkInRoute = createRoute({
+      getParentRoute: () => adminLayoutRoute,
       path: "/check-in",
       validateSearch: validateCheckInSearch,
       component: CheckInPage,
     });
-    const routeTree = rootRoute.addChildren([checkInRoute]);
+    const routeTree = rootRoute.addChildren([adminLayoutRoute.addChildren([checkInRoute])]);
     const memoryHistory = createMemoryHistory({ initialEntries: [initialEntry] });
     const router = createRouter({ routeTree, history: memoryHistory });
     await router.load();
@@ -121,13 +127,18 @@ describe("CheckInPage", () => {
 
   it("invalidates the checked-in registration query after submitting", async () => {
     const rootRoute = createRootRoute();
-    const checkInRoute = createRoute({
+    const adminLayoutRoute = createRoute({
       getParentRoute: () => rootRoute,
+      id: "admin-layout",
+      component: () => <Outlet />,
+    });
+    const checkInRoute = createRoute({
+      getParentRoute: () => adminLayoutRoute,
       path: "/check-in",
       validateSearch: validateCheckInSearch,
       component: CheckInPage,
     });
-    const routeTree = rootRoute.addChildren([checkInRoute]);
+    const routeTree = rootRoute.addChildren([adminLayoutRoute.addChildren([checkInRoute])]);
     const memoryHistory = createMemoryHistory({
       initialEntries: [`/check-in?id=${SEED_REG_ID}&token=${SEED_REG_TOKEN}`],
     });

--- a/frontend/tests/components/CheckInPage.test.tsx
+++ b/frontend/tests/components/CheckInPage.test.tsx
@@ -65,6 +65,25 @@ vi.mock("@/paraglide/messages", () => ({
   },
 }));
 
+function createCheckInTestRouter(initialEntry: string) {
+  const rootRoute = createRootRoute();
+  const adminLayoutRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    id: "admin-layout",
+    component: () => <Outlet />,
+  });
+  const checkInRoute = createRoute({
+    getParentRoute: () => adminLayoutRoute,
+    path: "/check-in",
+    validateSearch: validateCheckInSearch,
+    component: CheckInPage,
+  });
+  const routeTree = rootRoute.addChildren([adminLayoutRoute.addChildren([checkInRoute])]);
+  const memoryHistory = createMemoryHistory({ initialEntries: [initialEntry] });
+
+  return createRouter({ routeTree, history: memoryHistory });
+}
+
 describe("CheckInPage", () => {
   beforeEach(() => {
     vi.mocked(useAuth).mockReturnValue({
@@ -79,21 +98,7 @@ describe("CheckInPage", () => {
   });
 
   async function renderPage(initialEntry = `/check-in?id=${SEED_REG_ID}&token=${SEED_REG_TOKEN}`) {
-    const rootRoute = createRootRoute();
-    const adminLayoutRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      id: "admin-layout",
-      component: () => <Outlet />,
-    });
-    const checkInRoute = createRoute({
-      getParentRoute: () => adminLayoutRoute,
-      path: "/check-in",
-      validateSearch: validateCheckInSearch,
-      component: CheckInPage,
-    });
-    const routeTree = rootRoute.addChildren([adminLayoutRoute.addChildren([checkInRoute])]);
-    const memoryHistory = createMemoryHistory({ initialEntries: [initialEntry] });
-    const router = createRouter({ routeTree, history: memoryHistory });
+    const router = createCheckInTestRouter(initialEntry);
     await router.load();
     const Wrapper = createTestQueryClientWrapper();
 
@@ -126,23 +131,7 @@ describe("CheckInPage", () => {
   });
 
   it("invalidates the checked-in registration query after submitting", async () => {
-    const rootRoute = createRootRoute();
-    const adminLayoutRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      id: "admin-layout",
-      component: () => <Outlet />,
-    });
-    const checkInRoute = createRoute({
-      getParentRoute: () => adminLayoutRoute,
-      path: "/check-in",
-      validateSearch: validateCheckInSearch,
-      component: CheckInPage,
-    });
-    const routeTree = rootRoute.addChildren([adminLayoutRoute.addChildren([checkInRoute])]);
-    const memoryHistory = createMemoryHistory({
-      initialEntries: [`/check-in?id=${SEED_REG_ID}&token=${SEED_REG_TOKEN}`],
-    });
-    const router = createRouter({ routeTree, history: memoryHistory });
+    const router = createCheckInTestRouter(`/check-in?id=${SEED_REG_ID}&token=${SEED_REG_TOKEN}`);
     await router.load();
     const { queryClient, Wrapper } = createTestQueryClientHarness();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");


### PR DESCRIPTION
### Motivation
- Tests for `CheckInPage` need to mirror the production router so `useSearch({ from: "/admin-layout/check-in" })` resolves in the test harness. 
- The MSW generated `mockServiceWorker.js` was updated to avoid cloning server-sent event streams as cloning can prevent client-side stream cancellations and buffer the entire stream.

### Description
- Updated `frontend/tests/components/CheckInPage.test.tsx` to mount an `admin-layout` parent route that renders an `Outlet` and to attach the `/check-in` route as a child so the test router matches production route context. 
- Modified `frontend/public/mockServiceWorker.js` to bump `PACKAGE_VERSION` to `2.15.0`, update `INTEGRITY_CHECKSUM`, detect `text/event-stream` responses, and skip cloning such streaming responses so their bodies are not buffered or duplicated when the library observes requests.

### Testing
- Ran the component tests with `pnpm test -- tests/components/CheckInPage.test.tsx` and Vitest reported all tests passing (`49` test files, `378` tests). 
- The `pnpm test` run completed successfully despite a local Node engine warning about Node `v22.22.2` vs the package `engines` requirement of `>=24.0.0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52aaba974c832e96177609ea62c925)