### PR TITLE
Scope active festival selection across web, Android, and MCP

### DIFF
--- a/android/app/src/main/kotlin/be/champagnefestival/android/data/api/ChampagneApiService.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/data/api/ChampagneApiService.kt
@@ -16,7 +16,7 @@ import retrofit2.http.Query
 
 interface ChampagneApiService {
     @GET("api/editions/active")
-    suspend fun getActiveEdition(): EditionOut
+    suspend fun getActiveEdition(@Query("edition_type") editionType: String = "festival"): EditionOut
 
     @GET("api/events")
     suspend fun getEvents(

--- a/android/app/src/test/kotlin/be/champagnefestival/android/data/repository/EditionRepositoryTest.kt
+++ b/android/app/src/test/kotlin/be/champagnefestival/android/data/repository/EditionRepositoryTest.kt
@@ -1,0 +1,61 @@
+package be.champagnefestival.android.data.repository
+
+import be.champagnefestival.android.core.network.ApiServiceFactory
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class EditionRepositoryTest {
+    private lateinit var server: MockWebServer
+    private lateinit var repository: DefaultEditionRepository
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val apiService =
+            ApiServiceFactory.create(
+                baseUrl = server.url("/").toString(),
+                client = OkHttpClient()
+            )
+        repository = DefaultEditionRepository(apiService)
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    @Test
+    fun `getActiveEdition scopes the request to festival editions`() = runTest {
+        server.enqueue(MockResponse.Builder().body(sampleEditionJson()).build())
+
+        val result = repository.getActiveEdition()
+
+        assertTrue(result.isSuccess)
+        assertEquals("2026-march", result.getOrNull()?.id)
+
+        val request = server.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/api/editions/active", request.url.encodedPath)
+        assertEquals("festival", request.url.queryParameter("edition_type"))
+    }
+
+    private fun sampleEditionJson(): String =
+        """
+        {
+          "id":"2026-march",
+          "year":2026,
+          "month":"march",
+          "edition_type":"festival",
+          "active":true,
+          "events":[]
+        }
+        """.trimIndent()
+}

--- a/backend/app/mcp/utils.py
+++ b/backend/app/mcp/utils.py
@@ -14,11 +14,19 @@ ROLE_VOLUNTEER = "volunteer"
 ROLE_PUBLIC = "public"
 
 
-async def get_active_edition_obj(db: Any) -> Edition | None:
-    """Return the current or next upcoming active edition, or None."""
+async def get_active_edition_obj(db: Any, edition_type: str | None = "festival") -> Edition | None:
+    """Return the current or next upcoming active edition, or None.
+
+    Defaults to festival editions only, so a nearer Bourse or capsule-exchange
+    edition can never stand in for the active festival in tools that omit an
+    explicit edition. Pass ``edition_type=None`` to search across all types.
+    """
     from sqlalchemy.orm import selectinload
 
-    result = await db.execute(select(Edition).options(selectinload(Edition.events)).where(Edition.active.is_(True)))
+    stmt = select(Edition).options(selectinload(Edition.events)).where(Edition.active.is_(True))
+    if edition_type is not None:
+        stmt = stmt.where(Edition.edition_type == edition_type)
+    result = await db.execute(stmt)
     editions: list[Edition] = list(result.scalars().all())
     if not editions:
         return None

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -90,6 +90,10 @@ class ChampagneFestivalMcpBackend:
     async def get_active_edition(self) -> dict:
         """Return the current or next upcoming active festival edition.
 
+        Only considers ``festival``-type editions — a nearer Bourse or capsule-exchange
+        edition never takes its place. Use ``list_editions`` to discover other edition
+        types and pass their ``edition_id`` to type-agnostic tools like ``get_event_schedule``.
+
         Returns a summary of the active edition including edition ID, year, month,
         type, event count, and scheduled dates. No PII is included.
 
@@ -111,7 +115,9 @@ class ChampagneFestivalMcpBackend:
         Parameters
         ----------
         edition_id:
-            The edition ID to fetch. When omitted, the active edition is used.
+            The edition ID to fetch. When omitted, the active festival edition is used —
+            pass an explicit ``edition_id`` (see ``list_editions``) to target a Bourse or
+            capsule-exchange edition instead.
 
         Returns a list of events with date, times, title, and category.
         No PII is included.
@@ -126,7 +132,9 @@ class ChampagneFestivalMcpBackend:
         Parameters
         ----------
         edition_id:
-            The edition ID. When omitted, the active edition is used.
+            The edition ID. When omitted, the active festival edition is used — pass an
+            explicit ``edition_id`` (see ``list_editions``) to target a Bourse or
+            capsule-exchange edition instead.
         """
         return await mcp_public.get_venue_plan_summary(self.session_factory, edition_id)
 
@@ -179,7 +187,8 @@ class ChampagneFestivalMcpBackend:
         Parameters
         ----------
         table_id:
-            Specific table ID. When omitted, all tables for the active edition are returned.
+            Specific table ID. When omitted, all tables for the active festival edition
+            are returned.
         """
         self._require_volunteer()
         return await mcp_seating.get_table_seating(self.session_factory, table_id)
@@ -240,7 +249,7 @@ class ChampagneFestivalMcpBackend:
         Parameters
         ----------
         edition_id:
-            The edition ID. When omitted, the active edition is used.
+            The edition ID. When omitted, the active festival edition is used.
         """
         self._require_volunteer()
         return await mcp_delivery.get_champagne_delivery_summary(self.session_factory, edition_id)
@@ -253,7 +262,7 @@ class ChampagneFestivalMcpBackend:
         Parameters
         ----------
         edition_id:
-            The edition ID. When omitted, the active edition is used.
+            The edition ID. When omitted, the active festival edition is used.
         """
         self._require_volunteer()
         return await mcp_delivery.get_undelivered_champagne_by_table(self.session_factory, edition_id)
@@ -268,7 +277,7 @@ class ChampagneFestivalMcpBackend:
         Parameters
         ----------
         edition_id:
-            The edition ID. When omitted, the active edition is used.
+            The edition ID. When omitted, the active festival edition is used.
         """
         self._require_volunteer()
         return await mcp_check_in.get_check_in_summary(self.session_factory, edition_id)

--- a/backend/tests/test_editions.py
+++ b/backend/tests/test_editions.py
@@ -202,6 +202,73 @@ async def test_active_edition_dates_are_unique_when_multiple_events_share_a_day(
 
 
 @pytest.mark.anyio
+async def test_active_edition_type_filter_excludes_nearer_community_editions(client):
+    """A nearer-ending Bourse or capsule-exchange edition must never stand in for the
+    active festival when a festival-specific caller filters by `edition_type=festival`.
+    """
+    venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    assert venue_response.status_code == 201
+    venue_id = venue_response.json()["id"]
+
+    editions = [
+        ("edition-bourse-nearest", "bourse", "2099-01-10"),
+        ("edition-capsule-exchange-mid", "capsule_exchange", "2099-02-15"),
+        ("edition-festival-farthest", "festival", "2099-03-21"),
+    ]
+    for edition_id, edition_type, event_date in editions:
+        edition_response = await client.post(
+            "/api/editions",
+            json={
+                "id": edition_id,
+                "year": 2099,
+                "month": "march",
+                "venue_id": venue_id,
+                "edition_type": edition_type,
+                "active": True,
+            },
+            headers=ADMIN_HEADERS,
+        )
+        assert edition_response.status_code == 201
+
+        event_response = await client.post(
+            "/api/events",
+            json={
+                "edition_id": edition_id,
+                "title": f"{edition_type} event",
+                "description": "",
+                "date": event_date,
+                "start_time": "18:00",
+                "end_time": "22:00",
+                "category": edition_type,
+                "registration_required": False,
+                "active": True,
+            },
+            headers=ADMIN_HEADERS,
+        )
+        assert event_response.status_code == 201
+
+    # Filtered: the festival edition wins even though it ends latest.
+    festival_response = await client.get("/api/editions/active", params={"edition_type": "festival"})
+    assert festival_response.status_code == 200
+    assert festival_response.json()["id"] == "edition-festival-farthest"
+
+    # Unfiltered: the nearest-ending edition (regardless of type) wins — this is the
+    # ambiguous default that festival-specific callers must avoid by filtering explicitly.
+    unfiltered_response = await client.get("/api/editions/active")
+    assert unfiltered_response.status_code == 200
+    assert unfiltered_response.json()["id"] == "edition-bourse-nearest"
+
+    # Other types remain independently selectable.
+    bourse_response = await client.get("/api/editions/active", params={"edition_type": "bourse"})
+    assert bourse_response.status_code == 200
+    assert bourse_response.json()["id"] == "edition-bourse-nearest"
+
+    capsule_response = await client.get("/api/editions/active", params={"edition_type": "capsule_exchange"})
+    assert capsule_response.status_code == 200
+    assert capsule_response.json()["id"] == "edition-capsule-exchange-mid"
+
+
+@pytest.mark.anyio
 async def test_standalone_event_can_move_within_same_single_day(client):
     venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
     assert venue_response.status_code == 201

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import app.mcp_server as mcp_module
-from app.mcp.utils import person_dict
+from app.mcp.utils import get_active_edition_obj, person_dict
 from app.mcp_server import (
     ROLE_ADMIN,
     ROLE_PUBLIC,
@@ -30,6 +30,7 @@ from app.mcp_server import (
     ChampagneFestivalMcpBackend,
     create_mcp_server,
 )
+from tests.helpers import ADMIN_HEADERS, VENUE_PAYLOAD
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -447,6 +448,96 @@ class TestGetActiveEdition:
         backend = ChampagneFestivalMcpBackend(_make_session_factory(db))
         result = await backend.get_active_edition()
         assert result["active_edition"] is None
+
+
+# ---------------------------------------------------------------------------
+# get_active_edition_obj — edition_type scoping against real mixed data
+# ---------------------------------------------------------------------------
+
+
+class TestGetActiveEditionObjEditionTypeScoping:
+    """Exercises `get_active_edition_obj` against a real DB session (not the MagicMock
+    fixtures used above) so the actual SQL `edition_type` filter is under test, using a
+    mix of active festival, Bourse, and capsule-exchange editions.
+    """
+
+    async def _seed_mixed_editions(self, client) -> None:
+        venue_response = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+        assert venue_response.status_code == 201
+        venue_id = venue_response.json()["id"]
+
+        editions = [
+            ("edition-bourse-nearest", "bourse", "2099-01-10"),
+            ("edition-capsule-exchange-mid", "capsule_exchange", "2099-02-15"),
+            ("edition-festival-farthest", "festival", "2099-03-21"),
+        ]
+        for edition_id, edition_type, event_date in editions:
+            edition_response = await client.post(
+                "/api/editions",
+                json={
+                    "id": edition_id,
+                    "year": 2099,
+                    "month": "march",
+                    "venue_id": venue_id,
+                    "edition_type": edition_type,
+                    "active": True,
+                },
+                headers=ADMIN_HEADERS,
+            )
+            assert edition_response.status_code == 201
+
+            event_response = await client.post(
+                "/api/events",
+                json={
+                    "edition_id": edition_id,
+                    "title": f"{edition_type} event",
+                    "description": "",
+                    "date": event_date,
+                    "start_time": "18:00",
+                    "end_time": "22:00",
+                    "category": edition_type,
+                    "registration_required": False,
+                    "active": True,
+                },
+                headers=ADMIN_HEADERS,
+            )
+            assert event_response.status_code == 201
+
+    @pytest.mark.anyio
+    async def test_default_selects_festival_over_nearer_bourse_and_capsule_exchange(self, client, db_session):
+        await self._seed_mixed_editions(client)
+
+        edition = await get_active_edition_obj(db_session)
+
+        assert edition is not None
+        assert edition.id == "edition-festival-farthest"
+
+    @pytest.mark.anyio
+    async def test_explicit_type_none_falls_back_to_nearest_ending_edition_of_any_type(self, client, db_session):
+        await self._seed_mixed_editions(client)
+
+        edition = await get_active_edition_obj(db_session, edition_type=None)
+
+        assert edition is not None
+        assert edition.id == "edition-bourse-nearest"
+
+    @pytest.mark.anyio
+    async def test_explicit_type_selects_that_type(self, client, db_session):
+        await self._seed_mixed_editions(client)
+
+        edition = await get_active_edition_obj(db_session, edition_type="capsule_exchange")
+
+        assert edition is not None
+        assert edition.id == "edition-capsule-exchange-mid"
+
+    @pytest.mark.anyio
+    async def test_mcp_get_active_edition_tool_never_returns_a_community_edition(self, client, db_session):
+        await self._seed_mixed_editions(client)
+
+        backend = ChampagneFestivalMcpBackend(_make_session_factory(db_session))
+        result = await backend.get_active_edition()
+
+        assert result["active_edition"]["id"] == "edition-festival-farthest"
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/hooks/useActiveEdition.ts
+++ b/frontend/src/hooks/useActiveEdition.ts
@@ -178,7 +178,7 @@ function createFallbackEdition(): ActiveEdition {
 }
 
 export async function fetchActiveEdition(): Promise<ActiveEdition> {
-  const res = await fetch("/api/editions/active");
+  const res = await fetch("/api/editions/active?edition_type=festival");
   if (!res.ok) {
     throw new ActiveEditionFetchError(`Failed to load active edition: ${res.status}`, res.status);
   }


### PR DESCRIPTION
## Summary

Several festival-specific workflows requested the active edition without an `edition_type` filter. Because the backend selects across all active edition types, a nearer Bourse or capsule-exchange edition could be returned as the "active festival" — this fixes the callers, not the already-filter-capable backend endpoint.

- **Web homepage** (`frontend/src/hooks/useActiveEdition.ts`): `fetchActiveEdition` now requests `/api/editions/active?edition_type=festival`.
- **Android** (`android/.../ChampagneApiService.kt`): `getActiveEdition()` now sends `edition_type=festival` by default (matches the existing `getEvents`/`getCheckInStats` optional-query-param pattern).
- **MCP** (`backend/app/mcp/utils.py`): `get_active_edition_obj` now defaults to `edition_type="festival"`. This is the single implicit-active-edition helper used by every MCP tool that falls back to "the active edition" when no `edition_id` is supplied (`get_active_edition`, `get_event_schedule`, `get_venue_plan_summary`, `get_table_seating`, `get_champagne_delivery_summary`, `get_undelivered_champagne_by_table`, `get_check_in_summary`), so fixing it there fixes all of them at once. Callers can still pass `edition_type=None` to search across all types; explicit `edition_id` lookups are untouched and continue to support any edition type.
- Docstrings on the affected MCP tools were updated to make the festival scoping explicit.
- `backend/app/routers/editions.py` already supported `edition_type` filtering — no change needed there.

## Test plan

- [x] `backend`: `uv run pytest` — 372 passed (added a router-level test with mixed active festival/Bourse/capsule-exchange editions, and MCP-level tests against a real DB session verifying `get_active_edition_obj`'s default/explicit-type/type-none behavior and that the `get_active_edition` MCP tool never returns a community edition)
- [x] `backend`: `uv run ruff check app tests` and `uv run ty check app` — clean
- [x] `frontend`: `pnpm test`, `pnpm typecheck`, `pnpm lint` — all pass (433 tests)
- [x] `android`: added `EditionRepositoryTest` asserting the outgoing request carries `edition_type=festival`, following the existing `CheckInNetworkRepositoryTest` MockWebServer pattern. **Not run locally** — this sandbox's egress policy blocks `services.gradle.org` (Gradle wrapper distribution download), so Android CI is the first place this actually builds/runs.

Closes #739.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TPxwrgGvVqMewSjeS19qJK)_