### PR TITLE
Clear exhibitors when converting a festival to a community edition

### DIFF
--- a/backend/app/routers/editions.py
+++ b/backend/app/routers/editions.py
@@ -211,6 +211,12 @@ async def update_edition(
         _validate_exhibitors_allowed(edition.edition_type, body.exhibitors)  # ty: ignore[invalid-argument-type]
         await _validate_exhibitor_ids(db, body.exhibitors)
         edition.exhibitors = list(body.exhibitors)
+    elif edition.edition_type != "festival" and edition.exhibitors:
+        # The edition type changed away from festival without an explicit exhibitors
+        # payload. Community editions can't carry exhibitors, so clear the now-invalid
+        # associations as part of the same atomic transition instead of rejecting the
+        # update.
+        edition.exhibitors = []
 
     _validate_exhibitors_allowed(edition.edition_type, edition.exhibitors)  # ty: ignore[invalid-argument-type]
 

--- a/backend/tests/test_editions.py
+++ b/backend/tests/test_editions.py
@@ -570,6 +570,171 @@ async def test_edition_rejects_vendor_exhibitors(client):
     assert "vendor" in r.json()["detail"].lower()
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize("target_type", ["bourse", "capsule_exchange"])
+async def test_converting_festival_to_community_edition_clears_exhibitors(client, target_type):
+    """Converting a festival with producers/sponsors to a community type must succeed
+    and atomically drop the now-invalid exhibitor associations, even if the caller
+    doesn't send an explicit `exhibitors` field alongside the type change.
+    """
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = r.json()["id"]
+    r = await client.post(
+        "/api/exhibitors",
+        json={"name": "Bollinger", "type": "producer"},
+        headers=ADMIN_HEADERS,
+    )
+    producer_id = r.json()["id"]
+    r = await client.post(
+        "/api/exhibitors",
+        json={"name": "Acme", "type": "sponsor"},
+        headers=ADMIN_HEADERS,
+    )
+    sponsor_id = r.json()["id"]
+
+    r = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-convert-to-community",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "edition_type": "festival",
+            "exhibitors": [producer_id, sponsor_id],
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+    assert len(r.json()["producers"]) == 1
+    assert len(r.json()["sponsors"]) == 1
+
+    r = await client.put(
+        "/api/editions/edition-convert-to-community",
+        json={"edition_type": target_type},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["edition_type"] == target_type
+    assert data["producers"] == []
+    assert data["sponsors"] == []
+
+    r = await client.get("/api/editions/edition-convert-to-community", headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json()["producers"] == []
+    assert r.json()["sponsors"] == []
+
+
+@pytest.mark.anyio
+async def test_converting_festival_to_community_edition_with_explicit_empty_exhibitors(client):
+    """The frontend contract sends an explicit `exhibitors: []` alongside the type
+    change; this must also succeed and clear associations (not just the implicit path).
+    """
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = r.json()["id"]
+    r = await client.post(
+        "/api/exhibitors",
+        json={"name": "Bollinger", "type": "producer"},
+        headers=ADMIN_HEADERS,
+    )
+    producer_id = r.json()["id"]
+
+    r = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-convert-explicit-empty",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "edition_type": "festival",
+            "exhibitors": [producer_id],
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+
+    r = await client.put(
+        "/api/editions/edition-convert-explicit-empty",
+        json={"edition_type": "bourse", "exhibitors": []},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["producers"] == []
+
+
+@pytest.mark.anyio
+async def test_festival_to_festival_edit_preserves_exhibitors(client):
+    """Editing a festival edition without touching its type must not disturb exhibitors."""
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = r.json()["id"]
+    r = await client.post(
+        "/api/exhibitors",
+        json={"name": "Bollinger", "type": "producer"},
+        headers=ADMIN_HEADERS,
+    )
+    producer_id = r.json()["id"]
+
+    r = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-festival-preserve",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "edition_type": "festival",
+            "exhibitors": [producer_id],
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+
+    r = await client.put(
+        "/api/editions/edition-festival-preserve",
+        json={"month": "april"},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["month"] == "april"
+    assert len(r.json()["producers"]) == 1
+    assert r.json()["producers"][0]["id"] == producer_id
+
+
+@pytest.mark.anyio
+async def test_community_edition_update_still_rejects_explicit_exhibitors(client):
+    """Backend validation must still reject an explicit attempt to assign exhibitors
+    to a community edition, whether or not the type is changing in the same request.
+    """
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = r.json()["id"]
+    r = await client.post(
+        "/api/exhibitors",
+        json={"name": "Bollinger", "type": "producer"},
+        headers=ADMIN_HEADERS,
+    )
+    producer_id = r.json()["id"]
+
+    r = await client.post(
+        "/api/editions",
+        json={
+            "id": "edition-community-reject",
+            "year": 2099,
+            "month": "march",
+            "venue_id": venue_id,
+            "edition_type": "bourse",
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+
+    r = await client.put(
+        "/api/editions/edition-community-reject",
+        json={"exhibitors": [producer_id]},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 400
+    assert "festival" in r.json()["detail"].lower()
+
+
 # ---------------------------------------------------------------------------
 # Edition attendance stats
 # ---------------------------------------------------------------------------

--- a/frontend/src/utils/adminContentApi.test.ts
+++ b/frontend/src/utils/adminContentApi.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { saveEdition } from "./adminContentApi";
+
+const authHeaders = () => ({ Authorization: "Bearer test-token" });
+
+function mockFetchResponse(body: Record<string, unknown>) {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+function sentBody(fetchMock: ReturnType<typeof mockFetchResponse>): Record<string, unknown> {
+  const options = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+  return JSON.parse(options?.body as string) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("saveEdition", () => {
+  const basePayload = {
+    id: "2026-march",
+    year: 2026,
+    month: "march",
+    venueId: "venue-1",
+    active: true,
+    externalPartner: "",
+    externalContactName: "",
+    externalContactEmail: "",
+  };
+
+  it("sends the selected exhibitor ids for a festival edition", async () => {
+    const fetchMock = mockFetchResponse({ id: "2026-march" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await saveEdition(
+      { ...basePayload, editionType: "festival", exhibitorIds: [1, 2] },
+      authHeaders,
+      "2026-march",
+    );
+
+    const body = sentBody(fetchMock);
+    expect(body.exhibitors).toEqual([1, 2]);
+  });
+
+  it.each(["bourse", "capsule_exchange"] as const)(
+    "explicitly sends an empty exhibitors list when converting to %s",
+    async (editionType) => {
+      const fetchMock = mockFetchResponse({ id: "2026-march" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await saveEdition(
+        { ...basePayload, editionType, exhibitorIds: [1, 2] },
+        authHeaders,
+        "2026-march",
+      );
+
+      const body = sentBody(fetchMock);
+      expect(body).toHaveProperty("exhibitors");
+      expect(body.exhibitors).toEqual([]);
+    },
+  );
+});

--- a/frontend/src/utils/adminContentApi.ts
+++ b/frontend/src/utils/adminContentApi.ts
@@ -203,7 +203,10 @@ export async function saveEdition(
         external_contact_name: payload.externalContactName?.trim() || null,
         external_contact_email: payload.externalContactEmail?.trim() || null,
         active: payload.active,
-        ...(payload.editionType === "festival" ? { exhibitors: payload.exhibitorIds } : {}),
+        // Always send `exhibitors` explicitly (even `[]` for community editions) so the
+        // backend receives an intentional instruction rather than treating the omitted
+        // field as "leave existing associations alone".
+        exhibitors: payload.editionType === "festival" ? payload.exhibitorIds : [],
       }),
     },
     isEdit ? "update edition" : "create edition",


### PR DESCRIPTION
## Summary

- The `EditionModal` correctly clears the local exhibitor selection when switching an edition's type away from `festival`, but `saveEdition` (`frontend/src/utils/adminContentApi.ts`) only included the `exhibitors` field in the API payload when `editionType === "festival"`. For community editions, the field was omitted entirely.
- On the backend, `update_edition` (`backend/app/routers/editions.py`) only touches `edition.exhibitors` when `"exhibitors"` is present in `body.model_fields_set`. Since the frontend never sent the field for community editions, the edition kept its old exhibitor associations after the type change — and the trailing `_validate_exhibitors_allowed` check then rejected the update outright.
- Fix: the frontend now always sends an explicit `exhibitors` list (`[]` for non-festival types), and the backend independently clears stale exhibitor associations whenever an edition's final type is non-festival and no explicit `exhibitors` payload was supplied — making the transition atomic and correct regardless of what a given client sends.

## Changes

- `frontend/src/utils/adminContentApi.ts`: `saveEdition` always includes `exhibitors` in the request body instead of omitting it for non-festival edition types.
- `backend/app/routers/editions.py`: `update_edition` clears `edition.exhibitors` when the edition type is non-festival and the request didn't explicitly set `exhibitors`, so the update succeeds instead of being rejected by the trailing validation check.
- `backend/tests/test_editions.py`: new tests covering festival→bourse and festival→capsule_exchange conversions (implicit and explicit-empty exhibitors), festival-to-festival edits preserving exhibitors, and community editions still rejecting explicit exhibitor assignment.
- `frontend/src/utils/adminContentApi.test.ts`: new contract test asserting `saveEdition` sends the selected exhibitor ids for festival editions and an explicit empty list for `bourse`/`capsule_exchange`.

## Test plan

- [x] `cd backend && uv run ruff check app` (using a locally started PostgreSQL 16 instance)
- [x] `cd backend && uv run ty check app`
- [x] `cd backend && uv run pytest` (377 passed)
- [x] `cd frontend && pnpm typecheck`
- [x] `cd frontend && pnpm lint`
- [x] `cd frontend && pnpm test` (436 passed)

Closes #740


---
_Generated by [Claude Code](https://claude.ai/code/session_01JM6EzHcn5tc33S8oyUdd3L)_