### PR TITLE
fix(backend): only trust X-Real-IP from private-network peers

### DIFF
--- a/backend/app/ratelimit.py
+++ b/backend/app/ratelimit.py
@@ -10,6 +10,7 @@ required.
 from __future__ import annotations
 
 import collections
+import ipaddress
 from datetime import UTC, datetime, timedelta
 
 from fastapi import Request
@@ -19,22 +20,36 @@ _RATE_LIMIT_WINDOW_SECONDS = 600
 _rate_limit_buckets: dict[str, collections.deque[datetime]] = {}
 
 
+def _peer_is_trusted_proxy(request: Request) -> bool:
+    """Whether the immediate TCP peer is a private-network address.
+
+    ``X-Real-IP`` is only trustworthy when the request actually arrived via
+    our reverse proxy rather than being sent directly by an arbitrary peer,
+    who could otherwise set the header to whatever they like. The proxy
+    always connects from a private address (loopback/Docker network), so
+    requiring that lets us tell the two apart without hardcoding the proxy's
+    exact address.
+    """
+    if not request.client or not request.client.host:
+        return False
+    try:
+        return ipaddress.ip_address(request.client.host).is_private
+    except ValueError:
+        return False
+
+
 def get_client_ip(request: Request) -> str:
     """Best-effort real client IP behind a reverse proxy.
 
-    Checks ``X-Real-IP`` first (set explicitly and exclusively by a trusted
-    proxy, never a raw client-appended list), then the first entry of
-    ``X-Forwarded-For``, then falls back to the direct connection IP. Only
-    trustworthy if the reverse proxy in front of this app actually sets/
-    overwrites these headers with the real client IP rather than passing
-    through whatever the client sent — see backend/README.md.
+    Only trusts ``X-Real-IP`` when the immediate connection peer is a
+    private-network address, i.e. it actually came through the reverse
+    proxy rather than being spoofed by an arbitrary caller — see
+    backend/README.md. Otherwise falls back to the direct connection IP.
     """
-    real_ip = request.headers.get("X-Real-IP")
-    if real_ip and real_ip.strip():
-        return real_ip.strip()
-    forwarded = request.headers.get("X-Forwarded-For")
-    if forwarded and forwarded.strip():
-        return forwarded.split(",")[0].strip()
+    if _peer_is_trusted_proxy(request):
+        real_ip = request.headers.get("X-Real-IP")
+        if real_ip and real_ip.strip():
+            return real_ip.strip()
     return request.client.host if request.client else "unknown"
 
 

--- a/backend/tests/test_ratelimit.py
+++ b/backend/tests/test_ratelimit.py
@@ -16,14 +16,19 @@ def _make_request(headers: dict[str, str], client_host: str | None = "10.0.0.1")
     return Request(scope)
 
 
-def test_get_client_ip_prefers_x_real_ip() -> None:
-    request = _make_request({"X-Real-IP": "203.0.113.5", "X-Forwarded-For": "198.51.100.9"})
+def test_get_client_ip_prefers_x_real_ip_from_trusted_proxy_peer() -> None:
+    request = _make_request({"X-Real-IP": "203.0.113.5"}, client_host="10.0.0.1")
     assert get_client_ip(request) == "203.0.113.5"
 
 
-def test_get_client_ip_falls_back_to_x_forwarded_for_first_entry() -> None:
-    request = _make_request({"X-Forwarded-For": "203.0.113.5, 198.51.100.9"})
-    assert get_client_ip(request) == "203.0.113.5"
+def test_get_client_ip_ignores_x_real_ip_from_untrusted_peer() -> None:
+    request = _make_request({"X-Real-IP": "203.0.113.5"}, client_host="8.8.8.8")
+    assert get_client_ip(request) == "8.8.8.8"
+
+
+def test_get_client_ip_ignores_x_forwarded_for() -> None:
+    request = _make_request({"X-Forwarded-For": "203.0.113.5, 198.51.100.9"}, client_host="10.0.0.1")
+    assert get_client_ip(request) == "10.0.0.1"
 
 
 def test_get_client_ip_falls_back_to_direct_connection() -> None:
@@ -34,3 +39,8 @@ def test_get_client_ip_falls_back_to_direct_connection() -> None:
 def test_get_client_ip_returns_unknown_with_no_signal() -> None:
     request = _make_request({}, client_host=None)
     assert get_client_ip(request) == "unknown"
+
+
+def test_get_client_ip_treats_invalid_peer_host_as_untrusted() -> None:
+    request = _make_request({"X-Real-IP": "203.0.113.5"}, client_host="not-an-ip")
+    assert get_client_ip(request) == "not-an-ip"


### PR DESCRIPTION
## Summary

- `get_client_ip()` in `backend/app/ratelimit.py` previously trusted `X-Real-IP` (and `X-Forwarded-For`) from **any** caller, with no verification that the request actually arrived via the reverse proxy. A client could set an arbitrary `X-Real-IP` header on each request to draw a fresh rate-limit bucket every time, bypassing the check-in/registration abuse guard entirely.
- `X-Real-IP` is now only honored when the immediate TCP peer (`request.client.host`) is a private-network address — i.e. the request actually came through the trusted reverse proxy — otherwise the direct connection IP is used.
- Dropped the raw `X-Forwarded-For` fallback, since it's client-appended and never trustworthy without the same peer check.

This mirrors the fix already applied in the `worktime` repo (`tjorim/worktime@1a2a82c`) for the identical pattern.

## Test plan

- [x] `uv run ruff check app` — passes
- [x] `uv run ty check app` — passes
- [x] `uv run pytest tests/test_ratelimit.py -v` — all 6 tests pass, including new coverage for untrusted-peer spoofing and invalid peer hosts

Fixes #750


---
_Generated by [Claude Code](https://claude.ai/code/session_016v7RhEBnuDH1brvs53yAA5)_