### PR TITLE
Fix OIDC callback router navigation

### DIFF
--- a/frontend/src/config/oidc.ts
+++ b/frontend/src/config/oidc.ts
@@ -17,14 +17,20 @@ const OIDC_REDIRECT_URI =
   import.meta.env.VITE_OIDC_REDIRECT_URI ?? `${window.location.origin}/admin`;
 const OIDC_SCOPE = import.meta.env.VITE_OIDC_SCOPE ?? "openid profile email";
 
-export const oidcConfig: AuthProviderProps = {
-  authority: OIDC_AUTHORITY,
-  client_id: OIDC_CLIENT_ID,
-  redirect_uri: OIDC_REDIRECT_URI,
-  scope: OIDC_SCOPE,
-  post_logout_redirect_uri: window.location.origin,
-  onSigninCallback: (user) => {
-    const returnTo = (user?.state as { returnTo?: string } | undefined)?.returnTo ?? "/admin";
-    window.history.replaceState({}, document.title, returnTo);
-  },
-};
+interface OidcConfigOptions {
+  navigateTo: (to: string) => void | Promise<void>;
+}
+
+export function createOidcConfig({ navigateTo }: OidcConfigOptions): AuthProviderProps {
+  return {
+    authority: OIDC_AUTHORITY,
+    client_id: OIDC_CLIENT_ID,
+    redirect_uri: OIDC_REDIRECT_URI,
+    scope: OIDC_SCOPE,
+    post_logout_redirect_uri: window.location.origin,
+    onSigninCallback: (user) => {
+      const returnTo = (user?.state as { returnTo?: string } | undefined)?.returnTo ?? "/admin";
+      return navigateTo(returnTo);
+    },
+  };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,7 +9,7 @@ import "bootstrap-icons/font/bootstrap-icons.css";
 import "leaflet/dist/leaflet.css";
 import Spinner from "react-bootstrap/Spinner";
 
-import { oidcConfig } from "./config/oidc";
+import { createOidcConfig } from "./config/oidc";
 import { AuthProvider } from "./contexts/AuthContext";
 
 import Footer from "./components/Footer";
@@ -452,6 +452,10 @@ const router = createAppRouter({
   CheckInRoute,
   MyRegistrationsRoute,
   PrivacyPolicyRoute,
+});
+
+const oidcConfig = createOidcConfig({
+  navigateTo: (to) => router.navigate({ to }),
 });
 
 declare module "@tanstack/react-router" {

--- a/frontend/tests/config/oidc.test.ts
+++ b/frontend/tests/config/oidc.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createOidcConfig } from "../../src/config/oidc";
+
+type SigninUser = Parameters<
+  NonNullable<ReturnType<typeof createOidcConfig>["onSigninCallback"]>
+>[0];
+
+describe("createOidcConfig", () => {
+  it("navigates through the app router to the OIDC return path", () => {
+    const navigateTo = vi.fn();
+    const config = createOidcConfig({ navigateTo });
+
+    config.onSigninCallback?.({ state: { returnTo: "/check-in?id=abc" } } as SigninUser);
+
+    expect(navigateTo).toHaveBeenCalledWith("/check-in?id=abc");
+  });
+
+  it("defaults post-sign-in navigation to the admin route", () => {
+    const navigateTo = vi.fn();
+    const config = createOidcConfig({ navigateTo });
+
+    config.onSigninCallback?.(undefined as unknown as SigninUser);
+
+    expect(navigateTo).toHaveBeenCalledWith("/admin");
+  });
+});


### PR DESCRIPTION
### Motivation
- Avoid using `window.history.replaceState` in the OIDC sign-in callback because it can leave the mounted router state out-of-sync with the URL after login redirects.
- Ensure post-login navigation goes through the app router so mounted route components and URL are consistent, and preserve the existing `/admin` fallback.

### Description
- Replace the exported `oidcConfig` with a factory `createOidcConfig({ navigateTo })` in `frontend/src/config/oidc.ts` that calls an injected `navigateTo` function from the sign-in callback instead of calling `history.replaceState`.
- Wire the factory into the app bootstrap in `frontend/src/main.tsx` by passing `router.navigate({ to })` so OIDC return redirects use TanStack Router navigation.
- Add unit tests `frontend/tests/config/oidc.test.ts` which verify the returned config navigates to the provided `returnTo` path and falls back to `/admin`.

### Testing
- Ran the focused unit tests with `cd frontend && pnpm exec vitest run tests/config/oidc.test.ts`, and the tests passed.
- Ran full TypeScript checks with `cd frontend && pnpm typecheck`, which succeeded (tooling emitted engine warnings about Node version but typecheck passed).
- Ran linting with `cd frontend && pnpm lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52d16cd954832ea419861e7d2af420)