### PR TITLE
fix: don't percent-encode mailto address in CommunityEvents

### DIFF
--- a/frontend/src/components/CommunityEvents.tsx
+++ b/frontend/src/components/CommunityEvents.tsx
@@ -260,7 +260,7 @@ export default function CommunityEvents() {
                           <Alert variant="warning" className="py-2 mb-0">
                             <strong>{m.community_events_table_reservations()}</strong>{" "}
                             {item.externalContactName} (
-                            <a href={`mailto:${encodeURIComponent(item.externalContactEmail)}`}>
+                            <a href={`mailto:${item.externalContactEmail}`}>
                               {item.externalContactEmail}
                             </a>
                             )


### PR DESCRIPTION
## Summary
- Addresses [review comment](https://github.com/tjorim/champagnefestival/pull/663#discussion_r3612114136) on PR #663.
- `frontend/src/components/CommunityEvents.tsx`: the `mailto:` link for `item.externalContactEmail` no longer wraps the address in `encodeURIComponent`.
  - The address is already validated by `EMAIL_REGEX`, so its character set is already URI-safe and contains no HTML-special characters.
  - Percent-encoding `@` as `%40` is known to break `mailto:` handling in some mail clients, which expect the raw address.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`

Targets `frontend/visual-refresh-and-fixes` (the head branch of #663) so merging this lands the fix directly in that PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_018eqsBiaqveEupDTzF9VSBA)_