### PR TITLE
Potential fix for code scanning alert no. 2: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/session/BiometricCryptoProvider.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/session/BiometricCryptoProvider.kt
@@ -11,7 +11,7 @@ import javax.crypto.SecretKey
 private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
 private const val KEY_ALIAS = "champagnefestival_biometric_gate_key"
 private const val TRANSFORMATION =
-    "${KeyProperties.KEY_ALGORITHM_AES}/${KeyProperties.BLOCK_MODE_CBC}/${KeyProperties.ENCRYPTION_PADDING_PKCS7}"
+    "${KeyProperties.KEY_ALGORITHM_AES}/${KeyProperties.BLOCK_MODE_GCM}/${KeyProperties.ENCRYPTION_PADDING_NONE}"
 
 /**
  * Backs the biometric prompt with a real AndroidKeyStore secret key that requires
@@ -39,8 +39,8 @@ class BiometricCryptoProvider {
         val spec =
             KeyGenParameterSpec
                 .Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
-                .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                 .setUserAuthenticationRequired(true)
                 .build()
         keyGenerator.init(spec)


### PR DESCRIPTION
Potential fix for [https://github.com/tjorim/champagnefestival/security/code-scanning/2](https://github.com/tjorim/champagnefestival/security/code-scanning/2)

Use AES-GCM instead of AES-CBC/PKCS7 in both the cipher transformation and keystore key generation parameters.

Best fix in this file:
1. Change `TRANSFORMATION` from `AES/CBC/PKCS7Padding` to `AES/GCM/NoPadding`.
2. Change key generation block mode from `BLOCK_MODE_CBC` to `BLOCK_MODE_GCM`.
3. Change key generation padding from `ENCRYPTION_PADDING_PKCS7` to `ENCRYPTION_PADDING_NONE`.

These changes should be made in `android/app/src/main/kotlin/be/champagnefestival/android/core/session/BiometricCryptoProvider.kt` at:
- constant definition around lines 13–14,
- key spec builder around lines 42–43.

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
