### PR TITLE
Align community contact email validation across backend and frontend

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import date as dt_date
 from datetime import datetime
 from typing import Literal, Self
@@ -810,6 +811,27 @@ class RoomOut(BaseModel):
 # Editions
 # ---------------------------------------------------------------------------
 
+# Canonical contract for community edition contact emails, shared with the
+# frontend's COMMUNITY_CONTACT_EMAIL_REGEX (frontend/src/config/constants.ts).
+# Deliberately narrower than Pydantic's EmailStr: ASCII-only RFC 5321 "dot-atom"
+# local part plus a conventional domain, so any address accepted here is
+# guaranteed renderable as a safe `mailto:` link and free of control/header
+# injection characters. Keep both patterns in sync.
+COMMUNITY_CONTACT_EMAIL_PATTERN = re.compile(
+    r"^[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*"
+    r"@[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+    r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*\.[A-Za-z]{2,}$"
+)
+
+
+def _validate_community_contact_email(v: str | None) -> str | None:
+    if v is not None and not COMMUNITY_CONTACT_EMAIL_PATTERN.match(v):
+        raise ValueError(
+            "external_contact_email must be an ASCII email address "
+            "(internationalized/Unicode addresses are not supported)."
+        )
+    return v
+
 
 class EditionCreate(BaseModel):
     id: str = Field(min_length=1, max_length=100)
@@ -823,6 +845,11 @@ class EditionCreate(BaseModel):
     exhibitors: list[int] = Field(default_factory=list)
     active: bool = True
 
+    @field_validator("external_contact_email")
+    @classmethod
+    def validate_external_contact_email(cls, v: str | None) -> str | None:
+        return _validate_community_contact_email(v)
+
 
 class EditionUpdate(BaseModel):
     year: int | None = Field(default=None, ge=2020, le=2100)
@@ -834,6 +861,11 @@ class EditionUpdate(BaseModel):
     external_contact_email: EmailStr | None = None
     exhibitors: list[int] | None = None
     active: bool | None = None
+
+    @field_validator("external_contact_email")
+    @classmethod
+    def validate_external_contact_email(cls, v: str | None) -> str | None:
+        return _validate_community_contact_email(v)
 
 
 class EditionItemOut(BaseModel):

--- a/backend/tests/test_editions.py
+++ b/backend/tests/test_editions.py
@@ -571,3 +571,98 @@ async def test_edition_stats_includes_editions_with_no_registrations(client):
     assert entry["total_guests"] == 0
     assert entry["total_checked_in"] == 0
     assert entry["events_count"] == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "email",
+    [
+        "organizer@example.com",
+        "first.last@example.co.uk",
+        "bourse+events@example.com",
+        # RFC 5321 atext characters beyond the common "safe" subset.
+        "bourse!#$%&'*=?^_`{|}~-tag@example.com",
+    ],
+)
+async def test_edition_accepts_legitimate_contact_emails(client, email):
+    venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = venue_response.json()["id"]
+
+    r = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-contact-valid",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "edition_type": "bourse",
+            "external_contact_email": email,
+        },
+        headers=ADMIN_HEADERS,
+    )
+
+    assert r.status_code == 201, r.text
+    assert r.json()["external_contact_email"] == email
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "email",
+    [
+        "organizer@example.com?bcc=other@example.com",
+        "organizer@example.com\r\nBcc:other@example.com",
+        "not-an-email",
+        '"quoted local part"@example.com',
+        # Unicode local part — SMTPUTF8 addresses are intentionally unsupported.
+        "örganizer@example.com",
+        # Unicode domain that has not been IDNA/punycode-encoded.
+        "organizer@münchen.example",
+        # Pydantic's EmailStr normalizes IDNA/punycode domains back to Unicode,
+        # so even an ASCII-on-the-wire internationalized domain is rejected.
+        "organizer@xn--nxasmq6b.example",
+    ],
+)
+async def test_edition_rejects_unsafe_or_unsupported_contact_emails(client, email):
+    venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = venue_response.json()["id"]
+
+    r = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-contact-invalid",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "edition_type": "bourse",
+            "external_contact_email": email,
+        },
+        headers=ADMIN_HEADERS,
+    )
+
+    assert r.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_edition_update_rejects_unsafe_contact_email(client):
+    venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = venue_response.json()["id"]
+
+    r = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-contact-update",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "edition_type": "bourse",
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+
+    r = await client.put(
+        "/api/editions/edition-contact-update",
+        json={"external_contact_email": "organizer@example.com?bcc=other@example.com"},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 422

--- a/frontend/src/components/CommunityEvents.tsx
+++ b/frontend/src/components/CommunityEvents.tsx
@@ -9,7 +9,7 @@ import RegistrationModal from "@/components/RegistrationModal";
 import type { Event } from "@/types/event";
 import { apiToEvent } from "@/types/event";
 import { m } from "@/paraglide/messages";
-import { EMAIL_REGEX } from "@/config/constants";
+import { COMMUNITY_CONTACT_EMAIL_REGEX } from "@/config/constants";
 
 interface ApiUpcomingEdition {
   id: string;
@@ -74,14 +74,20 @@ function readOptionalString(
   return value;
 }
 
+/**
+ * Unlike readOptionalString's siblings, an invalid value here is dropped rather
+ * than thrown: a malformed contact address on one edition must not take down
+ * the entire community events response and hide unrelated editions/events.
+ */
 function readOptionalEmail(
   record: Record<string, unknown>,
   key: string,
   context: string,
 ): string | undefined {
   const value = readOptionalString(record, key, context);
-  if (value !== undefined && !EMAIL_REGEX.test(value)) {
-    throw new Error(`${context}.${key} must be a valid email address or null.`);
+  if (value !== undefined && !COMMUNITY_CONTACT_EMAIL_REGEX.test(value)) {
+    console.warn(`${context}.${key} is not a valid, safe email address; omitting it.`);
+    return undefined;
   }
   return value;
 }

--- a/frontend/src/components/CommunityEvents.tsx
+++ b/frontend/src/components/CommunityEvents.tsx
@@ -77,15 +77,18 @@ function readOptionalString(
 /**
  * Unlike readOptionalString's siblings, an invalid value here is dropped rather
  * than thrown: a malformed contact address on one edition must not take down
- * the entire community events response and hide unrelated editions/events.
+ * the entire community events response and hide unrelated editions/events. This
+ * checks the type directly instead of delegating to readOptionalString, since
+ * that helper throws on a non-string value — which would defeat the point.
  */
 function readOptionalEmail(
   record: Record<string, unknown>,
   key: string,
   context: string,
 ): string | undefined {
-  const value = readOptionalString(record, key, context);
-  if (value !== undefined && !COMMUNITY_CONTACT_EMAIL_REGEX.test(value)) {
+  const value = record[key];
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== "string" || !COMMUNITY_CONTACT_EMAIL_REGEX.test(value)) {
     console.warn(`${context}.${key} is not a valid, safe email address; omitting it.`);
     return undefined;
   }

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -15,3 +15,14 @@ export const CAROUSEL_AUTOPLAY_DELAY_MS = 3000;
  * and rejects obvious invalid ones. Used consistently across all form components.
  */
 export const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+/**
+ * Canonical contract for community edition contact emails, shared with the
+ * backend's COMMUNITY_CONTACT_EMAIL_PATTERN (backend/app/schemas.py). ASCII-only
+ * RFC 5321 "dot-atom" local part plus a conventional domain — a superset of
+ * EMAIL_REGEX's character set that still excludes control/whitespace characters,
+ * so a matching value is always safe to render as a `mailto:` link. Keep both
+ * patterns in sync.
+ */
+export const COMMUNITY_CONTACT_EMAIL_REGEX =
+  /^[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*@[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*\.[A-Za-z]{2,}$/;

--- a/frontend/tests/components/CommunityEvents.test.tsx
+++ b/frontend/tests/components/CommunityEvents.test.tsx
@@ -244,6 +244,31 @@ describe("CommunityEvents", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
+  it("drops a non-string contact email without hiding the edition", async () => {
+    server.use(
+      http.get("/api/editions/upcoming", ({ request }) => {
+        const editionType = new URL(request.url).searchParams.get("edition_type");
+        if (editionType !== "bourse") return HttpResponse.json([]);
+
+        return HttpResponse.json([
+          {
+            id: "edition-bourse",
+            edition_type: "bourse",
+            external_contact_name: "Organizer",
+            external_contact_email: 12345,
+            venue: { name: "Staf Versluys" },
+            events: [{ ...BASE_EVENT, id: "event-bourse", title: "Bourse tasting" }],
+          },
+        ]);
+      }),
+    );
+
+    renderCommunityEvents();
+
+    expect(await screen.findByText("Bourse tasting")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   it("accepts legitimate edge-case addresses the backend can return", async () => {
     server.use(
       http.get("/api/editions/upcoming", ({ request }) => {

--- a/frontend/tests/components/CommunityEvents.test.tsx
+++ b/frontend/tests/components/CommunityEvents.test.tsx
@@ -193,24 +193,125 @@ describe("CommunityEvents", () => {
     expect(await screen.findByRole("alert")).toBeInTheDocument();
   });
 
-  it("rejects unsafe external contact email values", async () => {
+  it("drops an unsafe external contact email without hiding the edition or other events", async () => {
     server.use(
-      http.get("/api/editions/upcoming", () =>
-        HttpResponse.json([
+      http.get("/api/editions/upcoming", ({ request }) => {
+        const editionType = new URL(request.url).searchParams.get("edition_type");
+        if (editionType !== "bourse") return HttpResponse.json([]);
+
+        return HttpResponse.json([
           {
             id: "edition-bourse",
             edition_type: "bourse",
+            external_contact_name: "Organizer",
             external_contact_email: "organizer@example.com?bcc=other@example.com",
             venue: { name: "Staf Versluys" },
             events: [{ ...BASE_EVENT, id: "event-bourse", title: "Bourse tasting" }],
           },
-        ]),
-      ),
+        ]);
+      }),
     );
 
     renderCommunityEvents();
 
-    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    expect(await screen.findByText("Bourse tasting")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.queryByText(/organizer@example\.com/)).not.toBeInTheDocument();
+  });
+
+  it("drops a control-character contact email (header injection) without hiding the edition", async () => {
+    server.use(
+      http.get("/api/editions/upcoming", ({ request }) => {
+        const editionType = new URL(request.url).searchParams.get("edition_type");
+        if (editionType !== "bourse") return HttpResponse.json([]);
+
+        return HttpResponse.json([
+          {
+            id: "edition-bourse",
+            edition_type: "bourse",
+            external_contact_name: "Organizer",
+            external_contact_email: "organizer@example.com\r\nBcc:other@example.com",
+            venue: { name: "Staf Versluys" },
+            events: [{ ...BASE_EVENT, id: "event-bourse", title: "Bourse tasting" }],
+          },
+        ]);
+      }),
+    );
+
+    renderCommunityEvents();
+
+    expect(await screen.findByText("Bourse tasting")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("accepts legitimate edge-case addresses the backend can return", async () => {
+    server.use(
+      http.get("/api/editions/upcoming", ({ request }) => {
+        const editionType = new URL(request.url).searchParams.get("edition_type");
+        if (editionType !== "bourse") return HttpResponse.json([]);
+
+        return HttpResponse.json([
+          {
+            id: "edition-bourse",
+            edition_type: "bourse",
+            external_contact_name: "Organizer",
+            // Tag addressing (RFC 5321 atext) and an IDNA/punycode-encoded
+            // internationalized domain — both valid, ASCII-safe addresses.
+            external_contact_email: "bourse+events@xn--nxasmq6b.example",
+            venue: { name: "Staf Versluys" },
+            events: [{ ...BASE_EVENT, id: "event-bourse", title: "Bourse tasting" }],
+          },
+        ]);
+      }),
+    );
+
+    renderCommunityEvents();
+
+    expect(await screen.findByText("Bourse tasting")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "bourse+events@xn--nxasmq6b.example" }),
+    ).toHaveAttribute("href", "mailto:bourse+events@xn--nxasmq6b.example");
+  });
+
+  it("does not hide unrelated community editions when a sibling edition has a malformed contact email", async () => {
+    server.use(
+      http.get("/api/editions/upcoming", ({ request }) => {
+        const editionType = new URL(request.url).searchParams.get("edition_type");
+        if (editionType === "bourse") {
+          return HttpResponse.json([
+            {
+              id: "edition-bourse",
+              edition_type: "bourse",
+              external_contact_name: "Organizer",
+              external_contact_email: "organizer@example.com?bcc=other@example.com",
+              venue: { name: "Staf Versluys" },
+              events: [{ ...BASE_EVENT, id: "event-bourse", title: "Bourse tasting" }],
+            },
+          ]);
+        }
+        return HttpResponse.json([
+          {
+            id: "edition-capsule",
+            edition_type: "capsule_exchange",
+            venue: { name: "Staf Versluys" },
+            events: [
+              {
+                ...BASE_EVENT,
+                id: "event-capsule",
+                edition_id: "edition-capsule",
+                title: "Capsule swap",
+              },
+            ],
+          },
+        ]);
+      }),
+    );
+
+    renderCommunityEvents();
+
+    expect(await screen.findByText("Bourse tasting")).toBeInTheDocument();
+    expect(screen.getByText("Capsule swap")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("rejects editions without an events array", async () => {


### PR DESCRIPTION
## Summary

Closes #738.

Community contact email addresses were validated differently on each side of
the API boundary: the backend used Pydantic's `EmailStr` (which, by default,
accepts internationalized/Unicode addresses), while the frontend applied a
much narrower, ASCII-only regex before rendering a `mailto:` link. An address
the backend accepted and stored could fail frontend validation — and because
that failure was a thrown error inside the shared response parser, it took
down the *entire* community events section (all edition types), not just the
one bad edition.

- **Canonical contract**: added a shared, documented ASCII "RFC 5321 dot-atom"
  email pattern — `COMMUNITY_CONTACT_EMAIL_PATTERN` in
  `backend/app/schemas.py` and the matching `COMMUNITY_CONTACT_EMAIL_REGEX` in
  `frontend/src/config/constants.ts`. It's a superset of the old frontend
  regex's character set (covers the full RFC 5321 atext local-part charset)
  while still rejecting control characters and other `mailto:`
  header-injection vectors.
- **Backend enforcement**: `EditionCreate`/`EditionUpdate` now validate
  `external_contact_email` against this pattern on write, intentionally
  rejecting internationalized/Unicode addresses (they can't safely round-trip
  through a `mailto:` link) rather than relying on `EmailStr`'s more
  permissive default behavior.
- **Frontend resilience**: `CommunityEvents.tsx`'s response parser no longer
  throws on a malformed `external_contact_email`. It drops just that field
  (logging a warning) so the edition and its events — and any unrelated
  editions — still render normally.

## Test plan

- [x] `backend`: `uv run pytest tests/test_editions.py -q` — new parametrized
      coverage for accepted addresses (RFC 5321 atext local parts, dotted
      local parts) and rejected ones (`mailto:` query/header injection,
      control characters, unquoted Unicode local part/domain, and a
      punycode-encoded domain that Pydantic normalizes back to Unicode)
- [x] `backend`: `uv run pytest -q` (full suite, 367 passed)
- [x] `backend`: `uv run ruff check app tests`, `uv run ty check app`
- [x] `frontend`: `vitest run tests/components/CommunityEvents.test.tsx` —
      updated/added coverage confirming a bad contact email is dropped
      without hiding the edition, a control-character injection attempt is
      dropped, a legitimate edge-case address is accepted and rendered as a
      safe `mailto:` link, and a malformed email on one edition type doesn't
      hide a sibling edition type
- [x] `frontend`: full `vitest run` (432 passed), `pnpm typecheck`, `pnpm lint`


---
_Generated by [Claude Code](https://claude.ai/code/session_01UbKMxQbFDbzcPXXwYAp2Q6)_