### PR TITLE
Exclude inactive events from public edition projections

### DIFF
--- a/backend/app/routers/editions.py
+++ b/backend/app/routers/editions.py
@@ -26,24 +26,29 @@ async def get_active_edition(
     db: AsyncSession = Depends(get_db),
     edition_type: EditionType | None = Query(default=None),
 ) -> dict:
-    """Return the current or next upcoming active edition, optionally filtered by type."""
+    """Return the current or next upcoming active edition, optionally filtered by type.
+
+    Only the edition's *active* events are considered: an inactive (draft/cancelled)
+    event neither keeps an otherwise-finished edition classified as upcoming, nor
+    appears in the response.
+    """
     editions = await _load_editions(db, include_inactive=False, edition_type=edition_type)
     if not editions:
         raise HTTPException(status_code=404, detail="No active editions found.")
 
     today = datetime.now(UTC).date()
-    dated = _sorted_editions(editions)
+    dated = _sorted_editions(editions, active_only=True)
     active = next(
         (
             edition
             for edition in dated
-            if (edition_end_date := _edition_end_date(edition)) and edition_end_date >= today
+            if (edition_end_date := _edition_end_date(_active_events(edition))) and edition_end_date >= today
         ),
         None,
     )
     if active is None:
         raise HTTPException(status_code=404, detail="No active or upcoming editions found.")
-    return await _edition_payload(db, active)
+    return await _edition_payload(db, active, active_only=True)
 
 
 @router.get("/upcoming", response_model=list[EditionOut])
@@ -51,11 +56,17 @@ async def list_upcoming_editions(
     db: AsyncSession = Depends(get_db),
     edition_type: EditionType | None = Query(default=None),
 ) -> list[dict]:
-    """List upcoming active editions across all supported edition types."""
+    """List upcoming active editions across all supported edition types.
+
+    Only each edition's active events count toward its upcoming status, and only
+    active events are serialized in the response; see `get_active_edition`.
+    """
     today = datetime.now(UTC).date()
     editions = await _load_editions(db, include_inactive=False, edition_type=edition_type)
-    upcoming = [edition for edition in editions if (_edition_end_date(edition) or date.min) >= today]
-    return await _edition_payloads(db, _sorted_editions(upcoming))
+    upcoming = [
+        edition for edition in editions if (_edition_end_date(_active_events(edition)) or date.min) >= today
+    ]
+    return await _edition_payloads(db, _sorted_editions(upcoming, active_only=True), active_only=True)
 
 
 @router.get("", response_model=list[EditionOut], dependencies=[Depends(require_admin)])
@@ -63,8 +74,9 @@ async def list_editions(
     db: AsyncSession = Depends(get_db),
     include_inactive: bool = Query(False),
 ) -> list[dict]:
+    """Admin listing: exposes every event (active or not) for management purposes."""
     editions = await _load_editions(db, include_inactive=include_inactive)
-    return await _edition_payloads(db, _sorted_editions(editions))
+    return await _edition_payloads(db, _sorted_editions(editions, active_only=False), active_only=False)
 
 
 @router.get("/stats", response_model=list[EditionAttendanceStats], dependencies=[Depends(require_admin)])
@@ -78,7 +90,7 @@ async def list_edition_attendance_stats(
     Registered but cancelled bookings are excluded from every count.
     """
     editions = await _load_editions(db, include_inactive=True, edition_type=edition_type)
-    editions = _sorted_editions(editions)
+    editions = _sorted_editions(editions, active_only=False)
 
     stmt = (
         select(
@@ -104,7 +116,7 @@ async def list_edition_attendance_stats(
                 "year": edition.year,
                 "month": edition.month,
                 "edition_type": edition.edition_type,
-                "start_date": _edition_start_date(edition),
+                "start_date": _edition_start_date(edition.events),
                 "events_count": len(edition.events),
                 "total_registrations": stats.total_registrations if stats else 0,
                 "total_guests": stats.total_guests if stats else 0,
@@ -117,7 +129,7 @@ async def list_edition_attendance_stats(
 @router.get("/{edition_id}", response_model=EditionOut, dependencies=[Depends(require_admin)])
 async def get_edition(edition_id: str, db: AsyncSession = Depends(get_db)) -> dict:
     edition = await _get_edition_or_404(db, edition_id)
-    return await _edition_payload(db, edition)
+    return await _edition_payload(db, edition, active_only=False)
 
 
 @router.post(
@@ -165,7 +177,7 @@ async def create_edition(
     )
     await db.commit()
     edition = await _get_edition_or_404(db, edition.id)
-    return await _edition_payload(db, edition)
+    return await _edition_payload(db, edition, active_only=False)
 
 
 @router.put("/{edition_id}", response_model=EditionOut, dependencies=[Depends(require_admin)])
@@ -215,7 +227,7 @@ async def update_edition(
     )
     await db.commit()
     edition = await _get_edition_or_404(db, edition.id)
-    return await _edition_payload(db, edition)
+    return await _edition_payload(db, edition, active_only=False)
 
 
 @router.delete(
@@ -311,7 +323,14 @@ async def _validate_exhibitor_ids(db: AsyncSession, exhibitor_ids: list[int]) ->
         )
 
 
-async def _edition_payloads(db: AsyncSession, editions: list[Edition]) -> list[dict]:
+async def _edition_payloads(db: AsyncSession, editions: list[Edition], *, active_only: bool) -> list[dict]:
+    """Build edition response payloads.
+
+    `active_only` controls whether inactive events are dropped from the serialized
+    `events`/`dates` fields. Public endpoints (`/active`, `/upcoming`) pass `True` so
+    inactive (draft/cancelled) events never appear in unauthenticated responses;
+    admin endpoints pass `False` so event management keeps seeing everything.
+    """
     venues = await _load_venues_by_ids(db, {edition.venue_id for edition in editions})
     exhibitor_map = await _load_exhibitors_by_ids(
         db,
@@ -327,15 +346,16 @@ async def _edition_payloads(db: AsyncSession, editions: list[Edition]) -> list[d
             )
             continue
         producers, sponsors, vendors = _resolve_exhibitors(edition, exhibitor_map)
+        events = _active_events(edition) if active_only else edition.events
         payloads.append(
             edition_to_dict(
                 edition,
                 venue=venues[edition.venue_id],
-                dates=_edition_dates(edition),
+                dates=_edition_dates(events),
                 events=[
                     event_to_summary_dict(event)
                     for event in sorted(
-                        edition.events,
+                        events,
                         key=lambda event: (event.date, event.start_time, event.created_at),
                     )
                 ],
@@ -347,8 +367,8 @@ async def _edition_payloads(db: AsyncSession, editions: list[Edition]) -> list[d
     return payloads
 
 
-async def _edition_payload(db: AsyncSession, edition: Edition) -> dict:
-    payloads = await _edition_payloads(db, [edition])
+async def _edition_payload(db: AsyncSession, edition: Edition, *, active_only: bool) -> dict:
+    payloads = await _edition_payloads(db, [edition], active_only=active_only)
     if not payloads:
         raise HTTPException(status_code=404, detail="Edition not found.")
     return payloads[0]
@@ -371,29 +391,34 @@ def _resolve_exhibitors(edition: Edition, exhibitor_map: dict[int, dict]) -> tup
     return producers, sponsors, vendors
 
 
-def _edition_dates(edition: Edition) -> list[date]:
-    return sorted({event.date for event in edition.events})
+def _active_events(edition: Edition) -> list[Event]:
+    return [event for event in edition.events if event.active]
 
 
-def _edition_start_date(edition: Edition) -> date | None:
-    return min((event.date for event in edition.events), default=None)
+def _edition_dates(events: list[Event]) -> list[date]:
+    return sorted({event.date for event in events})
 
 
-def _edition_end_date(edition: Edition) -> date | None:
-    return max((event.date for event in edition.events), default=None)
+def _edition_start_date(events: list[Event]) -> date | None:
+    return min((event.date for event in events), default=None)
 
 
-def _sorted_editions(editions: list[Edition]) -> list[Edition]:
-    return sorted(
-        editions,
-        key=lambda edition: (
-            _edition_start_date(edition) or date.max,
-            _edition_end_date(edition) or date.max,
+def _edition_end_date(events: list[Event]) -> date | None:
+    return max((event.date for event in events), default=None)
+
+
+def _sorted_editions(editions: list[Edition], *, active_only: bool) -> list[Edition]:
+    def sort_key(edition: Edition) -> tuple:
+        events = _active_events(edition) if active_only else edition.events
+        return (
+            _edition_start_date(events) or date.max,
+            _edition_end_date(events) or date.max,
             edition.year,
             edition.month,
             edition.created_at,
-        ),
-    )
+        )
+
+    return sorted(editions, key=sort_key)
 
 
 def _validate_exhibitors_allowed(edition_type: EditionType, exhibitors: list[int]) -> None:

--- a/backend/app/routers/editions.py
+++ b/backend/app/routers/editions.py
@@ -63,9 +63,7 @@ async def list_upcoming_editions(
     """
     today = datetime.now(UTC).date()
     editions = await _load_editions(db, include_inactive=False, edition_type=edition_type)
-    upcoming = [
-        edition for edition in editions if (_edition_end_date(_active_events(edition)) or date.min) >= today
-    ]
+    upcoming = [edition for edition in editions if (_edition_end_date(_active_events(edition)) or date.min) >= today]
     return await _edition_payloads(db, _sorted_editions(upcoming, active_only=True), active_only=True)
 
 
@@ -346,19 +344,15 @@ async def _edition_payloads(db: AsyncSession, editions: list[Edition], *, active
             )
             continue
         producers, sponsors, vendors = _resolve_exhibitors(edition, exhibitor_map)
+        # `Edition.events` is loaded pre-ordered by (date, start_time, created_at); filtering
+        # to active events preserves that order, so no re-sort is needed here.
         events = _active_events(edition) if active_only else edition.events
         payloads.append(
             edition_to_dict(
                 edition,
                 venue=venues[edition.venue_id],
                 dates=_edition_dates(events),
-                events=[
-                    event_to_summary_dict(event)
-                    for event in sorted(
-                        events,
-                        key=lambda event: (event.date, event.start_time, event.created_at),
-                    )
-                ],
+                events=[event_to_summary_dict(event) for event in events],
                 producers=producers,
                 sponsors=sponsors,
                 vendors=vendors,
@@ -396,15 +390,16 @@ def _active_events(edition: Edition) -> list[Event]:
 
 
 def _edition_dates(events: list[Event]) -> list[date]:
-    return sorted({event.date for event in events})
+    """Unique event dates in chronological order (relies on `events` being pre-sorted by date)."""
+    return list(dict.fromkeys(event.date for event in events))
 
 
 def _edition_start_date(events: list[Event]) -> date | None:
-    return min((event.date for event in events), default=None)
+    return events[0].date if events else None
 
 
 def _edition_end_date(events: list[Event]) -> date | None:
-    return max((event.date for event in events), default=None)
+    return events[-1].date if events else None
 
 
 def _sorted_editions(editions: list[Edition], *, active_only: bool) -> list[Edition]:

--- a/backend/tests/test_editions.py
+++ b/backend/tests/test_editions.py
@@ -250,11 +250,10 @@ async def test_standalone_event_can_move_within_same_single_day(client):
 
 
 @pytest.mark.anyio
-async def test_community_edition_upcoming_lists_every_event_in_time_order(client):
-    """Community editions may hold multiple same-day events; the public payload lists them all,
+async def test_community_edition_upcoming_lists_every_active_event_in_time_order(client):
+    """Community editions may hold multiple same-day events; the public payload lists every
 
-    in date/time order, regardless of each event's `active` flag. (Filtering to active-only
-    is a public-frontend concern, not a backend one — see CommunityEvents.tsx.)
+    active one in date/time order, and excludes inactive (draft/cancelled) events entirely.
     """
     venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
     assert venue_response.status_code == 201
@@ -315,9 +314,111 @@ async def test_community_edition_upcoming_lists_every_event_in_time_order(client
     edition = next(e for e in r.json() if e["id"] == "edition-bourse-multi-event")
     assert [event["title"] for event in edition["events"]] == [
         "Bourse Opening",
-        "Draft Tasting",
         "Bourse Auction",
     ]
+
+
+@pytest.mark.anyio
+async def test_inactive_event_does_not_keep_finished_edition_upcoming(client):
+    """An edition whose only future event is inactive must not be reported as active/upcoming."""
+    venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    assert venue_response.status_code == 201
+    venue_id = venue_response.json()["id"]
+
+    edition_response = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-only-inactive-future",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "active": True,
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert edition_response.status_code == 201
+
+    event_response = await client.post(
+        "/api/events",
+        json={
+            "edition_id": "edition-only-inactive-future",
+            "title": "Draft Sunday",
+            "description": "",
+            "date": "2099-03-22",
+            "start_time": "14:00",
+            "category": "festival",
+            "registration_required": False,
+            "active": False,
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert event_response.status_code == 201
+
+    active_response = await client.get("/api/editions/active")
+    assert active_response.status_code == 404
+
+    upcoming_response = await client.get("/api/editions/upcoming")
+    assert upcoming_response.status_code == 200
+    assert all(edition["id"] != "edition-only-inactive-future" for edition in upcoming_response.json())
+
+
+@pytest.mark.anyio
+async def test_inactive_events_excluded_from_active_edition_response(client):
+    """A mix of active and inactive events on the same edition: only the active one is returned."""
+    venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    assert venue_response.status_code == 201
+    venue_id = venue_response.json()["id"]
+
+    edition_response = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-mixed-active",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "active": True,
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert edition_response.status_code == 201
+
+    for payload in [
+        {
+            "edition_id": "edition-mixed-active",
+            "title": "Draft Preview",
+            "description": "",
+            "date": "2099-03-20",
+            "start_time": "10:00",
+            "category": "festival",
+            "registration_required": False,
+            "active": False,
+        },
+        {
+            "edition_id": "edition-mixed-active",
+            "title": "Published Gala",
+            "description": "",
+            "date": "2099-03-21",
+            "start_time": "18:00",
+            "category": "festival",
+            "registration_required": False,
+            "active": True,
+        },
+    ]:
+        event_response = await client.post("/api/events", json=payload, headers=ADMIN_HEADERS)
+        assert event_response.status_code == 201
+
+    active_response = await client.get("/api/editions/active")
+    assert active_response.status_code == 200
+    data = active_response.json()
+    assert data["id"] == "edition-mixed-active"
+    assert [event["title"] for event in data["events"]] == ["Published Gala"]
+    assert data["dates"] == ["2099-03-21"]
+
+    admin_response = await client.get(f"/api/editions/{data['id']}", headers=ADMIN_HEADERS)
+    assert admin_response.status_code == 200
+    admin_data = admin_response.json()
+    assert [event["title"] for event in admin_data["events"]] == ["Draft Preview", "Published Gala"]
+    assert admin_data["dates"] == ["2099-03-20", "2099-03-21"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Closes #737.

`/api/editions/active` and `/api/editions/upcoming` derived edition start/end dates and serialized events from *every* associated event, including inactive (draft/cancelled) ones. That meant:

- An inactive future event could keep an otherwise-finished edition classified as upcoming.
- Inactive events could be returned in unauthenticated public responses.

`backend/app/routers/editions.py`:
- Added `_active_events(edition)` to filter an edition's events down to `active=True`.
- `_edition_dates` / `_edition_start_date` / `_edition_end_date` now take an explicit `events` list instead of an `Edition`, so callers choose which set (active-only vs. all) to derive dates from.
- `_sorted_editions` and `_edition_payloads` / `_edition_payload` take an `active_only` flag: `True` for the public `/active` and `/upcoming` endpoints (drops inactive events from dates/status/serialization), `False` for admin endpoints (`list_editions`, `get_edition`, `create_edition`, `update_edition`, `/stats`) which continue to expose every event for management.
- An edition whose only events are inactive now correctly falls out of the active/upcoming selection (its computed end date is `None`) instead of erroring.

`backend/tests/test_editions.py`:
- Updated the existing multi-event ordering test to assert inactive events are excluded from the public payload (previously this documented the old "filtering is a frontend concern" behavior).
- Added coverage for an edition whose only future event is inactive (must not appear in `/active` or `/upcoming`).
- Added coverage for a mix of active/inactive events on one edition: the public `/active` response only returns the active one, while the admin `GET /api/editions/{id}` response still returns both.

No frontend changes were needed — `frontend/src/hooks/useActiveEdition.ts` and `frontend/src/components/CommunityEvents.tsx` already just render whatever events the backend returns (`CommunityEvents.tsx` also has a client-side `active` filter from #743, which is now redundant but harmless defense-in-depth).

## Test plan

- [x] `cd backend && uv run pytest` (355 passed)
- [x] `cd backend && uv run ruff check app` / `uv run ty check app`


---
_Generated by [Claude Code](https://claude.ai/code/session_013BvAUGsAivng3MPVfdEQ1N)_