### PR TITLE
Fix volunteer check-in login return path

### DIFF
--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, useCallback, useEffect } from "react";
-import { useSearch } from "@tanstack/react-router";
+import { useLocation, useSearch } from "@tanstack/react-router";
 import Container from "react-bootstrap/Container";
 import Card from "react-bootstrap/Card";
 import Button from "react-bootstrap/Button";
@@ -269,6 +269,7 @@ export default function CheckInPage() {
   const { id: registrationId, token: checkInToken } = useSearch({
     from: "/admin-layout/check-in",
   });
+  const location = useLocation();
   const [success, setSuccess] = useState(false);
   const [alreadyCheckedIn, setAlreadyCheckedIn] = useState(false);
   const [searchOpen, setSearchOpen] = useState(true);
@@ -278,6 +279,7 @@ export default function CheckInPage() {
   const hasQrCredentials = Boolean(registrationId && checkInToken);
   const checkInQueryKey = queryKeys.checkInRegistration(registrationId ?? "", checkInToken ?? "");
   const canManageEntranceActions = auth.hasRole("admin") || auth.hasRole("volunteer");
+  const returnTo = location.href;
 
   const authHeaders = useCallback((): Record<string, string> => {
     const token = auth.getAccessToken();
@@ -516,7 +518,7 @@ export default function CheckInPage() {
                           className="d-flex justify-content-between align-items-center gap-3 flex-wrap"
                         >
                           <span>{m.checkin_manual_search_login_required()}</span>
-                          <Button variant="outline-warning" size="sm" onClick={auth.login}>
+                          <Button variant="outline-warning" size="sm" onClick={() => auth.login(returnTo)}>
                             {m.admin_login_button()}
                           </Button>
                         </Alert>

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -279,7 +279,7 @@ export default function CheckInPage() {
   const hasQrCredentials = Boolean(registrationId && checkInToken);
   const checkInQueryKey = queryKeys.checkInRegistration(registrationId ?? "", checkInToken ?? "");
   const canManageEntranceActions = auth.hasRole("admin") || auth.hasRole("volunteer");
-  const returnTo = location.href;
+  const returnTo = location.pathname + location.searchStr;
 
   const authHeaders = useCallback((): Record<string, string> => {
     const token = auth.getAccessToken();

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -10,7 +10,7 @@ export interface AuthContextType {
   hasRole: (role: string) => boolean;
   /** Returns the current OIDC access token, or null when not authenticated. */
   getAccessToken: () => string | null;
-  login: () => void;
+  login: (returnTo?: string) => void;
   logout: () => void;
 }
 
@@ -78,8 +78,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const hasRole = useCallback((role: string) => roles.includes(role), [roles]);
 
-  const login = useCallback(() => {
-    oidcAuth.signinRedirect({ state: { returnTo: "/admin" } }).catch((error: unknown) => {
+  const login = useCallback((returnTo = "/admin") => {
+    oidcAuth.signinRedirect({ state: { returnTo } }).catch((error: unknown) => {
       devError("signinRedirect failed:", error);
     });
   }, [oidcAuth]);

--- a/frontend/tests/components/CheckInPage.test.tsx
+++ b/frontend/tests/components/CheckInPage.test.tsx
@@ -188,6 +188,25 @@ describe("CheckInPage", () => {
     expect(screen.getByText("Sign in as a volunteer or admin.")).toBeInTheDocument();
   });
 
+  it("returns volunteers to check-in after signing in for manual search", async () => {
+    const login = vi.fn();
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      roles: [],
+      hasRole: vi.fn().mockReturnValue(false),
+      getAccessToken: vi.fn().mockReturnValue(null),
+      login,
+      logout: vi.fn(),
+    });
+
+    await renderPage("/check-in");
+
+    fireEvent.click(screen.getByRole("button", { name: /login/i }));
+
+    expect(login).toHaveBeenCalledWith("/check-in");
+  });
+
   it("submits manual check-in for a selected volunteer search result", async () => {
     await renderPage("/check-in");
 


### PR DESCRIPTION
### Motivation

- Volunteers signing in from the manual check-in search should be returned to the `/check-in` route instead of the admin landing page after OIDC login.
- Make `login` callers able to request a custom return path while preserving the existing `/admin` default for admin flows.

### Description

- Change `AuthContext` so `login` accepts an optional `returnTo?: string` parameter and forwards it via `oidcAuth.signinRedirect({ state: { returnTo } })` with a default of `"/admin"`.
- Update `CheckInPage` to import `useLocation`, compute the current route as `returnTo`, and call `auth.login(returnTo)` from the manual-search login button so volunteers return to the check-in page after signing in.
- Add a unit test in `frontend/tests/components/CheckInPage.test.tsx` that verifies the manual-search login button calls `login("/check-in")` for unauthenticated users.
- Minor import and type updates to support the new usage in the check-in component.

### Testing

- Ran `pnpm typecheck` and the TypeScript build/compilation step succeeded.
- Ran `pnpm lint` and the lint step completed without errors.
- Attempted the focused test run `pnpm test -- tests/components/CheckInPage.test.tsx`, but the run timed out/failed in this environment because the container uses Node `v22` while the project requires Node `>=24`, so the test could not be fully executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b3afdc5c832e9c08729ec9df6f5b)