### PR TITLE
Surface OIDC authentication errors in app UI

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -167,6 +167,7 @@
   "admin_token_placeholder": "Enter your admin token",
   "admin_login_button": "Login",
   "admin_login_error": "Invalid admin token. Please try again.",
+  "auth_error_title": "Authentication problem",
   "admin_logout": "Logout",
   "admin_registrations_tab": "Registrations",
   "admin_tables_tab": "Hall Layout",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -167,6 +167,7 @@
   "admin_token_placeholder": "Entrez votre jeton d'administration",
   "admin_login_button": "Se connecter",
   "admin_login_error": "Jeton d'administration invalide. Veuillez réessayer.",
+  "auth_error_title": "Problème d’authentification",
   "admin_logout": "Se déconnecter",
   "admin_registrations_tab": "Inscriptions",
   "admin_tables_tab": "Plan de salle",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -167,6 +167,7 @@
   "admin_token_placeholder": "Voer uw beheerderscode in",
   "admin_login_button": "Aanmelden",
   "admin_login_error": "Ongeldige beheerderscode. Probeer opnieuw.",
+  "auth_error_title": "Authenticatieprobleem",
   "admin_logout": "Afmelden",
   "admin_registrations_tab": "Registraties",
   "admin_tables_tab": "Zaalindeling",

--- a/frontend/src/components/CheckInPage.tsx
+++ b/frontend/src/components/CheckInPage.tsx
@@ -492,6 +492,15 @@ export default function CheckInPage() {
           {m.checkin_title()}
         </h2>
 
+        {auth.authError ? (
+          <Alert variant="danger" dismissible onClose={auth.clearAuthError}>
+            <Alert.Heading as="h3" className="h6">
+              {m.auth_error_title()}
+            </Alert.Heading>
+            <p className="mb-0">{auth.authError}</p>
+          </Alert>
+        ) : null}
+
         {shouldShowAuthLoadingGate ? (
           <div className="text-center py-4">
             <Spinner animation="border" variant="warning" role="status">

--- a/frontend/src/components/admin/AdminLoginForm.tsx
+++ b/frontend/src/components/admin/AdminLoginForm.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@/contexts/AuthContext";
+import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Container from "react-bootstrap/Container";
 import { m } from "@/paraglide/messages";
@@ -14,10 +15,15 @@ export default function AdminLoginForm() {
       </h2>
       <div className="row justify-content-center">
         <div className="col-12 col-sm-8 col-md-6 col-lg-4 text-center">
-          <Button
-            variant="warning"
-            onClick={() => auth.login()}
-          >
+          {auth.authError ? (
+            <Alert variant="danger" dismissible onClose={auth.clearAuthError}>
+              <Alert.Heading as="h3" className="h6">
+                {m.auth_error_title()}
+              </Alert.Heading>
+              <p className="mb-0">{auth.authError}</p>
+            </Alert>
+          ) : null}
+          <Button variant="warning" onClick={() => auth.login()}>
             {m.admin_login_button()}
           </Button>
         </div>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { createContext, useCallback, useContext, useMemo } from "react";
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
 import { useAuth as useOidcAuth } from "react-oidc-context";
 import { devError } from "@/utils/devLog";
 
@@ -10,6 +10,9 @@ export interface AuthContextType {
   hasRole: (role: string) => boolean;
   /** Returns the current OIDC access token, or null when not authenticated. */
   getAccessToken: () => string | null;
+  /** Authentication error to show in the app instead of leaving it in the console/provider only. */
+  authError: string | null;
+  clearAuthError: () => void;
   login: (returnTo?: string) => void;
   logout: () => void;
 }
@@ -35,6 +38,12 @@ function decodeTokenClaims(token: string | undefined): TokenClaims | null {
   } catch {
     return null;
   }
+}
+
+function formatAuthError(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  return fallback;
 }
 
 function extractRealmRoles(...claims: Array<TokenClaims | null | undefined>): string[] {
@@ -66,6 +75,8 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const oidcAuth = useOidcAuth();
+  const [redirectError, setRedirectError] = useState<string | null>(null);
+  const [dismissedOidcError, setDismissedOidcError] = useState<string | null>(null);
 
   const getAccessToken = useCallback((): string | null => {
     return oidcAuth.user?.access_token ?? null;
@@ -78,15 +89,35 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const hasRole = useCallback((role: string) => roles.includes(role), [roles]);
 
-  const login = useCallback((returnTo = "/admin") => {
-    oidcAuth.signinRedirect({ state: { returnTo } }).catch((error: unknown) => {
-      devError("signinRedirect failed:", error);
-    });
-  }, [oidcAuth]);
+  const oidcError = oidcAuth.error
+    ? formatAuthError(oidcAuth.error, "Authentication failed. Please try again.")
+    : null;
+  const visibleOidcError = oidcError === dismissedOidcError ? null : oidcError;
+  const authError = redirectError ?? visibleOidcError;
+
+  const clearAuthError = useCallback(() => {
+    setRedirectError(null);
+    setDismissedOidcError(oidcError);
+  }, [oidcError]);
+
+  const login = useCallback(
+    (returnTo = "/admin") => {
+      setRedirectError(null);
+      setDismissedOidcError(null);
+      oidcAuth.signinRedirect({ state: { returnTo } }).catch((error: unknown) => {
+        devError("signinRedirect failed:", error);
+        setRedirectError(formatAuthError(error, "Could not start sign-in. Please try again."));
+      });
+    },
+    [oidcAuth],
+  );
 
   const logout = useCallback(() => {
+    setRedirectError(null);
+    setDismissedOidcError(null);
     oidcAuth.signoutRedirect().catch((error: unknown) => {
       devError("signoutRedirect failed:", error);
+      setRedirectError(formatAuthError(error, "Could not sign out. Please try again."));
     });
   }, [oidcAuth]);
 
@@ -97,10 +128,22 @@ export function AuthProvider({ children }: AuthProviderProps) {
       roles,
       hasRole,
       getAccessToken,
+      authError,
+      clearAuthError,
       login,
       logout,
     }),
-    [oidcAuth.isAuthenticated, oidcAuth.isLoading, roles, hasRole, getAccessToken, login, logout],
+    [
+      oidcAuth.isAuthenticated,
+      oidcAuth.isLoading,
+      roles,
+      hasRole,
+      getAccessToken,
+      authError,
+      clearAuthError,
+      login,
+      logout,
+    ],
   );
 
   return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useAuth as useOidcAuth } from "react-oidc-context";
 import { devError } from "@/utils/devLog";
 
@@ -75,6 +75,7 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const oidcAuth = useOidcAuth();
+  const { signinRedirect, signoutRedirect } = oidcAuth;
   const [redirectError, setRedirectError] = useState<string | null>(null);
   const [dismissedOidcError, setDismissedOidcError] = useState<string | null>(null);
 
@@ -92,6 +93,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const oidcError = oidcAuth.error
     ? formatAuthError(oidcAuth.error, "Authentication failed. Please try again.")
     : null;
+
+  useEffect(() => {
+    if (oidcError === null) {
+      setDismissedOidcError(null);
+    }
+  }, [oidcError]);
+
   const visibleOidcError = oidcError === dismissedOidcError ? null : oidcError;
   const authError = redirectError ?? visibleOidcError;
 
@@ -104,22 +112,22 @@ export function AuthProvider({ children }: AuthProviderProps) {
     (returnTo = "/admin") => {
       setRedirectError(null);
       setDismissedOidcError(null);
-      oidcAuth.signinRedirect({ state: { returnTo } }).catch((error: unknown) => {
+      signinRedirect({ state: { returnTo } }).catch((error: unknown) => {
         devError("signinRedirect failed:", error);
         setRedirectError(formatAuthError(error, "Could not start sign-in. Please try again."));
       });
     },
-    [oidcAuth],
+    [signinRedirect],
   );
 
   const logout = useCallback(() => {
     setRedirectError(null);
     setDismissedOidcError(null);
-    oidcAuth.signoutRedirect().catch((error: unknown) => {
+    signoutRedirect().catch((error: unknown) => {
       devError("signoutRedirect failed:", error);
       setRedirectError(formatAuthError(error, "Could not sign out. Please try again."));
     });
-  }, [oidcAuth]);
+  }, [signoutRedirect]);
 
   const contextValue = useMemo<AuthContextType>(
     () => ({

--- a/frontend/tests/components/AdminLoginForm.test.tsx
+++ b/frontend/tests/components/AdminLoginForm.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AdminLoginForm from "@/components/admin/AdminLoginForm";
+import { useAuth } from "@/contexts/AuthContext";
+
+vi.mock("@/paraglide/messages", () => ({
+  m: {
+    admin_title: () => "Admin",
+    admin_login_button: () => "Login",
+    auth_error_title: () => "Authentication problem",
+  },
+}));
+
+describe("AdminLoginForm", () => {
+  it("surfaces OIDC and redirect errors in the login UI", () => {
+    const clearAuthError = vi.fn();
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      roles: [],
+      hasRole: vi.fn().mockReturnValue(false),
+      getAccessToken: vi.fn().mockReturnValue(null),
+      authError: "Keycloak is unreachable.",
+      clearAuthError,
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    render(<AdminLoginForm />);
+
+    expect(screen.getByRole("heading", { name: "Authentication problem" })).toBeInTheDocument();
+    expect(screen.getByText("Keycloak is unreachable.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    expect(clearAuthError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/components/CheckInPage.test.tsx
+++ b/frontend/tests/components/CheckInPage.test.tsx
@@ -56,6 +56,7 @@ vi.mock("@/paraglide/messages", () => ({
     checkin_manual_not_checked_in: () => "Not checked in",
     checkin_search_error: () => "Could not search registrations.",
     admin_login_button: () => "Login",
+    auth_error_title: () => "Authentication problem",
     admin_loading: () => "Loading…",
     admin_checked_in: () => "Checked in",
     admin_strap_issued: () => "Strap issued",
@@ -95,6 +96,8 @@ describe("CheckInPage", () => {
       roles: ["admin"],
       hasRole: vi.fn((role: string) => role === "admin"),
       getAccessToken: vi.fn().mockReturnValue("mock-access-token"),
+      authError: null,
+      clearAuthError: vi.fn(),
       login: vi.fn(),
       logout: vi.fn(),
     });
@@ -180,6 +183,8 @@ describe("CheckInPage", () => {
       roles: [],
       hasRole: vi.fn().mockReturnValue(false),
       getAccessToken: vi.fn().mockReturnValue("mock-access-token"),
+      authError: null,
+      clearAuthError: vi.fn(),
       login: vi.fn(),
       logout: vi.fn(),
     });
@@ -198,6 +203,8 @@ describe("CheckInPage", () => {
       roles: [],
       hasRole: vi.fn().mockReturnValue(false),
       getAccessToken: vi.fn().mockReturnValue(null),
+      authError: null,
+      clearAuthError: vi.fn(),
       login: vi.fn(),
       logout: vi.fn(),
     });
@@ -217,6 +224,8 @@ describe("CheckInPage", () => {
       roles: [],
       hasRole: vi.fn().mockReturnValue(false),
       getAccessToken: vi.fn().mockReturnValue(null),
+      authError: null,
+      clearAuthError: vi.fn(),
       login,
       logout: vi.fn(),
     });

--- a/frontend/tests/contexts.AuthContext.test.tsx
+++ b/frontend/tests/contexts.AuthContext.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useAuth as useOidcAuth } from "react-oidc-context";
+import type { User } from "oidc-client-ts";
+import { describe, expect, it, vi } from "vitest";
+
+const { AuthProvider, useAuth } =
+  await vi.importActual<typeof import("@/contexts/AuthContext")>("@/contexts/AuthContext");
+
+function mockOidcError(error: Error | null) {
+  vi.mocked(useOidcAuth).mockReturnValue({
+    isAuthenticated: false,
+    isLoading: false,
+    user: null as User | null,
+    error,
+    signinRedirect: vi.fn().mockResolvedValue(undefined),
+    signoutRedirect: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ReturnType<typeof useOidcAuth>);
+}
+
+function AuthErrorConsumer() {
+  const auth = useAuth();
+
+  return (
+    <div>
+      <span>{auth.authError ?? "No auth error"}</span>
+      <button type="button" onClick={auth.clearAuthError}>
+        Clear auth error
+      </button>
+    </div>
+  );
+}
+
+describe("AuthProvider", () => {
+  it("shows the same provider error again after the provider clears and re-emits it", () => {
+    mockOidcError(new Error("Keycloak is unavailable."));
+    const { rerender } = render(
+      <AuthProvider>
+        <AuthErrorConsumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText("Keycloak is unavailable.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear auth error" }));
+
+    expect(screen.getByText("No auth error")).toBeInTheDocument();
+
+    mockOidcError(null);
+    rerender(
+      <AuthProvider>
+        <AuthErrorConsumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText("No auth error")).toBeInTheDocument();
+
+    mockOidcError(new Error("Keycloak is unavailable."));
+    rerender(
+      <AuthProvider>
+        <AuthErrorConsumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByText("Keycloak is unavailable.")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -38,6 +38,8 @@ vi.mock("@/contexts/AuthContext", () => ({
     roles: ["admin"],
     hasRole: vi.fn((role: string) => role === "admin"),
     getAccessToken: vi.fn().mockReturnValue("mock-access-token"),
+    authError: null,
+    clearAuthError: vi.fn(),
     login: vi.fn(),
     logout: vi.fn(),
   }),

--- a/frontend/tests/state/LiveUpdatesProvider.test.tsx
+++ b/frontend/tests/state/LiveUpdatesProvider.test.tsx
@@ -49,6 +49,8 @@ describe("LiveUpdatesProvider", () => {
       roles: ["admin"],
       hasRole: vi.fn((role: string) => role === "admin"),
       getAccessToken: vi.fn().mockReturnValue("mock-access-token"),
+      authError: null,
+      clearAuthError: vi.fn(),
       login: vi.fn(),
       logout: vi.fn(),
     });
@@ -72,6 +74,8 @@ describe("LiveUpdatesProvider", () => {
       roles: [],
       hasRole: vi.fn().mockReturnValue(false),
       getAccessToken: vi.fn().mockReturnValue(null),
+      authError: null,
+      clearAuthError: vi.fn(),
       login: vi.fn(),
       logout: vi.fn(),
     });


### PR DESCRIPTION
### Motivation
- Make OIDC/provider and redirect startup failures visible to users instead of leaving them only in console logs.
- Provide clear, dismissible in-app feedback on admin and volunteer/check-in screens when authentication is unavailable or fails.

### Description
- Added `authError: string | null` and `clearAuthError()` to the auth context and expose `authError` via the `AuthProvider`; aggregate `oidcAuth.error` and redirect (`signinRedirect`/`signoutRedirect`) failures into this state and format messages with `formatAuthError`.
- Added dismissible alert UI on the admin login (`frontend/src/components/admin/AdminLoginForm.tsx`) and check-in page (`frontend/src/components/CheckInPage.tsx`) that shows `authError` with a localized title.
- Introduced localized message key `auth_error_title` in `frontend/messages/{en,fr,nl}.json` and added a regression test `frontend/tests/components/AdminLoginForm.test.tsx` covering display and dismissal behavior.
- Updated test setup and existing tests to include the new `authError` and `clearAuthError` mocks and added a small UX behavior to avoid re-showing dismissed provider errors (`dismissedOidcError` logic).

### Testing
- Ran `pnpm typecheck` which completed successfully.
- Ran `pnpm lint` which completed successfully.
- Ran unit tests with `pnpm exec vitest run tests/components/AdminLoginForm.test.tsx tests/components/CheckInPage.test.tsx` and the test suite passed (2 files, 20 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a536dea52ec832ea9e121652e34bdcf)