### PR TITLE
Raise CodeQL Kotlin support gate to 2.4.0

### DIFF
--- a/.github/workflows/codeql-android.yml
+++ b/.github/workflows/codeql-android.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
           kotlin_version="$(awk -F '"' '/^kotlin = / { print $2 }' android/gradle/libs.versions.toml)"
-          max_supported="2.3.29"
+          max_supported="2.4.0"
           if printf '%s\n%s\n' "${kotlin_version}" "${max_supported}" | sort -V -C; then
             echo "supported=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/codeql-android.yml
+++ b/.github/workflows/codeql-android.yml
@@ -42,7 +42,7 @@ jobs:
             echo "supported=true" >> "$GITHUB_OUTPUT"
           else
             echo "supported=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping CodeQL java-kotlin analysis: Kotlin ${kotlin_version} is newer than CodeQL's current Kotlin support."
+            echo "::warning::Skipping CodeQL java-kotlin analysis: Kotlin ${kotlin_version} is newer than CodeQL's current Kotlin support."
           fi
 
       - name: Initialize CodeQL


### PR DESCRIPTION
## Summary

- CodeQL 2.26.0 [added support for Kotlin up to 2.4.0](``https://github.blog/changelog/2026-07-10-codeql-2-26-0-adds-kotlin-2-4-0-support-and-ai-prompt-injection-detection/),`` and the pinned `codeql-action@v4.37.0` already bundles CodeQL CLI 2.26.0.
- `android/gradle/libs.versions.toml` already uses `kotlin = "2.4.0"`, but `codeql-android.yml`'s own version gate was still capped at `2.3.29`, so CodeQL's java-kotlin analysis for the android module was silently being skipped every run.
- Bumped the gate's `max_supported` from `2.3.29` to `2.4.0` so analysis actually runs again.

## Test plan

- [ ] CodeQL Android workflow run shows `supported=true` and completes the java-kotlin analysis (no longer skipped)

Closes #716

---
_Generated by [Claude Code](https://claude.ai/code/session_017vJRx33cQWZwLVvp79uMDC)_