### PR TITLE
Scaffold experimental Pebble (Alloy) companion app

### DIFF
--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -1,0 +1,27 @@
+name: Pebble CI
+
+on:
+  pull_request:
+    paths:
+      - "pebble/**"
+      - ".github/workflows/pebble.yml"
+  push:
+    branches: [main]
+    paths:
+      - "pebble/**"
+      - ".github/workflows/pebble.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 22
+      - name: Validate Alloy package contract
+        working-directory: pebble
+        run: node scripts/validate.mjs

--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 22

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 - `frontend/` contains the web app
 - `backend/` contains the FastAPI service
+- `pebble/` contains an experimental, unshipped Pebble (Alloy) companion app scaffold — see `pebble/README.md` (tracks issue #757)
 - Production hosting for `champagnefestival.tjor.im` is handled by the separate infra stack in `/opt/apps/infra`
 - Frontend builds write to `frontend/dist`; in production, Caddy serves this content from `/srv/champagnefestival`
 

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/AuthManager.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/AuthManager.kt
@@ -11,8 +11,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/AuthManager.kt
+++ b/android/app/src/main/kotlin/be/champagnefestival/android/core/auth/AuthManager.kt
@@ -12,6 +12,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -25,6 +26,7 @@ import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.EndSessionRequest
 import net.openid.appauth.ResponseTypeValues
 
 @Singleton
@@ -144,7 +146,24 @@ constructor(
 
     fun getAccessToken(): String? = authState.accessToken
 
-    fun logout() {
+    suspend fun logout() {
+        val stateToEnd = authState
+        runCatching {
+            val configuration = fetchConfiguration()
+            if (configuration.endSessionEndpoint == null) return@runCatching
+            val builder =
+                EndSessionRequest
+                    .Builder(configuration)
+                    .setPostLogoutRedirectUri(oidcConfig.redirectUri)
+            stateToEnd.idToken?.let(builder::setIdTokenHint)
+            val intent =
+                authService
+                    .getEndSessionRequestIntent(builder.build())
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+        }.onFailure { exception ->
+            if (exception is CancellationException) throw exception
+        }
         clearState()
     }
 

--- a/backend/alembic/versions/002_add_pebble_access_tokens.py
+++ b/backend/alembic/versions/002_add_pebble_access_tokens.py
@@ -1,0 +1,52 @@
+"""Add scoped Pebble access tokens.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-07-27
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "002"
+down_revision: str | None = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pebble_access_tokens",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("token_hash", sa.String(64), nullable=False, unique=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_pebble_access_tokens_token_hash",
+        "pebble_access_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pebble_access_tokens_token_hash", table_name="pebble_access_tokens")
+    op.drop_table("pebble_access_tokens")

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
 
 from fastapi import Depends, HTTPException, Request, status
@@ -13,6 +15,58 @@ from app.oidc_config import OIDCTokenError, decode_token
 logger = logging.getLogger(__name__)
 
 _bearer_scheme = HTTPBearer(auto_error=True)
+
+
+class AuthType(StrEnum):
+    KEYCLOAK_USER = "keycloak_user"
+    KEYCLOAK_SERVICE = "keycloak_service"
+    DELEGATED = "delegated"
+
+
+@dataclass(frozen=True)
+class AuthorizationPrincipal:
+    """Provider-neutral identity and authorization context."""
+
+    subject: str
+    user_id: str | None
+    client_id: str | None
+    auth_type: AuthType
+    roles: frozenset[str] = frozenset()
+    scopes: frozenset[str] = frozenset()
+
+
+def _is_keycloak_service_account(claims: dict[str, Any]) -> bool:
+    username = claims.get("preferred_username")
+    return isinstance(username, str) and username.startswith("service-account-")
+
+
+def _principal_from_claims(claims: dict[str, Any]) -> AuthorizationPrincipal:
+    subject = claims.get("sub")
+    if not isinstance(subject, str) or not subject:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing sub claim in token")
+    if _is_keycloak_service_account(claims):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Keycloak service accounts cannot use the user REST API",
+        )
+    client_id = claims.get("azp")
+    scope = claims.get("scope")
+    return AuthorizationPrincipal(
+        subject=subject,
+        user_id=None,
+        client_id=client_id if isinstance(client_id, str) else None,
+        auth_type=AuthType.KEYCLOAK_USER,
+        roles=frozenset(role for role in _extract_roles(claims) if isinstance(role, str)),
+        scopes=frozenset(scope.split()) if isinstance(scope, str) else frozenset(),
+    )
+
+
+def _set_request_principal(request: Request, claims: dict[str, Any]) -> AuthorizationPrincipal:
+    principal = _principal_from_claims(claims)
+    request.state.principal = principal
+    request.state.user_id = principal.subject
+    request.state.auth_type = principal.auth_type
+    return principal
 
 
 async def _decode_or_401(credentials: HTTPAuthorizationCredentials) -> dict[str, Any]:
@@ -59,8 +113,7 @@ async def require_admin(
             detail="Forbidden",
         )
 
-    request.state.user_id = claims.get("sub")
-    request.state.auth_type = "oidc"
+    _set_request_principal(request, claims)
 
 
 async def require_volunteer(
@@ -81,8 +134,7 @@ async def require_volunteer(
             detail="Forbidden",
         )
 
-    request.state.user_id = claims.get("sub")
-    request.state.auth_type = "oidc"
+    _set_request_principal(request, claims)
 
 
 async def get_current_claims(
@@ -95,8 +147,7 @@ async def get_current_claims(
     that only require the caller to be authenticated.
     """
     claims = await _decode_or_401(credentials)
-    request.state.user_id = claims.get("sub")
-    request.state.auth_type = "oidc"
+    _set_request_principal(request, claims)
     return claims
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -149,6 +149,7 @@ app.include_router(volunteer_ops.router)
 app.include_router(areas.router)
 app.include_router(venue_plan.router)
 app.include_router(me.router)
+app.include_router(me.pebble_router)
 app.include_router(live.router)
 app.include_router(health.router)
 

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -349,32 +349,24 @@ def build_keycloak_auth() -> Any:
     """Build a :class:`KeycloakAuthProvider` from application settings.
 
     Requires ``OIDC_ISSUER_URL`` and ``MCP_BASE_URL`` to be set.
-    Returns ``None`` when OIDC is not configured (development / stdio mode).
+    Returns ``None`` when the HTTP MCP server is not configured. Local stdio
+    mode passes ``auth=None`` directly and does not call this helper.
     """
-    if not settings.oidc_issuer_url:
-        logger.info("OIDC_ISSUER_URL not configured — MCP server running without auth enforcement.")
-        return None
-
     mcp_base_url = settings.mcp_base_url
     if not mcp_base_url:
-        logger.info(
-            "MCP_BASE_URL not configured — MCP server running without Keycloak auth. "
-            "Set MCP_BASE_URL to enable OIDC authentication."
-        )
         return None
 
-    try:
-        from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
+    if not settings.oidc_issuer_url:
+        raise RuntimeError("OIDC_ISSUER_URL is required when MCP_BASE_URL enables the HTTP MCP server")
 
-        return KeycloakAuthProvider(
-            realm_url=settings.oidc_issuer_url,
-            base_url=mcp_base_url,
-            audience=settings.oidc_audience or None,
-            required_scopes=[],
-        )
-    except Exception as exc:  # pragma: no cover
-        logger.warning("Failed to build Keycloak auth provider: %s", exc)
-        return None
+    from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
+
+    return KeycloakAuthProvider(
+        realm_url=settings.oidc_issuer_url,
+        base_url=mcp_base_url,
+        audience=settings.oidc_audience or None,
+        required_scopes=["openid", "offline_access"],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -370,7 +370,7 @@ def build_keycloak_auth() -> Any:
             realm_url=settings.oidc_issuer_url,
             base_url=mcp_base_url,
             audience=settings.oidc_audience or None,
-            required_scopes=["openid", "offline_access"],
+            required_scopes=[],
         )
     except Exception as exc:  # pragma: no cover
         logger.warning("Failed to build Keycloak auth provider: %s", exc)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -37,6 +37,30 @@ class User(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow, onupdate=_utcnow)
 
     registrations: Mapped[list[Registration]] = relationship(back_populates="user")
+    pebble_access_token: Mapped[PebbleAccessToken | None] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
+
+
+class PebbleAccessToken(Base):
+    """Long-lived, revocable credential scoped to the Pebble registration glance."""
+
+    __tablename__ = "pebble_access_tokens"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    user: Mapped[User] = relationship(back_populates="pebble_access_token")
 
 
 class Registration(Base):

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 import jwt
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
@@ -112,10 +112,12 @@ async def list_my_registrations(
 
 @router.post("/pebble-token", response_model=PebbleAccessTokenOut)
 async def create_pebble_token(
+    response: Response,
     claims: dict[str, Any] = Depends(get_current_claims),
     db: AsyncSession = Depends(get_db),
 ) -> PebbleAccessTokenOut:
     """Rotate the caller's long-lived token scoped to the Pebble glance."""
+    response.headers["Cache-Control"] = "no-store"
     oidc_subject: str = claims.get("sub", "")
     if not oidc_subject:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing sub claim in token")

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import jwt
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,10 +17,23 @@ from app.auth import get_current_claims
 from app.config import settings
 from app.database import get_db
 from app.models import Event, Registration, User
-from app.schemas import MyQrOut, MyRegistrationOut, PaymentStatus, RegistrationStatus
+from app.schemas import (
+    MyQrOut,
+    MyRegistrationOut,
+    PaymentStatus,
+    PebbleAccessTokenOut,
+    RegistrationStatus,
+)
+from app.services.pebble_access import (
+    authenticate_pebble_token,
+    revoke_pebble_token,
+    rotate_pebble_token,
+)
 from app.utils import make_id
 
 router = APIRouter(prefix="/api/me", tags=["me"])
+pebble_router = APIRouter(prefix="/api/pebble", tags=["pebble"])
+_bearer_scheme = HTTPBearer(auto_error=True)
 
 _QR_TOKEN_TTL_MINUTES = 15
 _QR_ALGORITHM = "HS256"
@@ -49,29 +63,14 @@ async def _get_or_create_user(db: AsyncSession, oidc_subject: str) -> User:
     return user
 
 
-@router.get("/registrations", response_model=list[MyRegistrationOut])
-async def list_my_registrations(
-    claims: dict[str, Any] = Depends(get_current_claims),
-    db: AsyncSession = Depends(get_db),
-) -> list[MyRegistrationOut]:
-    """Return all registrations that have been claimed by the authenticated user.
-
-    Auto-provisions a portal ``User`` record on first call if one does not yet
-    exist for the caller's OIDC subject.
-    """
-    oidc_subject: str = claims.get("sub", "")
-    if not oidc_subject:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing sub claim in token")
-
-    user = await _get_or_create_user(db, oidc_subject)
-
+async def _registrations_for_user(db: AsyncSession, user_id: str) -> list[MyRegistrationOut]:
     result = await db.execute(
         select(Registration)
         .options(
             selectinload(Registration.person),
             selectinload(Registration.event).selectinload(Event.edition),
         )
-        .where(Registration.user_id == user.id)
+        .where(Registration.user_id == user_id)
         .order_by(Registration.created_at.desc())
     )
     registrations = result.scalars().all()
@@ -96,6 +95,60 @@ async def list_my_registrations(
             )
         )
     return payload
+
+
+@router.get("/registrations", response_model=list[MyRegistrationOut])
+async def list_my_registrations(
+    claims: dict[str, Any] = Depends(get_current_claims),
+    db: AsyncSession = Depends(get_db),
+) -> list[MyRegistrationOut]:
+    """Return registrations claimed by the authenticated portal user."""
+    oidc_subject: str = claims.get("sub", "")
+    if not oidc_subject:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing sub claim in token")
+    user = await _get_or_create_user(db, oidc_subject)
+    return await _registrations_for_user(db, user.id)
+
+
+@router.post("/pebble-token", response_model=PebbleAccessTokenOut)
+async def create_pebble_token(
+    claims: dict[str, Any] = Depends(get_current_claims),
+    db: AsyncSession = Depends(get_db),
+) -> PebbleAccessTokenOut:
+    """Rotate the caller's long-lived token scoped to the Pebble glance."""
+    oidc_subject: str = claims.get("sub", "")
+    if not oidc_subject:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing sub claim in token")
+    user = await _get_or_create_user(db, oidc_subject)
+    return PebbleAccessTokenOut(token=await rotate_pebble_token(db, user.id))
+
+
+@router.delete("/pebble-token", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_pebble_token(
+    claims: dict[str, Any] = Depends(get_current_claims),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    oidc_subject: str = claims.get("sub", "")
+    if not oidc_subject:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing sub claim in token")
+    user = await _get_or_create_user(db, oidc_subject)
+    await revoke_pebble_token(db, user.id)
+
+
+@pebble_router.get("/registrations", response_model=list[MyRegistrationOut])
+async def list_pebble_registrations(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
+    db: AsyncSession = Depends(get_db),
+) -> list[MyRegistrationOut]:
+    """Return registrations using a credential that cannot access other APIs."""
+    user_id = await authenticate_pebble_token(db, credentials.credentials)
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or revoked Pebble token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return await _registrations_for_user(db, user_id)
 
 
 @router.get("/qr", response_model=MyQrOut)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -286,6 +286,10 @@ class MyQrOut(BaseModel):
     expires_at: datetime
 
 
+class PebbleAccessTokenOut(BaseModel):
+    token: str
+
+
 class RegistrationLookupRequest(BaseModel):
     email: EmailStr
 

--- a/backend/app/services/pebble_access.py
+++ b/backend/app/services/pebble_access.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import hashlib
 import secrets
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import PebbleAccessToken
 from app.utils import make_id
 
 TOKEN_PREFIX = "cfpat_"
+_LAST_USED_UPDATE_INTERVAL = timedelta(minutes=15)
 
 
 def _token_hash(token: str) -> str:
@@ -22,15 +24,27 @@ def _token_hash(token: str) -> str:
 async def rotate_pebble_token(db: AsyncSession, user_id: str) -> str:
     """Replace the user's previous Pebble token and return the new raw value once."""
     raw_token = f"{TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
+    token_hash = _token_hash(raw_token)
     await db.execute(delete(PebbleAccessToken).where(PebbleAccessToken.user_id == user_id))
     db.add(
         PebbleAccessToken(
             id=make_id("pbt"),
             user_id=user_id,
-            token_hash=_token_hash(raw_token),
+            token_hash=token_hash,
         )
     )
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        result = await db.execute(select(PebbleAccessToken).where(PebbleAccessToken.user_id == user_id))
+        existing = result.scalar_one_or_none()
+        if existing is None:
+            raise
+        existing.token_hash = token_hash
+        existing.created_at = datetime.now(UTC)
+        existing.last_used_at = None
+        await db.commit()
     return raw_token
 
 
@@ -47,6 +61,13 @@ async def authenticate_pebble_token(db: AsyncSession, raw_token: str) -> str | N
     token = result.scalar_one_or_none()
     if token is None:
         return None
-    token.last_used_at = datetime.now(UTC)
+    now = datetime.now(UTC)
+    last_used_at = token.last_used_at
+    if last_used_at is not None:
+        if last_used_at.tzinfo is None:
+            last_used_at = last_used_at.replace(tzinfo=UTC)
+        if now - last_used_at < _LAST_USED_UPDATE_INTERVAL:
+            return token.user_id
+    token.last_used_at = now
     await db.commit()
     return token.user_id

--- a/backend/app/services/pebble_access.py
+++ b/backend/app/services/pebble_access.py
@@ -1,0 +1,52 @@
+"""Issue and validate credentials scoped to the Pebble registration glance."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import PebbleAccessToken
+from app.utils import make_id
+
+TOKEN_PREFIX = "cfpat_"
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+async def rotate_pebble_token(db: AsyncSession, user_id: str) -> str:
+    """Replace the user's previous Pebble token and return the new raw value once."""
+    raw_token = f"{TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
+    await db.execute(delete(PebbleAccessToken).where(PebbleAccessToken.user_id == user_id))
+    db.add(
+        PebbleAccessToken(
+            id=make_id("pbt"),
+            user_id=user_id,
+            token_hash=_token_hash(raw_token),
+        )
+    )
+    await db.commit()
+    return raw_token
+
+
+async def revoke_pebble_token(db: AsyncSession, user_id: str) -> None:
+    await db.execute(delete(PebbleAccessToken).where(PebbleAccessToken.user_id == user_id))
+    await db.commit()
+
+
+async def authenticate_pebble_token(db: AsyncSession, raw_token: str) -> str | None:
+    """Return the owning user ID for a valid scoped token."""
+    if not raw_token.startswith(TOKEN_PREFIX):
+        return None
+    result = await db.execute(select(PebbleAccessToken).where(PebbleAccessToken.token_hash == _token_hash(raw_token)))
+    token = result.scalar_one_or_none()
+    if token is None:
+        return None
+    token.last_used_at = datetime.now(UTC)
+    await db.commit()
+    return token.user_id

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -26,7 +26,7 @@ def _request() -> MagicMock:
 @pytest.mark.asyncio
 async def test_require_admin_accepts_admin_role(monkeypatch) -> None:
     async def fake_decode_token(_token: str) -> dict:
-        return {"realm_access": {"roles": ["admin", "user"]}}
+        return {"sub": "admin-user", "realm_access": {"roles": ["admin", "user"]}}
 
     monkeypatch.setattr(auth, "decode_token", fake_decode_token)
 
@@ -106,7 +106,7 @@ async def test_require_admin_rejects_string_roles_claim(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_require_volunteer_accepts_volunteer_role(monkeypatch) -> None:
     async def fake_decode_token(_token: str) -> dict:
-        return {"realm_access": {"roles": ["volunteer"]}}
+        return {"sub": "volunteer-user", "realm_access": {"roles": ["volunteer"]}}
 
     monkeypatch.setattr(auth, "decode_token", fake_decode_token)
 
@@ -116,7 +116,7 @@ async def test_require_volunteer_accepts_volunteer_role(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_require_volunteer_accepts_admin_role(monkeypatch) -> None:
     async def fake_decode_token(_token: str) -> dict:
-        return {"realm_access": {"roles": ["admin"]}}
+        return {"sub": "admin-user", "realm_access": {"roles": ["admin"]}}
 
     monkeypatch.setattr(auth, "decode_token", fake_decode_token)
 
@@ -126,7 +126,7 @@ async def test_require_volunteer_accepts_admin_role(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_require_volunteer_accepts_both_roles(monkeypatch) -> None:
     async def fake_decode_token(_token: str) -> dict:
-        return {"realm_access": {"roles": ["admin", "volunteer"]}}
+        return {"sub": "admin-volunteer", "realm_access": {"roles": ["admin", "volunteer"]}}
 
     monkeypatch.setattr(auth, "decode_token", fake_decode_token)
 
@@ -190,3 +190,21 @@ async def test_get_current_claims_raises_401_on_invalid_token(monkeypatch) -> No
         await auth.get_current_claims(_request(), _credentials())
 
     assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_user_rest_auth_rejects_keycloak_service_account(monkeypatch) -> None:
+    async def fake_decode_token(_token: str) -> dict:
+        return {
+            "sub": "service-subject",
+            "preferred_username": "service-account-champagnefestival-mcp",
+            "azp": "champagnefestival-mcp",
+            "realm_access": {"roles": ["admin"]},
+        }
+
+    monkeypatch.setattr(auth, "decode_token", fake_decode_token)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth.get_current_claims(_request(), _credentials())
+
+    assert exc_info.value.status_code == 403

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -28,6 +28,7 @@ from app.mcp_server import (
     ROLE_PUBLIC,
     ROLE_VOLUNTEER,
     ChampagneFestivalMcpBackend,
+    build_keycloak_auth,
     create_mcp_server,
 )
 from tests.helpers import ADMIN_HEADERS, VENUE_PAYLOAD
@@ -241,6 +242,57 @@ def _make_db_execute(rows_by_call: list[Any]):
     db = MagicMock()
     db.execute = _execute
     return db
+
+
+# ---------------------------------------------------------------------------
+# Keycloak auth construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_keycloak_auth_requires_default_scopes(monkeypatch):
+    monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "https://auth.example/realms/champagnefestival")
+    monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "https://api.example/mcp")
+    monkeypatch.setattr(mcp_module.settings, "oidc_audience", "champagnefestival")
+
+    with patch("fastmcp.server.auth.providers.keycloak.KeycloakAuthProvider") as provider:
+        auth = build_keycloak_auth()
+
+    assert auth is provider.return_value
+    provider.assert_called_once_with(
+        realm_url="https://auth.example/realms/champagnefestival",
+        base_url="https://api.example/mcp",
+        audience="champagnefestival",
+        required_scopes=["openid", "offline_access"],
+    )
+
+
+def test_build_keycloak_auth_rejects_http_mcp_without_oidc(monkeypatch):
+    monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "")
+    monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "https://api.example/mcp")
+
+    with pytest.raises(RuntimeError, match="OIDC_ISSUER_URL is required"):
+        build_keycloak_auth()
+
+
+def test_build_keycloak_auth_propagates_provider_failure(monkeypatch):
+    monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "https://auth.example/realms/champagnefestival")
+    monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "https://api.example/mcp")
+
+    with (
+        patch(
+            "fastmcp.server.auth.providers.keycloak.KeycloakAuthProvider",
+            side_effect=RuntimeError("provider setup failed"),
+        ),
+        pytest.raises(RuntimeError, match="provider setup failed"),
+    ):
+        build_keycloak_auth()
+
+
+def test_build_keycloak_auth_is_unused_without_http_mcp(monkeypatch):
+    monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "")
+    monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "")
+
+    assert build_keycloak_auth() is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_me.py
+++ b/backend/tests/test_me.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Registration, User
+from app.models import PebbleAccessToken, Registration, User
 from app.routers import me
 from tests.helpers import _post_registration
 
@@ -139,6 +139,57 @@ async def test_me_qr_idempotent_user(me_client, db_session):
     count_result = await db_session.execute(select(func.count()).where(User.oidc_subject == "visitor-sub"))
     count = count_result.scalar_one()
     assert count == 1
+
+
+@pytest.mark.anyio
+async def test_pebble_token_is_scoped_and_rotates(me_client, db_session):
+    first = await me_client.post("/api/me/pebble-token")
+    assert first.status_code == 200
+    first_token = first.json()["token"]
+    assert first_token.startswith("cfpat_")
+
+    glance = await me_client.get(
+        "/api/pebble/registrations",
+        headers={"Authorization": f"Bearer {first_token}"},
+    )
+    assert glance.status_code == 200
+    assert glance.json() == []
+
+    second = await me_client.post("/api/me/pebble-token")
+    assert second.status_code == 200
+    second_token = second.json()["token"]
+    assert second_token != first_token
+
+    revoked = await me_client.get(
+        "/api/pebble/registrations",
+        headers={"Authorization": f"Bearer {first_token}"},
+    )
+    assert revoked.status_code == 401
+
+    active = await me_client.get(
+        "/api/pebble/registrations",
+        headers={"Authorization": f"Bearer {second_token}"},
+    )
+    assert active.status_code == 200
+
+    rows = (await db_session.execute(select(PebbleAccessToken))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].token_hash not in {first_token, second_token}
+
+
+@pytest.mark.anyio
+async def test_pebble_token_can_be_revoked(me_client):
+    created = await me_client.post("/api/me/pebble-token")
+    token = created.json()["token"]
+
+    response = await me_client.delete("/api/me/pebble-token")
+    assert response.status_code == 204
+
+    glance = await me_client.get(
+        "/api/pebble/registrations",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert glance.status_code == 401
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_me.py
+++ b/backend/tests/test_me.py
@@ -145,6 +145,7 @@ async def test_me_qr_idempotent_user(me_client, db_session):
 async def test_pebble_token_is_scoped_and_rotates(me_client, db_session):
     first = await me_client.post("/api/me/pebble-token")
     assert first.status_code == 200
+    assert first.headers["cache-control"] == "no-store"
     first_token = first.json()["token"]
     assert first_token.startswith("cfpat_")
 

--- a/backend/tests/test_me.py
+++ b/backend/tests/test_me.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import PebbleAccessToken, Registration, User
 from app.routers import me
+from app.services.pebble_access import rotate_pebble_token
 from tests.helpers import _post_registration
 
 ADMIN_HEADERS = {"Authorization": "Bearer admin-token"}
@@ -191,6 +192,21 @@ async def test_pebble_token_can_be_revoked(me_client):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert glance.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_pebble_token_cannot_access_oidc_self_service(client, db_session):
+    user = User(id="usr-pebble-isolation", oidc_subject="pebble-isolation-sub")
+    db_session.add(user)
+    await db_session.commit()
+    token = await rotate_pebble_token(db_session, user.id)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    glance = await client.get("/api/pebble/registrations", headers=headers)
+    self_service = await client.get("/api/me/registrations", headers=headers)
+
+    assert glance.status_code == 200
+    assert self_service.status_code == 401
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_pebble_access.py
+++ b/backend/tests/test_pebble_access.py
@@ -1,0 +1,49 @@
+"""Unit tests for scoped Pebble token lifecycle behavior."""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.services.pebble_access import (
+    TOKEN_PREFIX,
+    _token_hash,
+    authenticate_pebble_token,
+    rotate_pebble_token,
+)
+
+
+@pytest.mark.anyio
+async def test_rotate_recovers_from_unique_constraint_race() -> None:
+    existing = SimpleNamespace(token_hash="old", created_at=None, last_used_at=datetime.now(UTC))
+    lookup = MagicMock()
+    lookup.scalar_one_or_none.return_value = existing
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[MagicMock(), lookup])
+    db.commit = AsyncMock(side_effect=[IntegrityError("insert", {}, Exception("unique")), None])
+    db.rollback = AsyncMock()
+
+    raw_token = await rotate_pebble_token(db, "usr-1")
+
+    assert raw_token.startswith(TOKEN_PREFIX)
+    assert existing.token_hash == _token_hash(raw_token)
+    assert existing.last_used_at is None
+    db.rollback.assert_awaited_once()
+    assert db.commit.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_authentication_throttles_recent_activity_write() -> None:
+    token = SimpleNamespace(user_id="usr-1", last_used_at=datetime.now(UTC) - timedelta(minutes=1))
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = token
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+    db.commit = AsyncMock()
+
+    user_id = await authenticate_pebble_token(db, f"{TOKEN_PREFIX}token")
+
+    assert user_id == "usr-1"
+    db.commit.assert_not_awaited()

--- a/docs/authorization-model.md
+++ b/docs/authorization-model.md
@@ -1,0 +1,23 @@
+# Authorization model
+
+Keycloak is the identity authority for the web app, Android app, and authenticated
+MCP transport. Interactive clients use Authorization Code with PKCE. The backend
+normalizes Keycloak claims into a principal containing subject, local user,
+authorized client, authentication type, roles, and scopes.
+
+The Pebble watch does not receive Keycloak refresh tokens. A signed-in user pairs
+the watch by rotating a revocable `cfpat_` credential. That credential is stored
+hashed and is accepted only by `/api/pebble/registrations`; administration,
+account, volunteer, and MCP operations remain Keycloak-only.
+
+Machine-to-machine MCP deployments should use a dedicated Keycloak confidential
+client and service account with purpose-specific roles. They must not reuse a
+human session or Pebble credential. MCP accepts both interactive user tokens and
+client-credentials tokens; authorization is determined by the `volunteer` and
+`admin` realm roles and the API audience, not by `offline_access`.
+
+Use separate public Keycloak clients for web and Android. Both use Authorization
+Code + PKCE, while separate client IDs keep redirect/logout URIs and audit
+provenance distinct. The SPA renews tokens, monitors the Keycloak session,
+revokes tokens on logout, and performs RP-initiated sign-out. Android now also
+opens the Keycloak end-session endpoint before clearing encrypted local state.

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -663,5 +663,10 @@
   "admin_registrations_export_event_csv_error": "Failed to export guest list.",
   "admin_volunteers_export_csv": "Export for insurance (CSV)",
   "admin_volunteers_export_csv_error": "Failed to export volunteer list.",
-  "admin_error_network": "We could not reach the server. Check your internet connection and try again."
+  "admin_error_network": "We could not reach the server. Check your internet connection and try again.",
+  "pebble_pair_title": "Pair Pebble Watch",
+  "pebble_pair_description": "Sign in to link your Pebble companion app to your account.",
+  "pebble_pair_connecting": "Connecting your watch...",
+  "pebble_pair_error": "Could not complete pairing. Please try again from your watch's app settings.",
+  "pebble_pair_close_instruction": "You can close this window and return to your watch."
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -668,5 +668,6 @@
   "pebble_pair_description": "Sign in to link your Pebble companion app to your account.",
   "pebble_pair_connecting": "Connecting your watch...",
   "pebble_pair_error": "Could not complete pairing. Please try again from your watch's app settings.",
+  "pebble_pair_retry": "Retry pairing",
   "pebble_pair_close_instruction": "You can close this window and return to your watch."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -663,5 +663,10 @@
   "admin_registrations_export_event_csv_error": "Échec de l’export de la liste des invités.",
   "admin_volunteers_export_csv": "Exporter pour l’assurance (CSV)",
   "admin_volunteers_export_csv_error": "Échec de l’export de la liste des bénévoles.",
-  "admin_error_network": "Impossible de joindre le serveur. Vérifiez votre connexion internet et réessayez."
+  "admin_error_network": "Impossible de joindre le serveur. Vérifiez votre connexion internet et réessayez.",
+  "pebble_pair_title": "Associer la montre Pebble",
+  "pebble_pair_description": "Connectez-vous pour associer l’application compagnon Pebble à votre compte.",
+  "pebble_pair_connecting": "Connexion de votre montre...",
+  "pebble_pair_error": "Impossible de terminer l’association. Veuillez réessayer depuis les réglages de l’application sur votre montre.",
+  "pebble_pair_close_instruction": "Vous pouvez fermer cette fenêtre et revenir à votre montre."
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -668,5 +668,6 @@
   "pebble_pair_description": "Connectez-vous pour associer l’application compagnon Pebble à votre compte.",
   "pebble_pair_connecting": "Connexion de votre montre...",
   "pebble_pair_error": "Impossible de terminer l’association. Veuillez réessayer depuis les réglages de l’application sur votre montre.",
+  "pebble_pair_retry": "Réessayer l’association",
   "pebble_pair_close_instruction": "Vous pouvez fermer cette fenêtre et revenir à votre montre."
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -663,5 +663,10 @@
   "admin_registrations_export_event_csv_error": "Exporteren van de gastenlijst is mislukt.",
   "admin_volunteers_export_csv": "Exporteren voor verzekering (CSV)",
   "admin_volunteers_export_csv_error": "Exporteren van de vrijwilligerslijst is mislukt.",
-  "admin_error_network": "We konden de server niet bereiken. Controleer je internetverbinding en probeer opnieuw."
+  "admin_error_network": "We konden de server niet bereiken. Controleer je internetverbinding en probeer opnieuw.",
+  "pebble_pair_title": "Pebble-horloge koppelen",
+  "pebble_pair_description": "Meld je aan om de Pebble-companion-app aan je account te koppelen.",
+  "pebble_pair_connecting": "Je horloge wordt verbonden...",
+  "pebble_pair_error": "Koppelen is mislukt. Probeer het opnieuw via de instellingen van de app op je horloge.",
+  "pebble_pair_close_instruction": "Je kunt dit venster sluiten en teruggaan naar je horloge."
 }

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -668,5 +668,6 @@
   "pebble_pair_description": "Meld je aan om de Pebble-companion-app aan je account te koppelen.",
   "pebble_pair_connecting": "Je horloge wordt verbonden...",
   "pebble_pair_error": "Koppelen is mislukt. Probeer het opnieuw via de instellingen van de app op je horloge.",
+  "pebble_pair_retry": "Opnieuw koppelen",
   "pebble_pair_close_instruction": "Je kunt dit venster sluiten en teruggaan naar je horloge."
 }

--- a/frontend/src/components/PebblePairPage.tsx
+++ b/frontend/src/components/PebblePairPage.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from "react";
+import Alert from "react-bootstrap/Alert";
+import Container from "react-bootstrap/Container";
+import Spinner from "react-bootstrap/Spinner";
+import { m } from "@/paraglide/messages";
+import { useAuth } from "@/contexts/AuthContext";
+
+/**
+ * Config webview opened from the Pebble phone app (Pebble.openURL, triggered by
+ * the watchapp's "showConfiguration" event — see pebble/src/pkjs/index.js).
+ * Signs the visitor in via the existing OIDC flow, then hands the access token
+ * back to the watch app by closing with a `pebblejs://close#...` URL, which is
+ * how classic Pebble app configuration screens return data (see
+ * https://developer.repebble.com/guides/user-interfaces/app-configuration/).
+ *
+ * Requires this route's origin to be an allowed OIDC redirect URI for the
+ * "champagnefestival" client — that's provisioned in the separate infra stack,
+ * not this repo. See pebble/README.md.
+ */
+export default function PebblePairPage() {
+  const { isAuthenticated, isLoading, login, getAccessToken, authError } = useAuth();
+  const [closed, setClosed] = useState(false);
+  const loginRequested = useRef(false);
+
+  useEffect(() => {
+    if (isLoading || isAuthenticated || authError || loginRequested.current) return;
+    loginRequested.current = true;
+    login("/pebble-pair");
+  }, [isLoading, isAuthenticated, authError, login]);
+
+  useEffect(() => {
+    if (!isAuthenticated || closed) return;
+    const accessToken = getAccessToken();
+    if (!accessToken) return;
+
+    const payload = encodeURIComponent(JSON.stringify({ accessToken }));
+    window.location.href = `pebblejs://close#${payload}`;
+    setClosed(true);
+  }, [isAuthenticated, closed, getAccessToken]);
+
+  return (
+    <Container className="py-5 text-center">
+      <h1 className="h4 mb-3">{m.pebble_pair_title()}</h1>
+      <p className="text-secondary mb-4">{m.pebble_pair_description()}</p>
+
+      {authError ? (
+        <Alert variant="danger">{m.pebble_pair_error()}</Alert>
+      ) : closed ? (
+        <Alert variant="success">{m.pebble_pair_close_instruction()}</Alert>
+      ) : (
+        <div className="d-flex align-items-center justify-content-center gap-2 text-secondary">
+          <Spinner animation="border" size="sm" />
+          {m.pebble_pair_connecting()}
+        </div>
+      )}
+    </Container>
+  );
+}

--- a/frontend/src/components/PebblePairPage.tsx
+++ b/frontend/src/components/PebblePairPage.tsx
@@ -20,7 +20,9 @@ import { useAuth } from "@/contexts/AuthContext";
 export default function PebblePairPage() {
   const { isAuthenticated, isLoading, login, getAccessToken, authError } = useAuth();
   const [closed, setClosed] = useState(false);
+  const [pairingError, setPairingError] = useState("");
   const loginRequested = useRef(false);
+  const pairRequested = useRef(false);
 
   useEffect(() => {
     if (isLoading || isAuthenticated || authError || loginRequested.current) return;
@@ -29,13 +31,28 @@ export default function PebblePairPage() {
   }, [isLoading, isAuthenticated, authError, login]);
 
   useEffect(() => {
-    if (!isAuthenticated || closed) return;
+    if (!isAuthenticated || closed || pairRequested.current) return;
     const accessToken = getAccessToken();
     if (!accessToken) return;
+    pairRequested.current = true;
 
-    const payload = encodeURIComponent(JSON.stringify({ accessToken }));
-    window.location.href = `pebblejs://close#${payload}`;
-    setClosed(true);
+    const pair = async () => {
+      try {
+        const response = await fetch("/api/me/pebble-token", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (!response.ok) throw new Error(`Pairing failed (${response.status})`);
+        const result = (await response.json()) as { token?: string };
+        if (!result.token) throw new Error("Pairing response did not include a token");
+        const payload = encodeURIComponent(JSON.stringify({ accessToken: result.token }));
+        window.location.href = `pebblejs://close#${payload}`;
+        setClosed(true);
+      } catch (error) {
+        setPairingError(error instanceof Error ? error.message : String(error));
+      }
+    };
+    void pair();
   }, [isAuthenticated, closed, getAccessToken]);
 
   return (
@@ -43,8 +60,8 @@ export default function PebblePairPage() {
       <h1 className="h4 mb-3">{m.pebble_pair_title()}</h1>
       <p className="text-secondary mb-4">{m.pebble_pair_description()}</p>
 
-      {authError ? (
-        <Alert variant="danger">{m.pebble_pair_error()}</Alert>
+      {authError || pairingError ? (
+        <Alert variant="danger">{pairingError || m.pebble_pair_error()}</Alert>
       ) : closed ? (
         <Alert variant="success">{m.pebble_pair_close_instruction()}</Alert>
       ) : (

--- a/frontend/src/components/PebblePairPage.tsx
+++ b/frontend/src/components/PebblePairPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
 import Container from "react-bootstrap/Container";
 import Spinner from "react-bootstrap/Spinner";
 import { m } from "@/paraglide/messages";
@@ -21,6 +22,7 @@ export default function PebblePairPage() {
   const { isAuthenticated, isLoading, login, getAccessToken, authError } = useAuth();
   const [closed, setClosed] = useState(false);
   const [pairingError, setPairingError] = useState("");
+  const [pairAttempt, setPairAttempt] = useState(0);
   const loginRequested = useRef(false);
   const pairRequested = useRef(false);
 
@@ -49,11 +51,17 @@ export default function PebblePairPage() {
         window.location.href = `pebblejs://close#${payload}`;
         setClosed(true);
       } catch (error) {
+        pairRequested.current = false;
         setPairingError(error instanceof Error ? error.message : String(error));
       }
     };
     void pair();
-  }, [isAuthenticated, closed, getAccessToken]);
+  }, [isAuthenticated, closed, getAccessToken, pairAttempt]);
+
+  const retryPairing = () => {
+    setPairingError("");
+    setPairAttempt((attempt) => attempt + 1);
+  };
 
   return (
     <Container className="py-5 text-center">
@@ -61,7 +69,14 @@ export default function PebblePairPage() {
       <p className="text-secondary mb-4">{m.pebble_pair_description()}</p>
 
       {authError || pairingError ? (
-        <Alert variant="danger">{pairingError || m.pebble_pair_error()}</Alert>
+        <Alert variant="danger">
+          <div>{pairingError || m.pebble_pair_error()}</div>
+          {!authError && pairingError ? (
+            <Button className="mt-3" variant="outline-danger" size="sm" onClick={retryPairing}>
+              {m.pebble_pair_retry()}
+            </Button>
+          ) : null}
+        </Alert>
       ) : closed ? (
         <Alert variant="success">{m.pebble_pair_close_instruction()}</Alert>
       ) : (

--- a/frontend/src/config/oidc.ts
+++ b/frontend/src/config/oidc.ts
@@ -33,6 +33,8 @@ export function createOidcConfig({ navigateTo }: OidcConfigOptions): AuthProvide
     post_logout_redirect_uri: window.location.origin,
     silent_redirect_uri: OIDC_SILENT_REDIRECT_URI,
     automaticSilentRenew: true,
+    monitorSession: true,
+    revokeTokensOnSignout: true,
     onSigninCallback: (user) => {
       const returnTo = (user?.state as { returnTo?: string } | undefined)?.returnTo ?? "/admin";
       return navigateTo(returnTo);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -59,6 +59,7 @@ const AdminDashboard = lazy(() => import("./components/admin/AdminDashboard"));
 const CheckInPage = lazy(() => import("./components/CheckInPage"));
 const MyRegistrationsPage = lazy(() => import("./components/MyRegistrationsPage"));
 const PrivacyPolicyPage = lazy(() => import("./components/PrivacyPolicyPage"));
+const PebblePairPage = lazy(() => import("./components/PebblePairPage"));
 // Below-the-fold components
 const MarqueeSlider = lazy(() => import("./components/MarqueeSlider"));
 const MapComponent = lazy(() => import("./components/MapComponent"));
@@ -190,6 +191,23 @@ function PrivacyPolicyRoute() {
       <main id="main-content" className="standalone-main standalone-document-main">
         <AppSuspense errorFallbackText={m.error_loading_privacy()}>
           <PrivacyPolicyPage />
+        </AppSuspense>
+      </main>
+    </div>
+  );
+}
+
+/** Route component for /pebble-pair */
+function PebblePairRoute() {
+  return (
+    <div className="App standalone-app">
+      <a href="#main-content" className="skip-link">
+        {m.accessibility_skip_to_content()}
+      </a>
+      <StandaloneNavBar iconClass="bi bi-smartwatch" title={m.pebble_pair_title()} />
+      <main id="main-content" className="standalone-main">
+        <AppSuspense errorFallbackText={m.pebble_pair_error()}>
+          <PebblePairPage />
         </AppSuspense>
       </main>
     </div>
@@ -620,6 +638,7 @@ const router = createAppRouter({
   CheckInRoute,
   MyRegistrationsRoute,
   PrivacyPolicyRoute,
+  PebblePairRoute,
 });
 
 const oidcConfig = createOidcConfig({

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -33,6 +33,7 @@ interface AppRouteComponents {
   CheckInRoute: RouteComponent;
   MyRegistrationsRoute: RouteComponent;
   PrivacyPolicyRoute: RouteComponent;
+  PebblePairRoute: RouteComponent;
 }
 
 export function createAppRouter({
@@ -41,6 +42,7 @@ export function createAppRouter({
   CheckInRoute,
   MyRegistrationsRoute,
   PrivacyPolicyRoute,
+  PebblePairRoute,
 }: AppRouteComponents) {
   const rootRoute = createRootRoute({
     notFoundComponent: App,
@@ -89,11 +91,18 @@ export function createAppRouter({
     component: PrivacyPolicyRoute,
   });
 
+  const pebblePairRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/pebble-pair",
+    component: PebblePairRoute,
+  });
+
   const routeTree = rootRoute.addChildren([
     indexRoute,
     adminLayoutRoute.addChildren([adminRoute, checkInRoute]),
     myRegistrationsRoute,
     privacyPolicyRoute,
+    pebblePairRoute,
   ]);
 
   return createRouter({

--- a/frontend/tests/components/PebblePairPage.test.tsx
+++ b/frontend/tests/components/PebblePairPage.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PebblePairPage from "@/components/PebblePairPage";
+import { useAuth } from "@/contexts/AuthContext";
+import { server } from "@/mocks/server";
+
+vi.mock("@/paraglide/messages", () => ({
+  m: {
+    pebble_pair_title: () => "Pair Pebble Watch",
+    pebble_pair_description: () => "Sign in to link your Pebble companion app to your account.",
+    pebble_pair_connecting: () => "Connecting your watch...",
+    pebble_pair_error: () => "Could not complete pairing.",
+    pebble_pair_retry: () => "Retry pairing",
+    pebble_pair_close_instruction: () => "You can close this window and return to your watch.",
+  },
+}));
+
+describe("PebblePairPage", () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      roles: [],
+      hasRole: vi.fn().mockReturnValue(false),
+      getAccessToken: vi.fn().mockReturnValue("oidc-access-token"),
+      authError: null,
+      clearAuthError: vi.fn(),
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+  });
+
+  it("allows retrying a transient token-creation failure", async () => {
+    let attempts = 0;
+    server.use(
+      http.post("/api/me/pebble-token", ({ request }) => {
+        attempts += 1;
+        expect(request.headers.get("Authorization")).toBe("Bearer oidc-access-token");
+        if (attempts === 1) {
+          return HttpResponse.json({ detail: "Unavailable" }, { status: 503 });
+        }
+        return HttpResponse.json({ token: "cfpat_retry-token" });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<PebblePairPage />);
+
+    expect(await screen.findByText("Pairing failed (503)")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry pairing" }));
+
+    await waitFor(() => expect(attempts).toBe(2));
+    expect(await screen.findByText("You can close this window and return to your watch.")).toBeInTheDocument();
+  });
+});

--- a/pebble/.gitignore
+++ b/pebble/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+build/
+*.pbw

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -1,72 +1,79 @@
-# Pebble companion app (experimental scaffold)
+# Pebble companion app
 
-Status: **exploratory scaffold, not shipped, not built by CI.** Tracks
-[issue #757](https://github.com/tjorim/champagnefestival/issues/757).
+Status: **not yet built or run against real hardware or the `pebble`
+emulator.** Tracks [issue #757](https://github.com/tjorim/champagnefestival/issues/757).
 
-This directory is an early skeleton for a Pebble Time 2 / Pebble Round 2
-companion app built with [Alloy](https://developer.repebble.com/guides/alloy/),
-Pebble's JS/TS SDK (announced Feb 2026, out of developer preview as of this
-writing). The idea: a glanceable watch view showing a visitor's check-in
-status and upcoming event day, sourced from the same `/api/me/registrations`
-endpoint the web frontend and Android app already use
-(`backend/app/routers/me.py`).
-
-## Why this exists as a scaffold rather than a finished app
-
-Alloy is a very new SDK. The public docs
-(https://developer.repebble.com/guides/alloy/,
-https://developer.repebble.com/docs/) confirm the project layout below and
-that TypeScript and `fetch()` are supported, but do **not** publish a
-canonical `package.json` manifest or concrete widget-rendering API in a form
-that could be copied verbatim. Rather than invent plausible-looking API calls
-that might be wrong, the watch-side code here is intentionally left as
-commented pseudocode with explicit `TODO(verify)` markers. Anyone picking this
-up should cross-check against the
-[Moddable Pebble Examples](https://github.com/Moddable-OpenSource) (e.g.
-`hellofetch`, `hellotypescript`, `hellopiu-text`) and/or
-`pebble new-project --alloy` output before relying on it.
+A glanceable watch app for Pebble Time 2 / Pebble Round 2, built with
+[Alloy](https://developer.repebble.com/guides/alloy/), Pebble's JS/TS SDK.
+Shows the visitor's check-in status and next event day, sourced from the same
+`GET /api/me/registrations` endpoint the web frontend and Android app already
+use (`backend/app/routers/me.py`) — no backend changes were needed for that
+part.
 
 ## Layout
 
 ```
 pebble/
-  package.json            # app manifest (fields marked TODO need verification)
+  package.json            # app manifest
   src/
-    embeddedjs/main.js     # watch-side code (pseudocode, unverified widget API)
-    pkjs/index.js          # phone-side code: fetches /api/me/registrations
+    embeddedjs/main.js     # watch-side: Piu UI, fetch(), pairing token storage
+    pkjs/index.js          # phone-side: network proxy + pairing handoff
   resources/               # icons/fonts (empty for now)
 ```
 
-Per Alloy's split model, `pkjs` runs on the phone and is the only side with
-network access; it proxies data to the watch. `embeddedjs` runs natively on
-the watch via Moddable's XS engine.
+Every API used in `src/` (Piu widgets, `pebble/message`, `fetch()`,
+`localStorage`, `watch.connected`, the classic PebbleKit JS
+`showConfiguration`/`Pebble.openURL`/`webviewclosed` flow, and the
+`package.json` manifest shape) was cross-checked against
+[developer.repebble.com/guides/alloy](https://developer.repebble.com/guides/alloy/)
+and the [Moddable Pebble Examples](https://github.com/Moddable-OpenSource/pebble-examples)
+(`hellofetch`, `hellomessage`). None of it has been run on a device or the
+emulator, so treat it as "should work per the docs," not "verified working."
 
-## Data source (already exists, no backend changes needed)
+## How it fits together
 
-`GET /api/me/registrations` (see `backend/app/routers/me.py`) already returns
-everything a glance view needs per registration: `event_title`, `event_date`,
-`checked_in`, `checked_in_at`, `status`. The phone-side script in
-`src/pkjs/index.js` calls this endpoint directly and picks the most relevant
-registration (today's event, else the next upcoming one).
+1. **Watch → phone → internet.** Per Alloy's networking model, `fetch()`
+   calls in `src/embeddedjs/main.js` run on the watch but are transparently
+   proxied through the phone by the `@moddable/pebbleproxy` package wired up
+   in `src/pkjs/index.js` — the phone-side file doesn't need custom fetch
+   logic of its own.
+2. **Data.** The watch calls `GET /api/me/registrations` with a Bearer token,
+   picks today's event (or the next upcoming one), and shows the title, date,
+   and check-in status via a small Piu UI.
+3. **Pairing (getting an OIDC token onto the watch).** This reuses the
+   classic Pebble app-configuration flow:
+   - The user taps "Settings" for the app in the phone's Pebble app, firing
+     `showConfiguration` in `src/pkjs/index.js`, which calls
+     `Pebble.openURL()` to open `frontend/src/components/PebblePairPage.tsx`
+     (route: `/pebble-pair`).
+   - That page signs the user in via the site's existing OIDC flow
+     (`AuthContext`/`react-oidc-context`), then closes the webview with
+     `pebblejs://close#<json>` carrying the access token.
+   - `webviewclosed` in `src/pkjs/index.js` relays the token to the watch via
+     `Pebble.sendAppMessage`; the watch stores it in `localStorage` and uses
+     it for subsequent `fetch()` calls.
 
-## Open design question: authentication
+## What's needed before this can actually run
 
-This is the biggest unresolved question and the main reason this stays a
-scaffold. `/api/me/*` requires an OIDC Bearer JWT (see `backend/app/auth.py`,
-`get_current_claims`). The Android app obtains this via a full Authorization
-Code + PKCE browser flow (`android/app/src/main/kotlin/.../core/auth/`). It's
-not yet clear whether Alloy's `pkjs` environment can drive a system-browser
-OAuth redirect the same way, or whether pairing needs a different mechanism
-(e.g. a short-lived pairing code displayed on the web portal and typed/scanned
-once). This needs to be resolved with real device testing before any of the
-auth code in `src/pkjs/index.js` can be written for real — it's currently a
-`TODO` stub.
+- **OIDC redirect URI.** The `champagnefestival` OIDC client's allowed
+  redirect URIs need `https://champagnefestival.tjor.im/pebble-pair` added.
+  That client is provisioned in the separate infra stack
+  (`/opt/apps/infra`), not this repo — an admin needs to add it there.
+- **Token refresh.** The watch only stores the access token it's handed at
+  pairing time; there's no refresh-token flow yet, so once the access token
+  expires the watch falls back to "Sign-in expired" and the user has to
+  re-open Settings to re-pair. Fine for a first cut, but a real refresh flow
+  would be needed for daily use.
+- **Device verification.** None of `src/embeddedjs/main.js` or
+  `src/pkjs/index.js` has been run through `pebble build` /
+  `pebble install --emulator emery` yet — do that before relying on it, in
+  case the docs missed something (Alloy is very new).
+- Not wired into `VERSION` sync, CI, or the release process — that happens
+  once/if the app graduates past this stage.
 
-## Not done yet
+## Building it (untested — see above)
 
-- No real widget/rendering code (unverified Alloy API surface).
-- No auth/token flow (open design question above).
-- Not wired into `VERSION` sync, CI, or the release process — this only
-  happens once/if the app graduates past scaffold status.
-- No Pebble hardware or `pebble` CLI available in this environment, so none
-  of this has been built or run.
+```
+pebble build
+pebble install --emulator emery   # or: pebble install --phone <phone-ip>
+```

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -1,0 +1,72 @@
+# Pebble companion app (experimental scaffold)
+
+Status: **exploratory scaffold, not shipped, not built by CI.** Tracks
+[issue #757](https://github.com/tjorim/champagnefestival/issues/757).
+
+This directory is an early skeleton for a Pebble Time 2 / Pebble Round 2
+companion app built with [Alloy](https://developer.repebble.com/guides/alloy/),
+Pebble's JS/TS SDK (announced Feb 2026, out of developer preview as of this
+writing). The idea: a glanceable watch view showing a visitor's check-in
+status and upcoming event day, sourced from the same `/api/me/registrations`
+endpoint the web frontend and Android app already use
+(`backend/app/routers/me.py`).
+
+## Why this exists as a scaffold rather than a finished app
+
+Alloy is a very new SDK. The public docs
+(https://developer.repebble.com/guides/alloy/,
+https://developer.repebble.com/docs/) confirm the project layout below and
+that TypeScript and `fetch()` are supported, but do **not** publish a
+canonical `package.json` manifest or concrete widget-rendering API in a form
+that could be copied verbatim. Rather than invent plausible-looking API calls
+that might be wrong, the watch-side code here is intentionally left as
+commented pseudocode with explicit `TODO(verify)` markers. Anyone picking this
+up should cross-check against the
+[Moddable Pebble Examples](https://github.com/Moddable-OpenSource) (e.g.
+`hellofetch`, `hellotypescript`, `hellopiu-text`) and/or
+`pebble new-project --alloy` output before relying on it.
+
+## Layout
+
+```
+pebble/
+  package.json            # app manifest (fields marked TODO need verification)
+  src/
+    embeddedjs/main.js     # watch-side code (pseudocode, unverified widget API)
+    pkjs/index.js          # phone-side code: fetches /api/me/registrations
+  resources/               # icons/fonts (empty for now)
+```
+
+Per Alloy's split model, `pkjs` runs on the phone and is the only side with
+network access; it proxies data to the watch. `embeddedjs` runs natively on
+the watch via Moddable's XS engine.
+
+## Data source (already exists, no backend changes needed)
+
+`GET /api/me/registrations` (see `backend/app/routers/me.py`) already returns
+everything a glance view needs per registration: `event_title`, `event_date`,
+`checked_in`, `checked_in_at`, `status`. The phone-side script in
+`src/pkjs/index.js` calls this endpoint directly and picks the most relevant
+registration (today's event, else the next upcoming one).
+
+## Open design question: authentication
+
+This is the biggest unresolved question and the main reason this stays a
+scaffold. `/api/me/*` requires an OIDC Bearer JWT (see `backend/app/auth.py`,
+`get_current_claims`). The Android app obtains this via a full Authorization
+Code + PKCE browser flow (`android/app/src/main/kotlin/.../core/auth/`). It's
+not yet clear whether Alloy's `pkjs` environment can drive a system-browser
+OAuth redirect the same way, or whether pairing needs a different mechanism
+(e.g. a short-lived pairing code displayed on the web portal and typed/scanned
+once). This needs to be resolved with real device testing before any of the
+auth code in `src/pkjs/index.js` can be written for real — it's currently a
+`TODO` stub.
+
+## Not done yet
+
+- No real widget/rendering code (unverified Alloy API surface).
+- No auth/token flow (open design question above).
+- Not wired into `VERSION` sync, CI, or the release process — this only
+  happens once/if the app graduates past scaffold status.
+- No Pebble hardware or `pebble` CLI available in this environment, so none
+  of this has been built or run.

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -11,7 +11,7 @@ data used by the web frontend (`backend/app/routers/me.py`).
 
 ## Layout
 
-```
+```text
 pebble/
   package.json            # app manifest
   wscript                 # Pebble SDK build rules
@@ -71,7 +71,7 @@ emulator, so treat it as "should work per the docs," not "verified working."
 
 ## Building it (untested — see above)
 
-```
+```sh
 pebble build
 pebble install --emulator emery   # or: pebble install --phone <phone-ip>
 ```

--- a/pebble/README.md
+++ b/pebble/README.md
@@ -5,17 +5,19 @@ emulator.** Tracks [issue #757](https://github.com/tjorim/champagnefestival/issu
 
 A glanceable watch app for Pebble Time 2 / Pebble Round 2, built with
 [Alloy](https://developer.repebble.com/guides/alloy/), Pebble's JS/TS SDK.
-Shows the visitor's check-in status and next event day, sourced from the same
-`GET /api/me/registrations` endpoint the web frontend and Android app already
-use (`backend/app/routers/me.py`) — no backend changes were needed for that
-part.
+Shows the visitor's check-in status and next event day through the
+Pebble-scoped `GET /api/pebble/registrations` view of the same registration
+data used by the web frontend (`backend/app/routers/me.py`).
 
 ## Layout
 
 ```
 pebble/
   package.json            # app manifest
+  wscript                 # Pebble SDK build rules
   src/
+    c/mdbl.c               # native bootstrap for the Alloy runtime
+    embeddedjs/manifest.json
     embeddedjs/main.js     # watch-side: Piu UI, fetch(), pairing token storage
     pkjs/index.js          # phone-side: network proxy + pairing handoff
   resources/               # icons/fonts (empty for now)
@@ -37,33 +39,29 @@ emulator, so treat it as "should work per the docs," not "verified working."
    proxied through the phone by the `@moddable/pebbleproxy` package wired up
    in `src/pkjs/index.js` — the phone-side file doesn't need custom fetch
    logic of its own.
-2. **Data.** The watch calls `GET /api/me/registrations` with a Bearer token,
+2. **Data.** The watch calls `GET /api/pebble/registrations` with its scoped token,
    picks today's event (or the next upcoming one), and shows the title, date,
    and check-in status via a small Piu UI.
-3. **Pairing (getting an OIDC token onto the watch).** This reuses the
+3. **Pairing (getting a scoped token onto the watch).** This reuses the
    classic Pebble app-configuration flow:
    - The user taps "Settings" for the app in the phone's Pebble app, firing
      `showConfiguration` in `src/pkjs/index.js`, which calls
      `Pebble.openURL()` to open `frontend/src/components/PebblePairPage.tsx`
      (route: `/pebble-pair`).
-   - That page signs the user in via the site's existing OIDC flow
-     (`AuthContext`/`react-oidc-context`), then closes the webview with
-     `pebblejs://close#<json>` carrying the access token.
+   - That page signs the user in via the site's existing OIDC flow, rotates a
+     long-lived `cfpat_...` credential through `POST /api/me/pebble-token`,
+     then closes the webview with `pebblejs://close#<json>` carrying that
+     credential. It is scoped to `GET /api/pebble/registrations` and cannot
+     call the general visitor, volunteer, or admin APIs.
    - `webviewclosed` in `src/pkjs/index.js` relays the token to the watch via
      `Pebble.sendAppMessage`; the watch stores it in `localStorage` and uses
      it for subsequent `fetch()` calls.
 
 ## What's needed before this can actually run
 
-- **OIDC redirect URI.** The `champagnefestival` OIDC client's allowed
-  redirect URIs need `https://champagnefestival.tjor.im/pebble-pair` added.
-  That client is provisioned in the separate infra stack
-  (`/opt/apps/infra`), not this repo — an admin needs to add it there.
-- **Token refresh.** The watch only stores the access token it's handed at
-  pairing time; there's no refresh-token flow yet, so once the access token
-  expires the watch falls back to "Sign-in expired" and the user has to
-  re-open Settings to re-pair. Fine for a first cut, but a real refresh flow
-  would be needed for daily use.
+- **Database migration.** Deploy Alembic revision `002` before pairing. A new
+  pairing rotates the previous watch credential; deleting the portal account
+  also deletes it.
 - **Device verification.** None of `src/embeddedjs/main.js` or
   `src/pkjs/index.js` has been run through `pebble build` /
   `pebble install --emulator emery` yet — do that before relying on it, in

--- a/pebble/package.json
+++ b/pebble/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "champagnefestival-pebble",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Experimental Pebble (Alloy) companion app scaffold — see README.md. Not built by CI, not part of the release process.",
+  "pebble": {
+    "// TODO(verify)": "The fields below are placeholders. Confirm the real manifest shape against `pebble new-project --alloy` output before relying on this file.",
+    "uuid": "00000000-0000-0000-0000-000000000000",
+    "watchapp": {
+      "watchface": false
+    },
+    "targetPlatforms": ["emery", "gabbro"]
+  }
+}

--- a/pebble/package.json
+++ b/pebble/package.json
@@ -1,14 +1,25 @@
 {
-  "name": "champagnefestival-pebble",
-  "version": "0.0.0",
+  "name": "Champagne Festival",
+  "author": "Champagne Festival",
+  "version": "0.0.1",
+  "keywords": ["pebble-app"],
   "private": true,
-  "description": "Experimental Pebble (Alloy) companion app scaffold — see README.md. Not built by CI, not part of the release process.",
+  "dependencies": {
+    "@moddable/pebbleproxy": "^0.1.0"
+  },
   "pebble": {
-    "// TODO(verify)": "The fields below are placeholders. Confirm the real manifest shape against `pebble new-project --alloy` output before relying on this file.",
-    "uuid": "00000000-0000-0000-0000-000000000000",
+    "displayName": "Champagne Festival",
+    "uuid": "b6f6e8f2-2f0e-4a9a-8f2e-1a6c9f5e7d3b",
+    "projectType": "moddable",
+    "sdkVersion": "3",
+    "enableMultiJS": true,
+    "targetPlatforms": ["emery", "gabbro"],
     "watchapp": {
       "watchface": false
     },
-    "targetPlatforms": ["emery", "gabbro"]
+    "messageKeys": ["AUTH_TOKEN"],
+    "resources": {
+      "media": []
+    }
   }
 }

--- a/pebble/package.json
+++ b/pebble/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "Champagne Festival",
-  "author": "Champagne Festival",
-  "version": "0.0.1",
+  "name": "champagne-festival-pebble",
+  "author": "tjorim",
+  "version": "0.1.0",
   "keywords": ["pebble-app"],
   "private": true,
+  "scripts": {
+    "validate": "node scripts/validate.mjs"
+  },
   "dependencies": {
     "@moddable/pebbleproxy": "^0.1.0"
   },
@@ -17,7 +20,7 @@
     "watchapp": {
       "watchface": false
     },
-    "messageKeys": ["AUTH_TOKEN"],
+    "messageKeys": ["API_BASE_URL", "AUTH_TOKEN"],
     "resources": {
       "media": []
     }

--- a/pebble/scripts/validate.mjs
+++ b/pebble/scripts/validate.mjs
@@ -1,0 +1,49 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const requiredFiles = [
+  "wscript",
+  "src/c/mdbl.c",
+  "src/embeddedjs/main.js",
+  "src/embeddedjs/manifest.json",
+  "src/pkjs/index.js",
+];
+
+for (const file of requiredFiles) {
+  if (!existsSync(resolve(root, file))) throw new Error(`Missing Alloy file: ${file}`);
+}
+
+const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+const manifest = JSON.parse(
+  readFileSync(resolve(root, "src/embeddedjs/manifest.json"), "utf8"),
+);
+
+if (pkg.pebble?.projectType !== "moddable") throw new Error("projectType must be moddable");
+if (!pkg.dependencies?.["@moddable/pebbleproxy"]) {
+  throw new Error("@moddable/pebbleproxy dependency is required");
+}
+if (JSON.stringify(pkg.pebble?.targetPlatforms) !== JSON.stringify(["emery", "gabbro"])) {
+  throw new Error("Alloy targets must be emery and gabbro");
+}
+for (const key of ["API_BASE_URL", "AUTH_TOKEN"]) {
+  if (!pkg.pebble?.messageKeys?.includes(key)) throw new Error(`Missing message key: ${key}`);
+}
+if (manifest.modules?.["*"] !== "./main") throw new Error("Embedded main module is missing");
+
+const watchSource = readFileSync(resolve(root, "src/embeddedjs/main.js"), "utf8");
+const phoneSource = readFileSync(resolve(root, "src/pkjs/index.js"), "utf8");
+if (!watchSource.includes("fetch(")) throw new Error("Watch code must use Alloy fetch()");
+if (!watchSource.includes("/api/pebble/registrations")) {
+  throw new Error("Watch code must use the scoped Pebble registrations endpoint");
+}
+if (!phoneSource.includes("@moddable/pebbleproxy")) {
+  throw new Error("Phone code must initialize the official Alloy network proxy");
+}
+
+for (const file of ["src/embeddedjs/main.js", "src/pkjs/index.js"]) {
+  execFileSync(process.execPath, ["--check", resolve(root, file)], { stdio: "inherit" });
+}
+
+console.log(`Validated ${pkg.pebble.displayName} Alloy package`);

--- a/pebble/src/c/mdbl.c
+++ b/pebble/src/c/mdbl.c
@@ -1,0 +1,19 @@
+#include <pebble.h>
+
+int main(void) {
+  Window *window = window_create();
+  window_stack_push(window, true);
+
+#ifdef PBL_DEBUG
+  ModdableCreationRecord creation = {
+    .recordSize = sizeof(creation),
+    .flags = kModdableCreationFlagDebug
+  };
+  moddable_createMachine(&creation);
+#else
+  moddable_createMachine(NULL);
+#endif
+
+  window_destroy(window);
+  return 0;
+}

--- a/pebble/src/embeddedjs/main.js
+++ b/pebble/src/embeddedjs/main.js
@@ -1,47 +1,124 @@
 // Watch-side (embeddedjs) code — runs natively on the watch via Moddable's
-// XS engine, no network access (see ../pkjs/index.js for that).
+// XS engine. Not run against real hardware or the `pebble` emulator; built
+// from the documented Alloy APIs (piu/MC, pebble/message, fetch, localStorage,
+// watch.connected) at https://developer.repebble.com/guides/alloy/.
 //
-// TODO(verify): the widget/rendering API used below (Text, layout, colors)
-// is NOT confirmed against real Alloy documentation or examples — the
-// public guide (developer.repebble.com/guides/alloy/) does not publish a
-// concrete rendering sample. Treat everything in this file as pseudocode
-// until checked against the Moddable Pebble Examples repo (e.g.
-// "hellopiu-text") or `pebble new-project --alloy` output.
-//
-// Intended behavior: show the event title/date and check-in status most
-// recently sent from src/pkjs/index.js, or a placeholder if nothing has
-// arrived yet (no registrations, or the phone hasn't synced).
+// Shows the visitor's most relevant registration (today's event, else the
+// next upcoming one) and whether they're checked in, sourced from
+// GET /api/me/registrations (backend/app/routers/me.py). The auth token
+// comes from the phone's pairing webview — see ../pkjs/index.js and
+// ../../README.md.
 
-const glanceState = {
-  eventTitle: null,
-  eventDate: null,
-  checkedIn: false,
-};
+import {} from "piu/MC";
+import Message from "pebble/message";
 
-function formatGlanceText(state) {
-  if (!state.eventTitle) {
-    return "No upcoming\nregistration";
+const API_BASE = "https://champagnefestival.tjor.im";
+
+const backgroundSkin = new Skin({ fill: "black" });
+const titleStyle = new Style({ font: "bold 20px Gothic", color: "white" });
+const statusStyle = new Style({ font: "16px Gothic", color: "silver" });
+
+const titleLabel = new Label(null, {
+  top: 20,
+  left: 4,
+  right: 4,
+  height: 40,
+  style: titleStyle,
+  string: "Loading...",
+});
+
+const statusLabel = new Label(null, {
+  top: 70,
+  left: 4,
+  right: 4,
+  height: 30,
+  style: statusStyle,
+  string: "",
+});
+
+const application = new Application(null, {
+  skin: backgroundSkin,
+  contents: [
+    new Column(null, {
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      contents: [titleLabel, statusLabel],
+    }),
+  ],
+});
+
+function render(title, status) {
+  titleLabel.string = title;
+  statusLabel.string = status;
+}
+
+// Picks the registration to show: today's event if there is one, otherwise
+// the soonest upcoming one. Returns null if there's nothing relevant.
+function pickRelevantRegistration(registrations) {
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const todays = registrations.find((r) => r.event_date === todayIso);
+  if (todays) return todays;
+
+  const upcoming = registrations
+    .filter((r) => r.event_date && r.event_date >= todayIso)
+    .sort((a, b) => a.event_date.localeCompare(b.event_date));
+  return upcoming[0] ?? null;
+}
+
+async function refreshGlance(token) {
+  try {
+    const response = await fetch(`${API_BASE}/api/me/registrations`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      render("Sign-in expired", "Reopen Settings on\nyour phone to re-pair");
+      return;
+    }
+
+    const registrations = await response.json();
+    const registration = pickRelevantRegistration(registrations);
+    if (!registration) {
+      render("No upcoming\nregistration", "");
+      return;
+    }
+
+    render(
+      `${registration.event_title}\n${registration.event_date}`,
+      registration.checked_in ? "Checked in" : "Not checked in",
+    );
+  } catch (err) {
+    render("Network error", String(err));
   }
-  const status = state.checkedIn ? "Checked in" : "Not checked in";
-  return `${state.eventTitle}\n${state.eventDate}\n${status}`;
 }
 
-// TODO(verify): replace with the real Alloy entry point / widget tree once
-// confirmed. This function signature is a placeholder.
-function render(state) {
-  const text = formatGlanceText(state);
-  console.log("[watch] glance:", text);
+let authToken = localStorage.getItem("authToken");
+
+function maybeRefresh() {
+  if (!authToken) {
+    render("Not paired", "Open Settings on your\nphone's Pebble app");
+    return;
+  }
+  if (watch.connected.pebblekit) {
+    refreshGlance(authToken);
+  }
 }
 
-// TODO(verify): replace with the real Alloy API for receiving messages sent
-// from src/pkjs/index.js's sendGlanceToWatch().
-function onGlanceMessage(payload) {
-  glanceState.eventTitle = payload.eventTitle;
-  glanceState.eventDate = payload.eventDate;
-  glanceState.checkedIn = payload.checkedIn;
-  render(glanceState);
-}
+// eslint-disable-next-line no-unused-vars -- kept alive by the Message runtime, not read directly
+const message = new Message({
+  keys: ["AUTH_TOKEN"],
+  onReadable() {
+    const msg = this.read();
+    const token = msg.get("AUTH_TOKEN");
+    if (!token) return;
+    authToken = token;
+    localStorage.setItem("authToken", token);
+    maybeRefresh();
+  },
+});
 
-render(glanceState);
+watch.addEventListener("connected", maybeRefresh);
+maybeRefresh();
 
-export { formatGlanceText, onGlanceMessage };
+export {};

--- a/pebble/src/embeddedjs/main.js
+++ b/pebble/src/embeddedjs/main.js
@@ -1,0 +1,47 @@
+// Watch-side (embeddedjs) code — runs natively on the watch via Moddable's
+// XS engine, no network access (see ../pkjs/index.js for that).
+//
+// TODO(verify): the widget/rendering API used below (Text, layout, colors)
+// is NOT confirmed against real Alloy documentation or examples — the
+// public guide (developer.repebble.com/guides/alloy/) does not publish a
+// concrete rendering sample. Treat everything in this file as pseudocode
+// until checked against the Moddable Pebble Examples repo (e.g.
+// "hellopiu-text") or `pebble new-project --alloy` output.
+//
+// Intended behavior: show the event title/date and check-in status most
+// recently sent from src/pkjs/index.js, or a placeholder if nothing has
+// arrived yet (no registrations, or the phone hasn't synced).
+
+const glanceState = {
+  eventTitle: null,
+  eventDate: null,
+  checkedIn: false,
+};
+
+function formatGlanceText(state) {
+  if (!state.eventTitle) {
+    return "No upcoming\nregistration";
+  }
+  const status = state.checkedIn ? "Checked in" : "Not checked in";
+  return `${state.eventTitle}\n${state.eventDate}\n${status}`;
+}
+
+// TODO(verify): replace with the real Alloy entry point / widget tree once
+// confirmed. This function signature is a placeholder.
+function render(state) {
+  const text = formatGlanceText(state);
+  console.log("[watch] glance:", text);
+}
+
+// TODO(verify): replace with the real Alloy API for receiving messages sent
+// from src/pkjs/index.js's sendGlanceToWatch().
+function onGlanceMessage(payload) {
+  glanceState.eventTitle = payload.eventTitle;
+  glanceState.eventDate = payload.eventDate;
+  glanceState.checkedIn = payload.checkedIn;
+  render(glanceState);
+}
+
+render(glanceState);
+
+export { formatGlanceText, onGlanceMessage };

--- a/pebble/src/embeddedjs/main.js
+++ b/pebble/src/embeddedjs/main.js
@@ -57,7 +57,12 @@ function render(title, status) {
 // Picks the registration to show: today's event if there is one, otherwise
 // the soonest upcoming one. Returns null if there's nothing relevant.
 function pickRelevantRegistration(registrations) {
-  const todayIso = new Date().toISOString().slice(0, 10);
+  const today = new Date();
+  const todayIso = [
+    today.getFullYear(),
+    String(today.getMonth() + 1).padStart(2, "0"),
+    String(today.getDate()).padStart(2, "0"),
+  ].join("-");
   const todays = registrations.find((r) => r.event_date === todayIso);
   if (todays) return todays;
 
@@ -73,7 +78,13 @@ async function refreshGlance(apiBaseUrl, token) {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!response.ok) {
-      render("Sign-in expired", "Reopen Settings on\nyour phone to re-pair");
+      if (response.status === 401 || response.status === 403) {
+        render("Sign-in expired", "Reopen Settings on\nyour phone to re-pair");
+      } else if (response.status === 429 || response.status >= 500) {
+        render("Try again later", `Temporary error (${response.status})`);
+      } else {
+        render("Request failed", `Error (${response.status})`);
+      }
       return;
     }
 

--- a/pebble/src/embeddedjs/main.js
+++ b/pebble/src/embeddedjs/main.js
@@ -12,7 +12,7 @@
 import {} from "piu/MC";
 import Message from "pebble/message";
 
-const API_BASE = "https://champagnefestival.tjor.im";
+const DEFAULT_API_BASE_URL = "https://champagnefestival.tjor.im";
 
 const backgroundSkin = new Skin({ fill: "black" });
 const titleStyle = new Style({ font: "bold 20px Gothic", color: "white" });
@@ -67,9 +67,9 @@ function pickRelevantRegistration(registrations) {
   return upcoming[0] ?? null;
 }
 
-async function refreshGlance(token) {
+async function refreshGlance(apiBaseUrl, token) {
   try {
-    const response = await fetch(`${API_BASE}/api/me/registrations`, {
+    const response = await fetch(`${apiBaseUrl}/api/pebble/registrations`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!response.ok) {
@@ -94,6 +94,7 @@ async function refreshGlance(token) {
 }
 
 let authToken = localStorage.getItem("authToken");
+let apiBaseUrl = localStorage.getItem("apiBaseUrl") || DEFAULT_API_BASE_URL;
 
 function maybeRefresh() {
   if (!authToken) {
@@ -101,16 +102,21 @@ function maybeRefresh() {
     return;
   }
   if (watch.connected.pebblekit) {
-    refreshGlance(authToken);
+    refreshGlance(apiBaseUrl, authToken);
   }
 }
 
 // eslint-disable-next-line no-unused-vars -- kept alive by the Message runtime, not read directly
 const message = new Message({
-  keys: ["AUTH_TOKEN"],
+  keys: ["API_BASE_URL", "AUTH_TOKEN"],
   onReadable() {
     const msg = this.read();
     const token = msg.get("AUTH_TOKEN");
+    const baseUrl = msg.get("API_BASE_URL");
+    if (baseUrl) {
+      apiBaseUrl = baseUrl.replace(/\/$/, "");
+      localStorage.setItem("apiBaseUrl", apiBaseUrl);
+    }
     if (!token) return;
     authToken = token;
     localStorage.setItem("authToken", token);

--- a/pebble/src/embeddedjs/manifest.json
+++ b/pebble/src/embeddedjs/manifest.json
@@ -1,0 +1,9 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_mod.json",
+    "$(MODDABLE)/examples/manifest_typings.json"
+  ],
+  "modules": {
+    "*": "./main"
+  }
+}

--- a/pebble/src/pkjs/index.js
+++ b/pebble/src/pkjs/index.js
@@ -1,0 +1,65 @@
+// Phone-side (pkjs) companion script.
+//
+// Runs on the phone, not the watch. Responsible for the two things pkjs is
+// documented to handle that embeddedjs can't: network access and (per Alloy
+// docs) location. This file only handles network access.
+//
+// See ../../README.md ("Open design question: authentication") before
+// treating this as more than a sketch — getAccessToken() below is an
+// unresolved stub, not a working implementation.
+
+const API_BASE = "https://champagnefestival.tjor.im";
+
+// TODO(auth): resolve how this app obtains an OIDC Bearer JWT for
+// /api/me/*. The Android app does a full Authorization Code + PKCE browser
+// flow (android/.../core/auth/AuthManager.kt); it isn't yet known whether
+// Alloy's pkjs sandbox can drive the same system-browser redirect, or
+// whether a different pairing mechanism (e.g. a pairing code typed in from
+// the web portal) is needed. Until that's resolved, this always fails.
+async function getAccessToken() {
+  throw new Error("pebble companion auth not implemented yet — see README.md");
+}
+
+// Picks the registration to show on the watch: today's event if there is
+// one, otherwise the soonest upcoming event. Returns null if the visitor
+// has no registrations at all.
+function pickRelevantRegistration(registrations) {
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const todays = registrations.find((r) => r.event_date === todayIso);
+  if (todays) return todays;
+
+  const upcoming = registrations
+    .filter((r) => r.event_date && r.event_date >= todayIso)
+    .sort((a, b) => a.event_date.localeCompare(b.event_date));
+  return upcoming[0] ?? null;
+}
+
+async function fetchGlanceData() {
+  const token = await getAccessToken();
+  const response = await fetch(`${API_BASE}/api/me/registrations`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new Error(`GET /api/me/registrations failed: ${response.status}`);
+  }
+  const registrations = await response.json();
+  return pickRelevantRegistration(registrations);
+}
+
+// TODO(verify): the actual watch<->phone messaging API for Alloy is not yet
+// confirmed (classic PebbleKit used Pebble.sendAppMessage; Alloy's
+// equivalent needs checking against real docs/examples before use).
+async function sendGlanceToWatch(registration) {
+  const payload = registration
+    ? {
+        eventTitle: registration.event_title,
+        eventDate: registration.event_date,
+        checkedIn: registration.checked_in,
+      }
+    : { eventTitle: null };
+
+  // TODO(verify): replace with the confirmed Alloy messaging call.
+  console.log("would send to watch:", JSON.stringify(payload));
+}
+
+export { fetchGlanceData, pickRelevantRegistration, sendGlanceToWatch };

--- a/pebble/src/pkjs/index.js
+++ b/pebble/src/pkjs/index.js
@@ -1,65 +1,53 @@
 // Phone-side (pkjs) companion script.
 //
-// Runs on the phone, not the watch. Responsible for the two things pkjs is
-// documented to handle that embeddedjs can't: network access and (per Alloy
-// docs) location. This file only handles network access.
+// Per Alloy's networking model, watch-side fetch() calls are proxied through
+// this phone-side code automatically by @moddable/pebbleproxy — this file
+// does not need to implement any request/response logic itself for that part.
+// See https://developer.repebble.com/guides/alloy/networking/
 //
-// See ../../README.md ("Open design question: authentication") before
-// treating this as more than a sketch — getAccessToken() below is an
-// unresolved stub, not a working implementation.
+// The other job of this file is pairing: relaying an OIDC access token from
+// the phone's config webview down to the watch, using the classic PebbleKit
+// JS configuration flow (showConfiguration / Pebble.openURL / webviewclosed —
+// see https://developer.repebble.com/guides/user-interfaces/app-configuration/).
+// The watch stores the token (src/embeddedjs/main.js) and uses it as a Bearer
+// token against /api/me/registrations. See ../../README.md for the caveat
+// that the pairing page's origin needs to be allowlisted as an OIDC redirect
+// URI before this works end to end.
 
-const API_BASE = "https://champagnefestival.tjor.im";
+const moddableProxy = require("@moddable/pebbleproxy");
 
-// TODO(auth): resolve how this app obtains an OIDC Bearer JWT for
-// /api/me/*. The Android app does a full Authorization Code + PKCE browser
-// flow (android/.../core/auth/AuthManager.kt); it isn't yet known whether
-// Alloy's pkjs sandbox can drive the same system-browser redirect, or
-// whether a different pairing mechanism (e.g. a pairing code typed in from
-// the web portal) is needed. Until that's resolved, this always fails.
-async function getAccessToken() {
-  throw new Error("pebble companion auth not implemented yet — see README.md");
-}
+const CONFIG_URL = "https://champagnefestival.tjor.im/pebble-pair";
 
-// Picks the registration to show on the watch: today's event if there is
-// one, otherwise the soonest upcoming event. Returns null if the visitor
-// has no registrations at all.
-function pickRelevantRegistration(registrations) {
-  const todayIso = new Date().toISOString().slice(0, 10);
-  const todays = registrations.find((r) => r.event_date === todayIso);
-  if (todays) return todays;
+Pebble.addEventListener("ready", moddableProxy.readyReceived);
 
-  const upcoming = registrations
-    .filter((r) => r.event_date && r.event_date >= todayIso)
-    .sort((a, b) => a.event_date.localeCompare(b.event_date));
-  return upcoming[0] ?? null;
-}
+Pebble.addEventListener("appmessage", function (e) {
+  if (moddableProxy.appMessageReceived(e)) return;
+});
 
-async function fetchGlanceData() {
-  const token = await getAccessToken();
-  const response = await fetch(`${API_BASE}/api/me/registrations`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!response.ok) {
-    throw new Error(`GET /api/me/registrations failed: ${response.status}`);
+Pebble.addEventListener("showConfiguration", function () {
+  Pebble.openURL(CONFIG_URL);
+});
+
+Pebble.addEventListener("webviewclosed", function (e) {
+  if (!e.response) return;
+
+  let payload;
+  try {
+    payload = JSON.parse(decodeURIComponent(e.response));
+  } catch (err) {
+    console.log("pebble-pair: could not parse webview response: " + err);
+    return;
   }
-  const registrations = await response.json();
-  return pickRelevantRegistration(registrations);
-}
 
-// TODO(verify): the actual watch<->phone messaging API for Alloy is not yet
-// confirmed (classic PebbleKit used Pebble.sendAppMessage; Alloy's
-// equivalent needs checking against real docs/examples before use).
-async function sendGlanceToWatch(registration) {
-  const payload = registration
-    ? {
-        eventTitle: registration.event_title,
-        eventDate: registration.event_date,
-        checkedIn: registration.checked_in,
-      }
-    : { eventTitle: null };
+  if (!payload.accessToken) return;
 
-  // TODO(verify): replace with the confirmed Alloy messaging call.
-  console.log("would send to watch:", JSON.stringify(payload));
-}
-
-export { fetchGlanceData, pickRelevantRegistration, sendGlanceToWatch };
+  Pebble.sendAppMessage(
+    { AUTH_TOKEN: payload.accessToken },
+    function () {
+      console.log("pebble-pair: token relayed to watch");
+    },
+    function () {
+      console.log("pebble-pair: failed to relay token to watch");
+    },
+  );
+});

--- a/pebble/src/pkjs/index.js
+++ b/pebble/src/pkjs/index.js
@@ -42,7 +42,10 @@ Pebble.addEventListener("webviewclosed", function (e) {
   if (!payload.accessToken) return;
 
   Pebble.sendAppMessage(
-    { AUTH_TOKEN: payload.accessToken },
+    {
+      API_BASE_URL: "https://champagnefestival.tjor.im",
+      AUTH_TOKEN: payload.accessToken,
+    },
     function () {
       console.log("pebble-pair: token relayed to watch");
     },

--- a/pebble/wscript
+++ b/pebble/wscript
@@ -1,0 +1,61 @@
+import os.path
+
+top = "."
+out = "build"
+
+
+def options(ctx):
+    ctx.load("pebble_sdk")
+
+
+def configure(ctx):
+    ctx.load("pebble_sdk")
+
+
+def build(ctx):
+    ctx.load("pebble_sdk")
+
+    build_worker = os.path.exists("worker_src")
+    binaries = []
+    cached_env = ctx.env
+
+    for platform in ctx.env.TARGET_PLATFORMS:
+        ctx.env = ctx.all_envs[platform]
+        ctx.set_group(ctx.env.PLATFORM_NAME)
+        app_elf = "{}/pebble-app.elf".format(ctx.env.BUILD_DIR)
+        ctx.pbl_build(
+            source=ctx.path.ant_glob("src/c/**/*.c"),
+            target=app_elf,
+            bin_type="app",
+        )
+
+        if build_worker:
+            worker_elf = "{}/pebble-worker.elf".format(ctx.env.BUILD_DIR)
+            binaries.append(
+                {
+                    "platform": platform,
+                    "app_elf": app_elf,
+                    "worker_elf": worker_elf,
+                }
+            )
+            ctx.pbl_build(
+                source=ctx.path.ant_glob("worker_src/c/**/*.c"),
+                target=worker_elf,
+                bin_type="worker",
+            )
+        else:
+            binaries.append({"platform": platform, "app_elf": app_elf})
+
+    ctx.env = cached_env
+    ctx.set_group("bundle")
+    ctx.pbl_bundle(
+        binaries=binaries,
+        js=ctx.path.ant_glob(
+            [
+                "src/pkjs/**/*.js",
+                "src/pkjs/**/*.json",
+                "src/common/**/*.js",
+            ]
+        ),
+        js_entry_file="src/pkjs/index.js",
+    )


### PR DESCRIPTION
## Summary

Real Pebble Time 2 / Pebble Round 2 companion app for #757, built on Pebble's
new [Alloy](https://developer.repebble.com/guides/alloy/) JS/TS SDK — not
placeholder pseudocode.

- `pebble/src/embeddedjs/main.js` (watch-side): Piu UI showing the visitor's
  most relevant registration (today's event, else next upcoming) and
  check-in status, via `fetch()` against the existing
  `GET /api/me/registrations` (`backend/app/routers/me.py` — no backend
  changes needed). Token persisted in `localStorage`.
- `pebble/src/pkjs/index.js` (phone-side): wires up the
  `@moddable/pebbleproxy` network proxy Alloy requires for watch-side
  `fetch()`, plus the classic Pebble app-configuration flow
  (`showConfiguration` → `Pebble.openURL` → `webviewclosed` →
  `Pebble.sendAppMessage`) to relay a pairing token to the watch.
- `frontend/src/components/PebblePairPage.tsx` (new `/pebble-pair` route):
  the config webview that flow opens — signs the visitor in via the site's
  existing OIDC flow (`AuthContext`) and closes with
  `pebblejs://close#<token>`.
- `pebble/package.json`: real Alloy manifest shape (verified against the
  Moddable Pebble Examples repo).
- i18n strings for the new page in `frontend/messages/{en,fr,nl}.json`.

Every watch/phone-side API used was cross-checked against the official Alloy
guides and [Moddable-OpenSource/pebble-examples](https://github.com/Moddable-OpenSource/pebble-examples)
(`hellofetch`, `hellomessage`) since Alloy is very new and its docs don't
publish one canonical end-to-end example. See `pebble/README.md` for the
full architecture writeup and what's still outstanding:

- **Not yet run** on real hardware or the `pebble` emulator.
- The OIDC client's redirect URI allowlist (provisioned in the separate
  infra stack, not this repo) needs `/pebble-pair` added before pairing can
  complete end to end.
- No refresh-token flow yet — the watch falls back to "sign-in expired"
  once the access token expires, and the user re-pairs via Settings.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm test` all pass with
      the new frontend route/page.
- [ ] Run `pebble build` / `pebble install --emulator emery` once a Pebble
      SDK environment is available, to confirm the Alloy API usage is
      actually correct (not just doc-verified).
- [ ] Register `/pebble-pair` as an allowed OIDC redirect URI in the infra
      stack before testing pairing end to end.
