### PR TITLE
fix(backend): fix ty type error from ruff/ty dependency bump

### DIFF
--- a/backend/app/mcp/seating.py
+++ b/backend/app/mcp/seating.py
@@ -159,10 +159,15 @@ async def get_table_seating(
         for table in tables:
             table_regs = table_reg_map.get(table.id, [])
             guests = []
+            guest_count = 0
+            checked_in_count = 0
             for reg in table_regs:
                 person = persons.get(reg.person_id)
                 if person is None:
                     continue
+                guest_count += reg.guest_count
+                if reg.checked_in:
+                    checked_in_count += 1
                 guests.append(
                     {
                         "registration_id": reg.id,
@@ -182,8 +187,8 @@ async def get_table_seating(
                     "capacity": table.capacity,
                     "layout_id": table.layout_id,
                     "guests": guests,
-                    "guest_count": sum(g["guest_count"] for g in guests),
-                    "checked_in_count": sum(1 for g in guests if g["checked_in"]),
+                    "guest_count": guest_count,
+                    "checked_in_count": checked_in_count,
                 }
             )
 


### PR DESCRIPTION
## Summary
- Fixes the `Backend CI` failure on #766 (dependabot bump of `ruff` 0.15.22→0.16.0 and `ty` 0.0.60→0.0.63): [run 30175165784](https://github.com/tjorim/champagnefestival/actions/runs/30175165784/job/89722654440#step:8:1)
- `ty` 0.0.63 infers dict-literal values as a union of every field's type, so `sum(g["guest_count"] for g in guests)` in `app/mcp/seating.py::get_table_seating` no longer matches any `sum()` overload (`no-matching-overload`)
- Accumulates `guest_count` and `checked_in_count` as plain `int`s while building the `guests` list instead of re-deriving them from the dict afterwards, which sidesteps the widened union type and is also a single pass instead of two

This branch includes the `python-quality` dependency bump from #766 so the fix and the bump land together; #766 can be closed once this merges since its diff is included here.

## Test plan
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 101 files already formatted
- [x] `uv run ty check .` — All checks passed (previously failed with `no-matching-overload`)
- [x] `uv run pytest tests/test_mcp_server.py -k "check_in_counts or guest_count or seating or table"` — 17 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvdeJLaugsNYb3bPsgmvJX)_