### PR TITLE
Render every active event for community editions

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -235,6 +235,14 @@ async def _validate_standalone_event_date(
     event_date: date,
     exclude_event_id: str | None = None,
 ) -> None:
+    """Enforce the community-edition event cardinality contract.
+
+    Community editions (`bourse`, `capsule_exchange`) may contain any number of events
+    (e.g. separate opening, tasting, and auction entries), but every event on such an
+    edition must share the same calendar date. Festival editions are unrestricted since
+    they legitimately span multiple days. The public UI and admin UI both render every
+    active event for an edition, so this is the only cardinality constraint enforced.
+    """
     if edition.edition_type == "festival":
         return
     stmt = select(Event.date).where(Event.edition_id == edition.id)

--- a/backend/tests/test_editions.py
+++ b/backend/tests/test_editions.py
@@ -250,8 +250,12 @@ async def test_standalone_event_can_move_within_same_single_day(client):
 
 
 @pytest.mark.anyio
-async def test_community_edition_upcoming_lists_every_active_event_in_time_order(client):
-    """Community editions may hold multiple same-day events; the public payload must list them all."""
+async def test_community_edition_upcoming_lists_every_event_in_time_order(client):
+    """Community editions may hold multiple same-day events; the public payload lists them all,
+
+    in date/time order, regardless of each event's `active` flag. (Filtering to active-only
+    is a public-frontend concern, not a backend one — see CommunityEvents.tsx.)
+    """
     venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
     assert venue_response.status_code == 201
     venue_id = venue_response.json()["id"]

--- a/backend/tests/test_editions.py
+++ b/backend/tests/test_editions.py
@@ -250,6 +250,128 @@ async def test_standalone_event_can_move_within_same_single_day(client):
 
 
 @pytest.mark.anyio
+async def test_community_edition_upcoming_lists_every_active_event_in_time_order(client):
+    """Community editions may hold multiple same-day events; the public payload must list them all."""
+    venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    assert venue_response.status_code == 201
+    venue_id = venue_response.json()["id"]
+
+    edition_response = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-bourse-multi-event",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "edition_type": "bourse",
+            "active": True,
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert edition_response.status_code == 201
+
+    # Created out of chronological order to prove ordering is by time, not insertion order.
+    for payload in [
+        {
+            "edition_id": "edition-bourse-multi-event",
+            "title": "Bourse Auction",
+            "description": "",
+            "date": "2099-03-21",
+            "start_time": "15:00",
+            "category": "exchange",
+            "registration_required": False,
+            "active": True,
+        },
+        {
+            "edition_id": "edition-bourse-multi-event",
+            "title": "Bourse Opening",
+            "description": "",
+            "date": "2099-03-21",
+            "start_time": "10:00",
+            "category": "exchange",
+            "registration_required": False,
+            "active": True,
+        },
+        {
+            "edition_id": "edition-bourse-multi-event",
+            "title": "Draft Tasting",
+            "description": "",
+            "date": "2099-03-21",
+            "start_time": "12:00",
+            "category": "exchange",
+            "registration_required": False,
+            "active": False,
+        },
+    ]:
+        event_response = await client.post("/api/events", json=payload, headers=ADMIN_HEADERS)
+        assert event_response.status_code == 201
+
+    r = await client.get("/api/editions/upcoming", params={"edition_type": "bourse"})
+    assert r.status_code == 200
+    edition = next(e for e in r.json() if e["id"] == "edition-bourse-multi-event")
+    assert [event["title"] for event in edition["events"]] == [
+        "Bourse Opening",
+        "Draft Tasting",
+        "Bourse Auction",
+    ]
+
+
+@pytest.mark.anyio
+async def test_standalone_event_rejects_a_second_date(client):
+    """Community editions may only span a single calendar date."""
+    venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    assert venue_response.status_code == 201
+    venue_id = venue_response.json()["id"]
+
+    edition_response = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-bourse-two-dates",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "edition_type": "bourse",
+            "active": True,
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert edition_response.status_code == 201
+
+    first_event = await client.post(
+        "/api/events",
+        json={
+            "edition_id": "edition-bourse-two-dates",
+            "title": "Bourse Opening",
+            "description": "",
+            "date": "2099-03-21",
+            "start_time": "10:00",
+            "category": "exchange",
+            "registration_required": False,
+            "active": True,
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert first_event.status_code == 201
+
+    second_event = await client.post(
+        "/api/events",
+        json={
+            "edition_id": "edition-bourse-two-dates",
+            "title": "Bourse Auction",
+            "description": "",
+            "date": "2099-03-22",
+            "start_time": "10:00",
+            "category": "exchange",
+            "registration_required": False,
+            "active": True,
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert second_event.status_code == 400
+    assert "single date" in second_event.json()["detail"].lower()
+
+
+@pytest.mark.anyio
 async def test_edition_rejects_vendor_exhibitors(client):
     """Vendor-type exhibitors must not be linked to editions."""
     r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)

--- a/frontend/src/components/CommunityEvents.tsx
+++ b/frontend/src/components/CommunityEvents.tsx
@@ -190,22 +190,22 @@ export default function CommunityEvents() {
   });
 
   const items = useMemo<CommunityEventCardData[]>(() => {
-    const cards = data.flatMap((edition): CommunityEventCardData[] => {
-      const event = (edition.events ?? []).map(apiToEvent)[0];
-      if (!event) return [];
-
-      return [
-        {
-          id: edition.id,
+    // Community editions may hold multiple same-day events (opening, tasting, auction, ...).
+    // Every active event is rendered as its own card; inactive (draft) events stay hidden.
+    const cards = data.flatMap((edition): CommunityEventCardData[] =>
+      (edition.events ?? [])
+        .map(apiToEvent)
+        .filter((event) => event.active)
+        .map((event) => ({
+          id: event.id,
           editionType: edition.edition_type,
           event,
           venueName: edition.venue?.name ?? "",
           externalPartner: edition.external_partner ?? undefined,
           externalContactName: edition.external_contact_name ?? undefined,
           externalContactEmail: edition.external_contact_email ?? undefined,
-        },
-      ];
-    });
+        })),
+    );
 
     return cards.sort(
       (left, right) =>
@@ -240,6 +240,7 @@ export default function CommunityEvents() {
                     <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
                       <div>
                         <h5 className="mb-1">{getEditionTitle(item.editionType)}</h5>
+                        <p className="mb-1 fw-semibold">{item.event.title}</p>
                         <p className="mb-1 text-muted">
                           <i className="bi bi-calendar-event me-2" aria-hidden="true" />
                           {formatDate(item.event.date)} • {item.event.startTime}

--- a/frontend/tests/components/CommunityEvents.test.tsx
+++ b/frontend/tests/components/CommunityEvents.test.tsx
@@ -103,6 +103,58 @@ describe("CommunityEvents", () => {
     ]);
   });
 
+  it("renders every active event for an edition, ordered by date and start time", async () => {
+    server.use(
+      http.get("/api/editions/upcoming", ({ request }) => {
+        const editionType = new URL(request.url).searchParams.get("edition_type");
+        if (editionType !== "bourse") return HttpResponse.json([]);
+
+        return HttpResponse.json([
+          {
+            id: "edition-bourse",
+            edition_type: "bourse",
+            venue: { name: "Staf Versluys" },
+            events: [
+              { ...BASE_EVENT, id: "event-auction", title: "Bourse Auction", start_time: "15:00" },
+              { ...BASE_EVENT, id: "event-opening", title: "Bourse Opening", start_time: "10:00" },
+            ],
+          },
+        ]);
+      }),
+    );
+
+    renderCommunityEvents();
+
+    const titles = await screen.findAllByText(/^Bourse (Opening|Auction)$/);
+    expect(titles.map((title) => title.textContent)).toEqual(["Bourse Opening", "Bourse Auction"]);
+  });
+
+  it("omits inactive events from the public list", async () => {
+    server.use(
+      http.get("/api/editions/upcoming", ({ request }) => {
+        const editionType = new URL(request.url).searchParams.get("edition_type");
+        if (editionType !== "bourse") return HttpResponse.json([]);
+
+        return HttpResponse.json([
+          {
+            id: "edition-bourse",
+            edition_type: "bourse",
+            venue: { name: "Staf Versluys" },
+            events: [
+              { ...BASE_EVENT, id: "event-opening", title: "Bourse Opening", active: true },
+              { ...BASE_EVENT, id: "event-draft", title: "Draft Tasting", active: false },
+            ],
+          },
+        ]);
+      }),
+    );
+
+    renderCommunityEvents();
+
+    expect(await screen.findByText("Bourse Opening")).toBeInTheDocument();
+    expect(screen.queryByText("Draft Tasting")).not.toBeInTheDocument();
+  });
+
   it("shows an error for malformed successful API responses", async () => {
     server.use(
       http.get("/api/editions/upcoming", () =>


### PR DESCRIPTION
## Summary

Closes #736.

Community editions (`bourse`, `capsule_exchange`) can legitimately contain multiple same-day events (e.g. separate opening, tasting, and auction entries) — the backend only ever enforced that events on a community edition share a single calendar date, and the admin `EditionCard` already lists/manages every event. The public `CommunityEvents` component was the outlier: it rendered only `edition.events[0]`, silently hiding every other event.

This picks contract **1** from the issue (multiple events allowed, public UI renders every active one) since that's what the backend and admin UI already implement — enforcing "exactly one event" would have required a new backend/admin restriction with no existing support for it.

- `frontend/src/components/CommunityEvents.tsx`: flatten each edition's **active** events into individual cards (one per event) instead of taking `events[0]`; show the event's own title so multiple events on one edition are distinguishable; keep sorting deterministic by date then start time.
- `backend/app/routers/events.py`: document the cardinality contract on `_validate_standalone_event_date` (multiple events allowed per community edition, but all must share one date; festival editions are unrestricted).
- Added backend coverage for a community edition with multiple same-day events (returned in time order via `/api/editions/upcoming`, inactive events retained in the raw payload) and for the existing "second date is rejected" validation path, which had no test.
- Added frontend coverage for rendering multiple active events per edition (ordered) and for hiding inactive events from the public list.

## Test plan

- [x] `cd backend && uv run pytest` (353 passed)
- [x] `cd backend && uv run ruff check app` / `uv run ty check app`
- [x] `cd frontend && pnpm test` / `pnpm typecheck` / `pnpm lint` / `pnpm build`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gefyvjuzoj6hdKMA8Jre6M)_