### PR TITLE
Potential fix for code scanning alert no. 1: Insecure local authentication

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -182,7 +182,7 @@ android {
 
     defaultConfig {
         applicationId = "im.tjor.champagnefestival"
-        minSdk = 26
+        minSdk = 30
         targetSdk = 37
         // versionCode = MAJOR * 1000000 + MINOR * 1000 + PATCH (e.g. v1.2.3 → 1002003)
         versionCode = versionCodeFor(appVersion)

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/lock/BiometricGateViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/lock/BiometricGateViewModel.kt
@@ -62,6 +62,15 @@ class BiometricGateViewModel(
         val callback =
             object : BiometricPrompt.AuthenticationCallback() {
                 override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    val cryptoObject = result.cryptoObject
+                    val hasCryptoPrimitive =
+                        cryptoObject?.cipher != null || cryptoObject?.signature != null || cryptoObject?.mac != null
+
+                    if (!hasCryptoPrimitive) {
+                        _uiState.value = LockUiState.Failed(strings.cryptoUnavailableMessage)
+                        return
+                    }
+
                     controller.markUnlocked()
                 }
 
@@ -93,7 +102,7 @@ class BiometricGateViewModel(
             }
             prompt.authenticate(promptInfo, cryptoObject)
         } else {
-            prompt.authenticate(promptInfo)
+            _uiState.value = LockUiState.Failed(strings.cryptoUnavailableMessage)
         }
     }
 }

--- a/android/app/src/main/kotlin/be/champagnefestival/android/feature/lock/BiometricGateViewModel.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/feature/lock/BiometricGateViewModel.kt
@@ -1,6 +1,5 @@
 package be.champagnefestival.android.feature.lock
 
-import android.os.Build
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
@@ -14,6 +13,19 @@ import kotlinx.coroutines.flow.asStateFlow
 
 private const val ALLOWED_AUTHENTICATORS =
     BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+
+/** Arbitrary single-byte input; only whether the cipher accepts it, not the output, matters. */
+private val CRYPTO_VERIFICATION_PAYLOAD = ByteArray(1)
+
+/**
+ * A successful [BiometricPrompt] callback only reflects a real keystore-verified unlock once we
+ * perform an operation through the returned cipher — a non-null [BiometricPrompt.CryptoObject]
+ * alone isn't proof the key was actually unlocked by the biometric hardware.
+ */
+internal fun BiometricPrompt.CryptoObject?.isVerifiedUnlock(): Boolean {
+    val cipher = this?.cipher ?: return false
+    return runCatching { cipher.doFinal(CRYPTO_VERIFICATION_PAYLOAD) }.isSuccess
+}
 
 sealed class LockUiState {
     data object Checking : LockUiState()
@@ -62,11 +74,7 @@ class BiometricGateViewModel(
         val callback =
             object : BiometricPrompt.AuthenticationCallback() {
                 override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-                    val cryptoObject = result.cryptoObject
-                    val hasCryptoPrimitive =
-                        cryptoObject?.cipher != null || cryptoObject?.signature != null || cryptoObject?.mac != null
-
-                    if (!hasCryptoPrimitive) {
+                    if (!result.cryptoObject.isVerifiedUnlock()) {
                         _uiState.value = LockUiState.Failed(strings.cryptoUnavailableMessage)
                         return
                     }
@@ -92,17 +100,11 @@ class BiometricGateViewModel(
                 .setAllowedAuthenticators(ALLOWED_AUTHENTICATORS)
                 .build()
 
-        // BiometricPrompt rejects a CryptoObject combined with DEVICE_CREDENTIAL below API 30
-        // (IllegalArgumentException), so only the keystore-verified path is available on R+.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val cryptoObject = cryptoProvider.createCryptoObject()
-            if (cryptoObject == null) {
-                _uiState.value = LockUiState.Failed(strings.cryptoUnavailableMessage)
-                return
-            }
-            prompt.authenticate(promptInfo, cryptoObject)
-        } else {
+        val cryptoObject = cryptoProvider.createCryptoObject()
+        if (cryptoObject == null) {
             _uiState.value = LockUiState.Failed(strings.cryptoUnavailableMessage)
+            return
         }
+        prompt.authenticate(promptInfo, cryptoObject)
     }
 }

--- a/android/app/src/test/kotlin/be/champagnefestival/android/feature/lock/BiometricGateViewModelTest.kt
+++ b/android/app/src/test/kotlin/be/champagnefestival/android/feature/lock/BiometricGateViewModelTest.kt
@@ -1,0 +1,56 @@
+package be.champagnefestival.android.feature.lock
+
+import androidx.biometric.BiometricPrompt
+import be.champagnefestival.android.core.session.BiometricLockController
+import io.mockk.mockk
+import io.mockk.verify
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BiometricGateViewModelTest {
+    private val controller = mockk<BiometricLockController>(relaxed = true)
+
+    @Test
+    fun `initial state is checking`() {
+        val viewModel = BiometricGateViewModel(controller)
+
+        assertEquals(LockUiState.Checking, viewModel.uiState.value)
+    }
+
+    @Test
+    fun `continueWithoutBiometric unlocks the controller`() {
+        val viewModel = BiometricGateViewModel(controller)
+
+        viewModel.continueWithoutBiometric()
+
+        verify { controller.markUnlocked() }
+    }
+
+    @Test
+    fun `isVerifiedUnlock is false for a null crypto object`() {
+        val cryptoObject: BiometricPrompt.CryptoObject? = null
+
+        assertFalse(cryptoObject.isVerifiedUnlock())
+    }
+
+    @Test
+    fun `isVerifiedUnlock is false when the cipher was never initialized`() {
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        val cryptoObject = BiometricPrompt.CryptoObject(cipher)
+
+        assertFalse(cryptoObject.isVerifiedUnlock())
+    }
+
+    @Test
+    fun `isVerifiedUnlock is true when the cipher completes a real operation`() {
+        val key = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding").apply { init(Cipher.ENCRYPT_MODE, key) }
+        val cryptoObject = BiometricPrompt.CryptoObject(cipher)
+
+        assertTrue(cryptoObject.isVerifiedUnlock())
+    }
+}


### PR DESCRIPTION
Potential fix for [https://github.com/tjorim/champagnefestival/security/code-scanning/1](https://github.com/tjorim/champagnefestival/security/code-scanning/1)

To fix this without changing intended functionality, the unlock decision must be bound to a successful keystore-backed cryptographic operation from `AuthenticationResult`:

- In `onAuthenticationSucceeded`, require `result.cryptoObject` to be present and to contain a usable crypto primitive (cipher/signature/mac) before calling `controller.markUnlocked()`.
- If no crypto object is present, treat it as failure and do not unlock.
- Avoid offering an insecure non-crypto auth path in `promptForAuthentication`; fail closed on platforms where this flow cannot provide a `CryptoObject` for the current authenticator combination.

Concretely in `android/app/src/main/kotlin/be/champagnefestival/android/feature/lock/BiometricGateViewModel.kt`:
1. Update `onAuthenticationSucceeded` to check `result.cryptoObject` and only unlock when it is non-null and contains at least one primitive.
2. Replace the API < 30 branch that currently calls `prompt.authenticate(promptInfo)` with a failure state message (reuse `strings.cryptoUnavailableMessage`) so insecure local-auth bypass is not possible.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
