### PR TITLE
Close Sentry sampling and rate-limiting gaps; adopt DB-secret and Host-validation patterns

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,6 +35,16 @@ DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/champagne
 # Production (dedicated user — credentials managed in infra repo):
 # DATABASE_URL=postgresql+asyncpg://champagnefestival_user:CHANGE_ME@postgres:5432/champagnefestival
 
+# Preferred production alternative: leave DATABASE_URL empty and set these
+# instead, with DB_PASSWORD_FILE pointing at a mounted secret (e.g. a Docker
+# secret) so the password never sits in this plaintext file. DATABASE_URL
+# always wins over these when set, as a local-dev override.
+# DB_HOST=postgres
+# DB_PORT=5432
+# DB_NAME=champagnefestival
+# DB_USER=champagnefestival_user
+# DB_PASSWORD_FILE=/run/secrets/champagnefestival_db_password
+
 # ─── CORS ────────────────────────────────────────────────────────────────────
 
 # Comma-separated list of allowed origins.
@@ -49,11 +59,34 @@ CORS_ORIGINS=http://localhost:5173
 # Minimum seconds between form load and submission (bot protection).
 MIN_FORM_SECONDS=3
 
+# ─── Rate limiting ───────────────────────────────────────────────────────────
+
+# General per-IP, per-route rate limiter applied to every /api endpoint.
+# The stricter check-in/registration limiter (5 req / 600s) always applies on
+# top of this as an override for those specific endpoints.
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_DEFAULT=60/minute
+
+# ─── Host header validation ──────────────────────────────────────────────────
+
+# Comma-separated list of allowed Host header values. Required in production.
+# Leave empty in development to disable Host header validation.
+# TRUSTED_HOSTS=champagnefestival.tjor.im
+
 # ─── Metrics ─────────────────────────────────────────────────────────────────
 
-# Shared secret required in the X-Metrics-Secret header to access GET /api/metrics.
-# Leave empty to disable the metrics endpoint (403 Forbidden).
-METRICS_SECRET=
+# Shared secret used to compute the X-Metrics-Token HMAC (see README) to
+# access GET /api/metrics. Leave empty to disable the metrics endpoint (403).
+METRICS_HMAC_SECRET=
+
+# ─── Error tracking (Sentry) ─────────────────────────────────────────────────
+
+# Sentry DSN for backend error tracking. Leave empty to disable Sentry.
+SENTRY_DSN=
+
+# Fraction (0.0-1.0) of transactions sampled for Sentry performance monitoring.
+# 0.0 (default) disables performance tracing; error tracking is unaffected.
+SENTRY_TRACES_SAMPLE_RATE=0.0
 
 # ─── Email notifications (planned — not yet implemented) ─────────────────────
 # Once implemented, a confirmation e-mail with QR code will be sent to the

--- a/backend/README.md
+++ b/backend/README.md
@@ -192,14 +192,22 @@ location /api/ {
 | Variable           | Required | Default                                                | Description                                                          |
 | ------------------ | -------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
 | `ENVIRONMENT`      | no       | `development`                                          | `development` or `production` — gates startup safety checks          |
-| `DATABASE_URL`     | no       | `postgresql+asyncpg://localhost/champagne`             | Async SQLAlchemy URL                                                 |
+| `DATABASE_URL`     | no       | `postgresql+asyncpg://localhost/champagne`             | Async SQLAlchemy URL. Local-dev override — takes precedence over `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER`/`DB_PASSWORD_FILE` below |
+| `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER` | no | `""` | Split connection parts, combined with `DB_PASSWORD_FILE` to build `DATABASE_URL` without a plaintext password |
+| `DB_PASSWORD_FILE` | no       | `""`                                                   | Path to a file (e.g. a Docker secret) containing the DB password     |
 | `OIDC_ISSUER_URL`  | yes in production | `""`                                          | OIDC provider base URL (e.g. Keycloak/authentik); admin endpoints return 401 until this is set |
 | `OIDC_AUDIENCE`    | no       | `""`                                                   | Expected `aud` claim in the JWT                                      |
 | `OIDC_JWKS_URI`    | no       | `""`                                                   | JWKS endpoint override; defaults to `{OIDC_ISSUER_URL}/.well-known/jwks.json` |
 | `OIDC_ALGORITHMS`  | no       | `RS256`                                                | Comma-separated accepted JWT signing algorithms                      |
 | `CORS_ORIGINS`     | no       | `""`                                                   | Comma-separated allowed origins, e.g. `https://champagnefestival.be` |
+| `TRUSTED_HOSTS`    | yes in production | `""`                                          | Comma-separated allowed `Host` header values; empty disables Host header validation |
+| `RATE_LIMIT_ENABLED` | no     | `true`                                                 | Toggles the general per-IP, per-route rate limiter applied to every `/api` route |
+| `RATE_LIMIT_DEFAULT` | no     | `60/minute`                                            | Default rate limit string (see [limits](https://limits.readthedocs.io/en/stable/quickstart.html#rate-limit-string-notation)) |
 | `MIN_FORM_SECONDS` | no       | `3`                                                    | Anti-spam: min seconds to fill the form                              |
 | `GUEST_ACCESS_TOKEN_TTL_MINUTES` | no | `30` | TTL in minutes for short-lived guest access tokens used by `/api/reservations/my/request` and `/api/reservations/my/access` |
+| `METRICS_HMAC_SECRET` | no    | `""`                                                   | Shared secret for the `X-Metrics-Token` HMAC on `GET /api/metrics`; empty disables the endpoint |
+| `SENTRY_DSN`       | no       | `""`                                                   | Sentry DSN for error tracking; empty disables Sentry                 |
+| `SENTRY_TRACES_SAMPLE_RATE` | no | `0.0`                                              | Fraction (0.0-1.0) of transactions sampled for Sentry performance monitoring |
 | `SMTP_HOST`        | no       | —                                                      | SMTP server (planned — see below)                                    |
 | `SMTP_PORT`        | no       | `587`                                                  | SMTP port (planned)                                                  |
 | `SMTP_USER`        | no       | —                                                      | SMTP username (planned)                                              |
@@ -262,7 +270,7 @@ See `.env.example` for a template.
 | `GET`    | `/api/health/liveness`          | public         | Fast alive check — no DB hit (for load-balancer liveness probes)           |
 | `GET`    | `/api/health/readiness`         | public         | DB connectivity check with 2 s timeout (for load-balancer readiness probes)|
 | `GET`    | `/api/health`                   | public         | Summary with links to liveness and readiness endpoints                     |
-| `GET`    | `/api/metrics`                  | `X-Metrics-Secret` header | Uptime, request rate, error rate, p50/p99 latency          |
+| `GET`    | `/api/metrics`                  | `X-Metrics-Token` header | Uptime, request rate, error rate, p50/p99 latency          |
 
 ---
 
@@ -382,23 +390,6 @@ offline use (e.g., printing guest lists, seating plans).
 1. Add `GET /api/reservations/export?format=csv` (admin) using Python's
    built-in `csv` module or `openpyxl` for Excel.
 2. Optionally add filtering query parameters (event, status, payment_status).
-
----
-
-### ⏱ Rate limiting
-
-**What:** Per-IP rate limiting on the public `POST /api/reservations` endpoint
-to prevent bulk submission attacks beyond what the honeypot + timing check
-catches.
-
-**Status:** Not implemented.
-
-**To implement:**
-
-1. Add `slowapi` (a FastAPI-native rate limiter built on `limits`) as a
-   dependency.
-2. Decorate `create_reservation` with `@limiter.limit("5/minute")`.
-3. Mount the `SlowAPI` middleware in `app/main.py`.
 
 ---
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,7 +1,11 @@
 """Application settings loaded from environment variables / .env file."""
 
 import logging
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
 
+from limits import parse as parse_rate_limit_string
 from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -41,6 +45,8 @@ class Settings(BaseSettings):
     Defaults to a local PostgreSQL database named 'champagne'.
     Set via DATABASE_URL environment variable, e.g.:
       postgresql+asyncpg://user:password@host:5432/champagne
+    Takes precedence over DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD_FILE below —
+    intended as a local-dev override so a plaintext URL never has to be used in production.
     """
 
     database_pool_size: int = 5
@@ -48,6 +54,25 @@ class Settings(BaseSettings):
 
     database_pool_max_overflow: int = 10
     """Extra connections allowed beyond pool size."""
+
+    db_host: str = ""
+    """Database host. Combined with DB_PORT/DB_NAME/DB_USER/DB_PASSWORD_FILE to build
+    DATABASE_URL without ever putting the password in a plaintext .env file. Ignored
+    when DATABASE_URL is set directly."""
+
+    db_port: int = 5432
+    """Database port, used only when building DATABASE_URL from DB_* parts."""
+
+    db_name: str = ""
+    """Database name, used only when building DATABASE_URL from DB_* parts."""
+
+    db_user: str = ""
+    """Database user, used only when building DATABASE_URL from DB_* parts."""
+
+    db_password_file: str = ""
+    """Path to a file containing the database password (e.g. a Docker secret).
+    Combined with DB_HOST/DB_PORT/DB_NAME/DB_USER to build DATABASE_URL. Ignored
+    when DATABASE_URL is set directly."""
 
     # --- CORS ---
     cors_origins: str = ""
@@ -60,15 +85,39 @@ class Settings(BaseSettings):
     """
 
     # --- Metrics ---
-    metrics_secret: str = ""
-    """Shared secret required in the ``X-Metrics-Secret`` header to access ``GET /api/metrics``.
-    Leave empty to disable the metrics endpoint entirely."""
+    metrics_hmac_secret: str = ""
+    """Shared secret used to compute the HMAC in the ``X-Metrics-Token`` header
+    (format ``<unix-timestamp>:<hex-hmac-sha256>``) required to access ``GET
+    /api/metrics``. Tokens older than 60 seconds are rejected, limiting the
+    value of a leaked token. Leave empty to disable the metrics endpoint entirely."""
 
     # --- Error tracking ---
     sentry_dsn: str = ""
     """Sentry DSN for backend error tracking. Leave empty to disable Sentry.
     Example: https://<key>@<org>.ingest.sentry.io/<project>
     """
+
+    sentry_traces_sample_rate: float = 0.0
+    """Fraction (0.0-1.0) of transactions sampled for Sentry performance monitoring.
+    0.0 (default) disables performance tracing entirely; error tracking is unaffected."""
+
+    # --- Rate limiting ---
+    rate_limit_enabled: bool = True
+    """Whether the general per-IP rate limiter applies to every /api route.
+    The stricter check-in/registration limiter (app/ratelimit.py) always applies
+    on top of this one, regardless of this setting."""
+
+    rate_limit_default: str = "60/minute"
+    """Default rate limit applied per client IP and route, e.g. "60/minute".
+    See https://limits.readthedocs.io/en/stable/quickstart.html#rate-limit-string-notation
+    for the accepted syntax."""
+
+    # --- Host header validation ---
+    trusted_hosts: str = ""
+    """Comma-separated list of allowed Host header values (Starlette's
+    TrustedHostMiddleware). Supports a leading wildcard for subdomains, e.g.
+    "*.champagnefestival.be". Required in production. Leave empty in development
+    to disable Host header validation entirely."""
 
     # --- MCP server ---
     mcp_base_url: str = ""
@@ -127,6 +176,22 @@ class Settings(BaseSettings):
             raise ValueError(f"ENVIRONMENT must be 'development' or 'production', got: {v}")
         return v
 
+    @field_validator("sentry_traces_sample_rate")
+    @classmethod
+    def validate_sentry_traces_sample_rate(cls, v: float) -> float:
+        if not 0.0 <= v <= 1.0:
+            raise ValueError("SENTRY_TRACES_SAMPLE_RATE must be between 0.0 and 1.0.")
+        return v
+
+    @field_validator("rate_limit_default")
+    @classmethod
+    def validate_rate_limit_default(cls, v: str) -> str:
+        try:
+            parse_rate_limit_string(v)
+        except ValueError as exc:
+            raise ValueError(f"RATE_LIMIT_DEFAULT is not a valid rate limit string: {v!r} ({exc})") from exc
+        return v
+
     @field_validator("guest_access_token_ttl_minutes")
     @classmethod
     def validate_guest_access_token_ttl_minutes(cls, v: int) -> int:
@@ -138,14 +203,48 @@ class Settings(BaseSettings):
             )
         return v
 
+    @model_validator(mode="before")
+    @classmethod
+    def build_database_url_from_parts(cls, data: Any) -> Any:
+        """Build DATABASE_URL from DB_HOST/DB_PORT/DB_NAME/DB_USER + DB_PASSWORD_FILE.
+
+        Keeps the database password out of a plaintext .env file in production —
+        DB_PASSWORD_FILE points at a mounted secret (e.g. a Docker secret) instead.
+        Only runs when DATABASE_URL isn't set directly, which always wins as a
+        local-dev override.
+        """
+        if not isinstance(data, dict) or data.get("database_url"):
+            return data
+
+        db_host = data.get("db_host")
+        db_name = data.get("db_name")
+        db_user = data.get("db_user")
+        password_file = data.get("db_password_file")
+        if not (db_host and db_name and db_user and password_file):
+            return data
+
+        try:
+            password = Path(password_file).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise ValueError(f"DB_PASSWORD_FILE could not be read: {password_file!r} ({exc})") from exc
+
+        db_port = data.get("db_port") or 5432
+        data["database_url"] = (
+            f"postgresql+asyncpg://{quote(str(db_user), safe='')}:{quote(password, safe='')}"
+            f"@{db_host}:{db_port}/{db_name}"
+        )
+        return data
+
     @model_validator(mode="after")
     def validate_production_oidc(self) -> "Settings":
-        """Refuse to start in production without OIDC issuer URL and QR signing secret."""
+        """Refuse to start in production without OIDC issuer URL, QR signing secret, and trusted hosts."""
         if self.environment == "production":
             if not self.oidc_issuer_url:
                 raise ValueError("OIDC_ISSUER_URL must be set in production.")
             if not self.qr_signing_secret:
                 raise ValueError("QR_SIGNING_SECRET must be set in production.")
+            if not self.trusted_hosts.strip():
+                raise ValueError("TRUSTED_HOSTS must be set in production.")
         return self
 
     # ------------------------------------------------------------------
@@ -175,6 +274,13 @@ class Settings(BaseSettings):
 
         return [origin.strip() for origin in cors_env.split(",") if origin.strip()]
 
+    def get_trusted_hosts_list(self) -> list[str]:
+        """Parse TRUSTED_HOSTS into a list of allowed Host header values.
+
+        Empty string returns an empty list — Host header validation is disabled.
+        """
+        return [host.strip() for host in self.trusted_hosts.split(",") if host.strip()]
+
     @staticmethod
     def _mask_db_credentials(url: str) -> str:
         """Return url with the password hidden."""
@@ -201,6 +307,18 @@ class Settings(BaseSettings):
 
         logger.info(
             f"OIDC:          {'configured' if self.oidc_issuer_url else 'NOT CONFIGURED — admin endpoints will return 401'}"
+        )
+
+        trusted_hosts = self.get_trusted_hosts_list()
+        if not trusted_hosts:
+            logger.warning("No TRUSTED_HOSTS configured — Host header validation is disabled!")
+        else:
+            logger.info(f"Trusted Hosts: {', '.join(trusted_hosts)}")
+
+        logger.info(f"Rate limiting: {'enabled' if self.rate_limit_enabled else 'disabled'} ({self.rate_limit_default})")
+        logger.info(
+            f"Sentry:        {'configured' if self.sentry_dsn else 'not configured'}"
+            + (f" (traces_sample_rate={self.sentry_traces_sample_rate})" if self.sentry_dsn else "")
         )
         logger.info("=" * 60)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -313,9 +313,12 @@ class Settings(BaseSettings):
         if not trusted_hosts:
             logger.warning("No TRUSTED_HOSTS configured — Host header validation is disabled!")
         else:
-            logger.info(f"Trusted Hosts: {', '.join(trusted_hosts)}")
+            # Logs a count only, not the configured values themselves.
+            logger.info(f"Trusted Hosts: {len(trusted_hosts)} allowed host pattern(s) configured")
 
-        logger.info(f"Rate limiting: {'enabled' if self.rate_limit_enabled else 'disabled'} ({self.rate_limit_default})")
+        logger.info(
+            f"Rate limiting: {'enabled' if self.rate_limit_enabled else 'disabled'} ({self.rate_limit_default})"
+        )
         logger.info(
             f"Sentry:        {'configured' if self.sentry_dsn else 'not configured'}"
             + (f" (traces_sample_rate={self.sentry_traces_sample_rate})" if self.sentry_dsn else "")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from app.config import settings
 from app.database import create_tables
 from app.mcp_server import build_keycloak_auth, create_mcp_server
-from app.middleware import add_cors_middleware
+from app.middleware import add_cors_middleware, add_rate_limit_middleware, add_trusted_host_middleware
 from app.observability import request_metrics_middleware
 from app.routers import (
     areas,
@@ -55,8 +55,15 @@ if settings.sentry_dsn:
     try:
         import sentry_sdk  # ty: ignore[unresolved-import]
 
-        sentry_sdk.init(dsn=settings.sentry_dsn, environment=settings.environment)
-        logger.info("✓ Sentry error tracking initialized")
+        sentry_sdk.init(
+            dsn=settings.sentry_dsn,
+            environment=settings.environment,
+            traces_sample_rate=settings.sentry_traces_sample_rate,
+        )
+        logger.info(
+            "✓ Sentry error tracking initialized (traces_sample_rate=%s)",
+            settings.sentry_traces_sample_rate,
+        )
     except ImportError:
         logger.warning("SENTRY_DSN configured but sentry-sdk is not installed — install sentry-sdk[fastapi]")
 
@@ -100,10 +107,16 @@ app = FastAPI(
 )
 
 add_cors_middleware(app, settings, mcp_enabled=_mcp_app is not None)
+add_rate_limit_middleware(app, settings)
 
-# Metrics middleware is registered last so it is outermost and captures every request,
-# including those short-circuited by CORS or OIDC auth.
+# Metrics middleware is registered next-to-last so it is close to outermost and
+# captures every request, including those short-circuited by CORS, rate
+# limiting, or OIDC auth.
 app.add_middleware(BaseHTTPMiddleware, dispatch=request_metrics_middleware)
+
+# Host header validation is registered last so it is outermost and rejects
+# requests with an unrecognised Host before any other middleware runs.
+add_trusted_host_middleware(app, settings)
 
 
 @app.exception_handler(IntegrityError)

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -5,9 +5,14 @@ from typing import Any
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.config import Settings
+from app.ratelimit import get_client_ip
 
 logger = logging.getLogger(__name__)
 
@@ -44,3 +49,37 @@ def add_cors_middleware(app: FastAPI, settings: Settings, *, mcp_enabled: bool =
         app.add_middleware(MCPAwareCORSMiddleware, **cors_kwargs)
     else:
         app.add_middleware(CORSMiddleware, **cors_kwargs)
+
+
+def add_rate_limit_middleware(app: FastAPI, settings: Settings) -> Limiter:
+    """Install a general, configurable per-IP rate limiter across every route.
+
+    Applies RATE_LIMIT_DEFAULT per client IP and route unless RATE_LIMIT_ENABLED
+    is false. This is a general floor, layered *underneath* the stricter,
+    hardcoded 5-req/600s limiter (app.ratelimit.check_rate_limit) already applied
+    to the check-in and registration endpoints — that one still overrides this
+    default for those specific abuse-prone routes.
+    """
+    limiter = Limiter(
+        key_func=get_client_ip,
+        default_limits=[settings.rate_limit_default],
+        enabled=settings.rate_limit_enabled,
+    )
+    app.state.limiter = limiter
+    app.exception_handler(RateLimitExceeded)(_rate_limit_exceeded_handler)
+    app.add_middleware(SlowAPIMiddleware)
+    return limiter
+
+
+def add_trusted_host_middleware(app: FastAPI, settings: Settings) -> None:
+    """Reject requests with an unrecognised Host header.
+
+    A no-op when TRUSTED_HOSTS is empty (the development default) — Host header
+    validation is required in production instead (see Settings.validate_production_oidc).
+    """
+    trusted_hosts = settings.get_trusted_hosts_list()
+    if not trusted_hosts:
+        logger.warning("No TRUSTED_HOSTS configured — Host header validation is disabled!")
+        return
+    logger.info("Host header validation configured with allowed hosts: %s", trusted_hosts)
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=trusted_hosts)

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -81,5 +81,6 @@ def add_trusted_host_middleware(app: FastAPI, settings: Settings) -> None:
     if not trusted_hosts:
         logger.warning("No TRUSTED_HOSTS configured — Host header validation is disabled!")
         return
-    logger.info("Host header validation configured with allowed hosts: %s", trusted_hosts)
+    # Logs a count only, not the configured values themselves.
+    logger.info("Host header validation configured with %d allowed host pattern(s)", len(trusted_hosts))
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=trusted_hosts)

--- a/backend/app/ratelimit.py
+++ b/backend/app/ratelimit.py
@@ -1,10 +1,9 @@
 """Shared in-process rate-limiting helpers.
 
-NOTE: this limiter is process-local. In a multi-worker deployment each worker
-maintains its own bucket, so the effective limit is
-_RATE_LIMIT_MAX_REQUESTS × number_of_workers per client IP. Replace with a
-Redis-backed implementation if strict per-IP enforcement across workers is
-required.
+NOTE: these limiters are process-local. In a multi-worker deployment each worker
+maintains its own buckets, so the effective limit is
+max_requests × number_of_workers per client IP. Replace with a Redis-backed
+implementation if strict per-IP enforcement across workers is required.
 """
 
 from __future__ import annotations

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -51,7 +51,8 @@ def _require_metrics_access(request: Request) -> None:
     except ValueError:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden") from None
 
-    if abs(time.time() - timestamp) > METRICS_TOKEN_MAX_AGE_SECONDS:
+    now = int(time.time())
+    if timestamp > now or now - timestamp > METRICS_TOKEN_MAX_AGE_SECONDS:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 
     expected_mac = hmac.new(secret.encode(), timestamp_str.encode(), hashlib.sha256).hexdigest()

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,6 +1,7 @@
 """Health check and metrics endpoints."""
 
 import asyncio
+import hashlib
 import hmac
 import logging
 import time
@@ -19,14 +20,42 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["health"])
 
+METRICS_TOKEN_MAX_AGE_SECONDS = 60
+
+
+def build_metrics_token(secret: str, timestamp: int | None = None) -> str:
+    """Build a ``X-Metrics-Token`` value: ``<unix-timestamp>:<hex-hmac-sha256>``."""
+    ts = str(timestamp if timestamp is not None else int(time.time()))
+    mac = hmac.new(secret.encode(), ts.encode(), hashlib.sha256).hexdigest()
+    return f"{ts}:{mac}"
+
 
 def _require_metrics_access(request: Request) -> None:
-    """Verify HMAC secret for metrics endpoint access."""
-    secret = settings.metrics_secret
+    """Verify a timestamped HMAC token for metrics endpoint access.
+
+    Expects ``X-Metrics-Token: <unix-timestamp>:<hex-hmac-sha256>``, the HMAC
+    computed over the timestamp using METRICS_HMAC_SECRET. Rejecting tokens
+    older than METRICS_TOKEN_MAX_AGE_SECONDS bounds how long a leaked token
+    remains useful, unlike a static shared secret which is valid forever.
+    """
+    secret = settings.metrics_hmac_secret
     if not secret:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
-    provided = request.headers.get("X-Metrics-Secret", "")
-    if not hmac.compare_digest(provided, secret):
+
+    timestamp_str, _, provided_mac = request.headers.get("X-Metrics-Token", "").partition(":")
+    if not timestamp_str or not provided_mac:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+    try:
+        timestamp = int(timestamp_str)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden") from None
+
+    if abs(time.time() - timestamp) > METRICS_TOKEN_MAX_AGE_SECONDS:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+    expected_mac = hmac.new(secret.encode(), timestamp_str.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(provided_mac, expected_mac):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
 
 
@@ -117,7 +146,9 @@ def metrics_endpoint(
 ) -> dict[str, float | int]:
     """HMAC-protected endpoint returning uptime, request rate, error rate and latency percentiles.
 
-    Pass the shared secret in the ``X-Metrics-Secret`` request header.
+    Pass a fresh ``<unix-timestamp>:<hex-hmac-sha256>`` token in the
+    ``X-Metrics-Token`` request header (see ``build_metrics_token``); tokens
+    older than ``METRICS_TOKEN_MAX_AGE_SECONDS`` are rejected.
     """
     snapshot = metrics.snapshot()
     return {

--- a/backend/docs/OBSERVABILITY.md
+++ b/backend/docs/OBSERVABILITY.md
@@ -54,17 +54,38 @@ Use `/api/health/readiness` for load-balancer health checks — not liveness.
 
 | Endpoint | Auth |
 |---|---|
-| `GET /api/metrics` | `X-Metrics-Secret` header (HMAC constant-time comparison) |
+| `GET /api/metrics` | `X-Metrics-Token` header: `<unix-timestamp>:<hex-hmac-sha256>`, HMAC computed over the timestamp with `METRICS_HMAC_SECRET` |
 
 Returns in-process counters: uptime, request total, error total, request rate, error rate, and latency percentiles (avg, p50, p99).
 
+Tokens older than `METRICS_TOKEN_MAX_AGE_SECONDS` (60s) are rejected, so a leaked token has a narrow window of use — unlike a static shared secret, which is valid forever once leaked. Build a token with `app.routers.health.build_metrics_token(secret)`, e.g.:
+
+```bash
+python -c "from app.routers.health import build_metrics_token; print(build_metrics_token('$METRICS_HMAC_SECRET'))"
+curl -H "X-Metrics-Token: $(python -c "from app.routers.health import build_metrics_token; print(build_metrics_token('$METRICS_HMAC_SECRET'))")" https://champagnefestival.tjor.im/api/metrics
+```
+
 **Important:** metrics are **process-local** and reset on every restart. Not aggregated across workers.
+
+---
+
+## Rate Limiting
+
+A general, configurable per-IP rate limiter (`RATE_LIMIT_ENABLED` / `RATE_LIMIT_DEFAULT`, via `slowapi`) applies to every `/api` route. The check-in and registration endpoints additionally enforce a stricter, hardcoded 5-req/600s limit (`app/ratelimit.py`) on top of the general default, as an override for that specific abuse vector.
+
+---
+
+## Host Header Validation
+
+`TRUSTED_HOSTS` (comma-separated) configures Starlette's `TrustedHostMiddleware`, rejecting requests whose `Host` header doesn't match. Required in production; disabled when empty (the development default).
 
 ---
 
 ## Error Tracking (Sentry)
 
 Sentry is initialised at startup if `SENTRY_DSN` is set. The SDK is an optional install (`sentry-sdk[fastapi]`). Unhandled exceptions are captured via `sentry_sdk.capture_exception()`. `send_default_pii` should be set to `False` to prevent capturing IP addresses and cookies.
+
+`SENTRY_TRACES_SAMPLE_RATE` (0.0-1.0, default `0.0`) controls performance transaction sampling; `0.0` disables performance tracing while leaving error tracking unaffected.
 
 ---
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "fastapi==0.139.2",
   "fastmcp==3.4.4",
   "httpx==0.28.1",
+  "limits==5.8.0",
   "phonenumbers==9.0.34",
   "psycopg[binary]==3.3.4",
   "pydantic[email]==2.13.4",
@@ -20,6 +21,7 @@ dependencies = [
   "PyJWT[crypto]==2.12.1",
   "python-dotenv==1.2.2",
   "python-multipart==0.0.32",
+  "slowapi==0.1.10",
   "sqlalchemy==2.0.51",
   "uvicorn[standard]==0.51.0",
 ]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -38,6 +38,12 @@ def reset_rate_limiter(monkeypatch):
     monkeypatch.setattr(ratelimit_module, "_rate_limit_buckets", {})
 
 
+@pytest.fixture(autouse=True)
+def reset_general_rate_limiter():
+    """Reset the general slowapi rate limiter's storage before every test for isolation."""
+    app.state.limiter.reset()
+
+
 def _assert_test_database_url(url: str) -> None:
     """Raise RuntimeError if *url* does not look like a safe test database.
 

--- a/backend/tests/test_general_rate_limit.py
+++ b/backend/tests/test_general_rate_limit.py
@@ -1,0 +1,96 @@
+"""Tests for the general per-IP rate limiter and Host header validation middleware."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.middleware import add_rate_limit_middleware, add_trusted_host_middleware
+
+
+def _ping_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/api/ping")
+    async def ping() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+@pytest.mark.anyio
+async def test_general_rate_limit_allows_requests_within_default():
+    app = _ping_app()
+    add_rate_limit_middleware(app, Settings(rate_limit_default="2/minute"))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.get("/api/ping")
+        second = await client.get("/api/ping")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_general_rate_limit_returns_429_once_exceeded():
+    app = _ping_app()
+    add_rate_limit_middleware(app, Settings(rate_limit_default="2/minute"))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.get("/api/ping")
+        await client.get("/api/ping")
+        third = await client.get("/api/ping")
+
+    assert third.status_code == 429
+
+
+@pytest.mark.anyio
+async def test_general_rate_limit_disabled_allows_unlimited_requests():
+    app = _ping_app()
+    add_rate_limit_middleware(app, Settings(rate_limit_default="1/minute", rate_limit_enabled=False))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(5):
+            r = await client.get("/api/ping")
+            assert r.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_trusted_host_middleware_rejects_unknown_host():
+    app = _ping_app()
+    add_trusted_host_middleware(app, Settings(trusted_hosts="allowed.example.test"))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://not-allowed.example.test") as client:
+        r = await client.get("/api/ping")
+
+    assert r.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_trusted_host_middleware_allows_configured_host():
+    app = _ping_app()
+    add_trusted_host_middleware(app, Settings(trusted_hosts="allowed.example.test"))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://allowed.example.test") as client:
+        r = await client.get("/api/ping")
+
+    assert r.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_trusted_host_middleware_noop_when_unconfigured():
+    app = _ping_app()
+    add_trusted_host_middleware(app, Settings(trusted_hosts=""))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://anything.example.test") as client:
+        r = await client.get("/api/ping")
+
+    assert r.status_code == 200

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import time
+
 import pytest
 from pydantic import ValidationError
 
 from app.config import GUEST_ACCESS_TOKEN_TTL_MAX_MINUTES, Settings
 from app.observability import InMemoryRequestMetrics
+from app.routers.health import build_metrics_token
 
 # ---------------------------------------------------------------------------
 # Health endpoints
@@ -71,15 +74,33 @@ async def test_metrics_forbidden_without_secret(client):
 
 @pytest.mark.anyio
 async def test_metrics_forbidden_wrong_secret(client, monkeypatch):
-    monkeypatch.setattr("app.routers.health.settings", type("S", (), {"metrics_secret": "correct"})())
-    r = await client.get("/api/metrics", headers={"X-Metrics-Secret": "wrong"})
+    monkeypatch.setattr("app.routers.health.settings", type("S", (), {"metrics_hmac_secret": "correct"})())
+    r = await client.get("/api/metrics", headers={"X-Metrics-Token": build_metrics_token("wrong")})
+    assert r.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_metrics_forbidden_malformed_token(client, monkeypatch):
+    monkeypatch.setattr("app.routers.health.settings", type("S", (), {"metrics_hmac_secret": "mysecret"})())
+    r = await client.get("/api/metrics", headers={"X-Metrics-Token": "not-a-valid-token"})
+    assert r.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_metrics_forbidden_stale_token(client, monkeypatch):
+    monkeypatch.setattr("app.routers.health.settings", type("S", (), {"metrics_hmac_secret": "mysecret"})())
+    stale_timestamp = int(time.time()) - 61
+    r = await client.get(
+        "/api/metrics",
+        headers={"X-Metrics-Token": build_metrics_token("mysecret", timestamp=stale_timestamp)},
+    )
     assert r.status_code == 403
 
 
 @pytest.mark.anyio
 async def test_metrics_ok_with_secret(client, monkeypatch):
-    monkeypatch.setattr("app.routers.health.settings", type("S", (), {"metrics_secret": "mysecret"})())
-    r = await client.get("/api/metrics", headers={"X-Metrics-Secret": "mysecret"})
+    monkeypatch.setattr("app.routers.health.settings", type("S", (), {"metrics_hmac_secret": "mysecret"})())
+    r = await client.get("/api/metrics", headers={"X-Metrics-Token": build_metrics_token("mysecret")})
     assert r.status_code == 200
     body = r.json()
     assert "uptime_seconds" in body
@@ -163,3 +184,77 @@ def test_settings_reject_excessive_guest_access_token_ttl():
 def test_settings_reject_production_without_qr_secret():
     with pytest.raises(ValidationError, match=r"QR_SIGNING_SECRET must be set in production\."):
         Settings(environment="production", oidc_issuer_url="https://auth.example.com", qr_signing_secret="")
+
+
+def test_settings_reject_production_without_trusted_hosts():
+    with pytest.raises(ValidationError, match=r"TRUSTED_HOSTS must be set in production\."):
+        Settings(
+            environment="production",
+            oidc_issuer_url="https://auth.example.com",
+            qr_signing_secret="secret",
+            trusted_hosts="",
+        )
+
+
+def test_settings_get_trusted_hosts_list_parses_comma_separated_values():
+    settings = Settings(trusted_hosts="champagnefestival.tjor.im, *.example.com")
+    assert settings.get_trusted_hosts_list() == ["champagnefestival.tjor.im", "*.example.com"]
+
+
+def test_settings_reject_sentry_traces_sample_rate_above_one():
+    with pytest.raises(ValidationError, match=r"SENTRY_TRACES_SAMPLE_RATE must be between 0.0 and 1.0\."):
+        Settings(sentry_traces_sample_rate=1.5)
+
+
+def test_settings_reject_sentry_traces_sample_rate_below_zero():
+    with pytest.raises(ValidationError, match=r"SENTRY_TRACES_SAMPLE_RATE must be between 0.0 and 1.0\."):
+        Settings(sentry_traces_sample_rate=-0.1)
+
+
+def test_settings_reject_invalid_rate_limit_default():
+    with pytest.raises(ValidationError, match=r"RATE_LIMIT_DEFAULT is not a valid rate limit string"):
+        Settings(rate_limit_default="not-a-rate-limit")
+
+
+def test_settings_builds_database_url_from_parts(tmp_path):
+    password_file = tmp_path / "db_password"
+    password_file.write_text("s3cr3t/p@ss\n")
+
+    settings = Settings(
+        database_url="",
+        db_host="postgres",
+        db_port=5544,
+        db_name="champagnefestival",
+        db_user="champagnefestival_user",
+        db_password_file=str(password_file),
+    )
+
+    assert settings.database_url == (
+        "postgresql+asyncpg://champagnefestival_user:s3cr3t%2Fp%40ss@postgres:5544/champagnefestival"
+    )
+
+
+def test_settings_database_url_override_wins_over_db_parts(tmp_path):
+    password_file = tmp_path / "db_password"
+    password_file.write_text("unused")
+
+    settings = Settings(
+        database_url="postgresql+asyncpg://explicit:pw@localhost:5432/explicit_db",
+        db_host="postgres",
+        db_name="champagnefestival",
+        db_user="champagnefestival_user",
+        db_password_file=str(password_file),
+    )
+
+    assert settings.database_url == "postgresql+asyncpg://explicit:pw@localhost:5432/explicit_db"
+
+
+def test_settings_missing_db_password_file_raises():
+    with pytest.raises(ValidationError, match=r"DB_PASSWORD_FILE could not be read"):
+        Settings(
+            database_url="",
+            db_host="postgres",
+            db_name="champagnefestival",
+            db_user="champagnefestival_user",
+            db_password_file="/nonexistent/path/to/secret",
+        )

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -98,6 +98,17 @@ async def test_metrics_forbidden_stale_token(client, monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_metrics_forbidden_future_token(client, monkeypatch):
+    monkeypatch.setattr("app.routers.health.settings", type("S", (), {"metrics_hmac_secret": "mysecret"})())
+    future_timestamp = int(time.time()) + 5
+    r = await client.get(
+        "/api/metrics",
+        headers={"X-Metrics-Token": build_metrics_token("mysecret", timestamp=future_timestamp)},
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.anyio
 async def test_metrics_ok_with_secret(client, monkeypatch):
     monkeypatch.setattr("app.routers.health.settings", type("S", (), {"metrics_hmac_secret": "mysecret"})())
     r = await client.get("/api/metrics", headers={"X-Metrics-Token": build_metrics_token("mysecret")})

--- a/backend/tests/test_request_correlation.py
+++ b/backend/tests/test_request_correlation.py
@@ -6,6 +6,8 @@ import logging
 
 import pytest
 
+from app.routers.health import build_metrics_token
+
 
 @pytest.mark.anyio
 async def test_response_includes_request_id_header(client):
@@ -51,8 +53,8 @@ async def test_request_id_present_on_error_response(client):
 
 @pytest.mark.anyio
 async def test_metrics_response_includes_request_id(client, monkeypatch):
-    monkeypatch.setattr("app.routers.health.settings", type("S", (), {"metrics_secret": "secret"})())
-    r = await client.get("/api/metrics", headers={"X-Metrics-Secret": "secret"})
+    monkeypatch.setattr("app.routers.health.settings", type("S", (), {"metrics_hmac_secret": "secret"})())
+    r = await client.get("/api/metrics", headers={"X-Metrics-Token": build_metrics_token("secret")})
     assert r.status_code == 200
     assert "x-request-id" in r.headers
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -209,7 +209,7 @@ wheels = [
 
 [[package]]
 name = "champagnefestival-backend"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -217,6 +217,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "limits" },
     { name = "phonenumbers" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic", extra = ["email"] },
@@ -224,6 +225,7 @@ dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
     { name = "python-multipart" },
+    { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -249,6 +251,7 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.139.2" },
     { name = "fastmcp", specifier = "==3.4.4" },
     { name = "httpx", specifier = "==0.28.1" },
+    { name = "limits", specifier = "==5.8.0" },
     { name = "phonenumbers", specifier = "==9.0.34" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pydantic", extras = ["email"], specifier = "==2.13.4" },
@@ -257,6 +260,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-multipart", specifier = "==0.0.32" },
     { name = "sentry-sdk", extras = ["fastapi"], marker = "extra == 'sentry'", specifier = "==2.66.0" },
+    { name = "slowapi", specifier = "==0.1.10" },
     { name = "sqlalchemy", specifier = "==2.0.51" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.51.0" },
 ]
@@ -358,6 +362,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/07/bf61d13de86d96a4c46aff00c9ca0eced44bcc8c3e16280605c1253e5720/cyclopts-4.16.1.tar.gz", hash = "sha256:8aa47bf92a5fb33abca5af05e576eecdb0d2f79893ad29238046df78370fc4a8", size = 181196, upload-time = "2026-05-25T15:29:08.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/8d/7f362c2fb8ef4decd2160bc24d4292c6ca658cc6d9a161b89ca5122bbdbf/cyclopts-4.16.1-py3-none-any.whl", hash = "sha256:617795392c4113a2c2cc7af716f20244900e87f23daa05442d1268d81472a592", size = 219020, upload-time = "2026-05-25T15:29:09.646Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
 
 [[package]]
@@ -488,6 +504,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -496,6 +513,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -504,6 +522,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -732,6 +751,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -1390,6 +1423,18 @@ fastapi = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/52/24527cf25a8b508926aff53350b0136561dfe86c7125f61526653666e1b2/slowapi-0.1.10.tar.gz", hash = "sha256:d320d5bc04d9f171a77fb16700faf3036d85b00f420f22924c8a225f95bd14f9", size = 13841, upload-time = "2026-06-13T11:59:31.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/8b/1d359f38706b4097d9a943bf8bd22599f537de4cbaff1e622d3e3936e164/slowapi-0.1.10-py3-none-any.whl", hash = "sha256:3acb61561dc9d687e3d3669362ff6a439de9ba44e2fed3a9c165da26b4b83e28", size = 14921, upload-time = "2026-06-13T11:59:30.485Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -1661,4 +1706,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]

--- a/infra/champagnefestival.env.example
+++ b/infra/champagnefestival.env.example
@@ -23,3 +23,42 @@ ADMIN_USERNAMES=
 
 # Comma-separated list of allowed origins.  Must include the frontend domain.
 CORS_ORIGINS=https://champagnefestival.tjor.im
+
+# ─── Database ─────────────────────────────────────────────────────────────────
+
+# Split host/port/name/user + a Docker secret file for the password, so the
+# password never sits in this plaintext .env file. DATABASE_URL, if set,
+# takes precedence over these (local-dev override) — leave it unset here.
+DB_HOST=postgres
+DB_PORT=5432
+DB_NAME=champagnefestival
+DB_USER=champagnefestival_user
+# Path to a Docker secret file containing only the password.
+DB_PASSWORD_FILE=/run/secrets/champagnefestival_db_password
+
+# ─── Rate limiting ────────────────────────────────────────────────────────────
+
+# General per-IP, per-route rate limiter applied to every /api endpoint. The
+# stricter check-in/registration limiter (5 req / 600s) always applies on top
+# of this as an override for those specific endpoints.
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_DEFAULT=60/minute
+
+# ─── Host header validation ───────────────────────────────────────────────────
+
+# Comma-separated list of allowed Host header values. Required.
+TRUSTED_HOSTS=champagnefestival.tjor.im
+
+# ─── Metrics ───────────────────────────────────────────────────────────────────
+
+# Shared secret used to compute the X-Metrics-Token HMAC (see backend/README.md)
+# required to access GET /api/metrics. Leave empty to disable the endpoint.
+METRICS_HMAC_SECRET=
+
+# ─── Error tracking (Sentry) ───────────────────────────────────────────────────
+
+# Sentry DSN for backend error tracking. Leave empty to disable Sentry.
+SENTRY_DSN=
+
+# Fraction (0.0-1.0) of transactions sampled for Sentry performance monitoring.
+SENTRY_TRACES_SAMPLE_RATE=0.1


### PR DESCRIPTION
Closes #753

## Summary

Closes the five gaps identified against the shared `worktime`/`daynest` infra conventions:

1. **Sentry performance sampling.** Added `SENTRY_TRACES_SAMPLE_RATE` (`Settings.sentry_traces_sample_rate`, validated 0.0–1.0) and wired it through to `sentry_sdk.init(..., traces_sample_rate=...)` in `backend/app/main.py`.
2. **General rate limiting.** Added a configurable, per-IP `slowapi` limiter (`RATE_LIMIT_ENABLED` / `RATE_LIMIT_DEFAULT`, default `60/minute`) applied to every `/api` route via `add_rate_limit_middleware` in `backend/app/middleware.py`. The existing hardcoded 5-req/600s check-in/registration limiter (`backend/app/ratelimit.py`) is unchanged and still layered on top as a stricter override for that specific abuse vector.
3. **DB secret pattern.** `Settings` now builds `DATABASE_URL` from `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER` + `DB_PASSWORD_FILE` (a Docker-secret-style file path) when `DATABASE_URL` isn't set directly — `DATABASE_URL` remains a local-dev override. Updated `infra/champagnefestival.env.example` and `backend/.env.example` accordingly.
4. **Metrics replay protection.** Replaced the static `X-Metrics-Secret` / `METRICS_SECRET` check with a timestamped `X-Metrics-Token` HMAC (`METRICS_HMAC_SECRET`, format `<unix-timestamp>:<hex-hmac-sha256>`) that rejects tokens older than 60 seconds. Added `build_metrics_token()` helper for generating tokens.
5. **Host header validation.** Added `TRUSTED_HOSTS` + Starlette's `TrustedHostMiddleware` (registered outermost, after CORS/rate-limit/metrics middleware), required in production alongside the existing `OIDC_ISSUER_URL`/`QR_SIGNING_SECRET` checks.

`slowapi`/`limits` added as new backend dependencies.

## Test plan

- [x] `uv run ruff check app tests` — passes
- [x] `uv run ty check app` — passes
- [x] `uv run pytest` — 403 passed (added coverage for all 5 settings/middleware changes, including a new `tests/test_general_rate_limit.py`)
- [ ] CI (Backend/Frontend/CodeQL) — pending


---
_Generated by [Claude Code](https://claude.ai/code/session_01FdrMExxVqefMsPf18ARC3q)_