### PR TITLE
fix: report the real constraint on a 409, and stop faking merged help periods

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -121,12 +121,27 @@ app.add_middleware(BaseHTTPMiddleware, dispatch=request_metrics_middleware)
 add_trusted_host_middleware(app, settings)
 
 
+# Postgres SQLSTATE codes worth naming. The catch-all used to describe every
+# constraint failure as a foreign-key problem, which sent admins looking for
+# related records after what was really a duplicate value.
+_INTEGRITY_DETAILS = {
+    "23502": "Cannot complete this operation because a required field is missing.",
+    "23503": "Cannot complete this operation because related records exist.",
+    "23505": "Cannot complete this operation because another record already uses one of these values.",
+    "23514": "Cannot complete this operation because a value fails a database constraint.",
+}
+_INTEGRITY_FALLBACK = "Cannot complete this operation because it violates a database constraint."
+
+
 @app.exception_handler(IntegrityError)
 async def integrity_error_handler(request: Request, exc: IntegrityError) -> JSONResponse:
-    logger.warning("IntegrityError on %s: %s", request.url.path, exc.orig)
+    # The asyncpg dialect copies the driver's SQLSTATE onto the wrapped error as
+    # both pgcode and sqlstate; psycopg only sets pgcode.
+    sqlstate = getattr(exc.orig, "pgcode", None) or getattr(exc.orig, "sqlstate", None)
+    logger.warning("IntegrityError (%s) on %s: %s", sqlstate or "no sqlstate", request.url.path, exc.orig)
     return JSONResponse(
         status_code=409,
-        content={"detail": "Cannot complete this operation because related records exist."},
+        content={"detail": _INTEGRITY_DETAILS.get(sqlstate or "", _INTEGRITY_FALLBACK)},
     )
 
 

--- a/backend/tests/test_integrity_error_handler.py
+++ b/backend/tests/test_integrity_error_handler.py
@@ -1,0 +1,70 @@
+"""The global IntegrityError handler names the constraint that actually failed.
+
+Every constraint failure used to be reported as "related records exist", which
+describes a foreign-key problem. A unique violation — the failure mode behind
+the person-merge bug — then sent admins hunting for related records that were
+never the cause.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from starlette.requests import Request
+
+from app.main import integrity_error_handler
+
+
+class _DriverError(Exception):
+    """Stand-in for the DBAPI error SQLAlchemy wraps, carrying a SQLSTATE."""
+
+    def __init__(self, message: str, pgcode: str | None = None) -> None:
+        super().__init__(message)
+        self.pgcode = pgcode
+        self.sqlstate = pgcode
+
+
+def _request(path: str = "/api/people/per_1/merge/per_2") -> Request:
+    return Request({"type": "http", "method": "POST", "path": path, "headers": []})
+
+
+async def _detail(pgcode: str | None) -> tuple[int, str]:
+    exc = IntegrityError("UPDATE people SET ...", {}, _DriverError("boom", pgcode))
+    response = await integrity_error_handler(_request(), exc)
+    return response.status_code, json.loads(response.body)["detail"]
+
+
+@pytest.mark.anyio
+async def test_unique_violation_does_not_blame_related_records():
+    status_code, detail = await _detail("23505")
+    assert status_code == 409
+    assert "already uses one of these values" in detail
+    assert "related records" not in detail
+
+
+@pytest.mark.anyio
+async def test_foreign_key_violation_keeps_the_related_records_wording():
+    status_code, detail = await _detail("23503")
+    assert status_code == 409
+    assert detail == "Cannot complete this operation because related records exist."
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("pgcode", "expected"),
+    [("23502", "required field is missing"), ("23514", "fails a database constraint")],
+)
+async def test_other_known_sqlstates_get_their_own_wording(pgcode: str, expected: str):
+    status_code, detail = await _detail(pgcode)
+    assert status_code == 409
+    assert expected in detail
+
+
+@pytest.mark.anyio
+async def test_unknown_sqlstate_falls_back_without_guessing():
+    """A driver that reports no SQLSTATE must not be described as a FK problem."""
+    status_code, detail = await _detail(None)
+    assert status_code == 409
+    assert detail == "Cannot complete this operation because it violates a database constraint."

--- a/backend/tests/test_integrity_error_handler.py
+++ b/backend/tests/test_integrity_error_handler.py
@@ -33,7 +33,8 @@ def _request(path: str = "/api/people/per_1/merge/per_2") -> Request:
 async def _detail(pgcode: str | None) -> tuple[int, str]:
     exc = IntegrityError("UPDATE people SET ...", {}, _DriverError("boom", pgcode))
     response = await integrity_error_handler(_request(), exc)
-    return response.status_code, json.loads(response.body)["detail"]
+    # JSONResponse.body is typed bytes | memoryview; bytes() accepts either.
+    return response.status_code, json.loads(bytes(response.body))["detail"]
 
 
 @pytest.mark.anyio

--- a/frontend/src/hooks/useAdminPeopleActions.ts
+++ b/frontend/src/hooks/useAdminPeopleActions.ts
@@ -58,17 +58,15 @@ export function useAdminPeopleActions({
     async (canonicalId: string, duplicateId: string) => {
       const updated = await mergePeopleMutation.mutateAsync({ canonicalId, duplicateId });
       const canonicalPerson = apiToPerson(updated as Record<string, unknown>);
-      const duplicate = people.find((person) => person.id === duplicateId);
       const existingCanonical = people.find((person) => person.id === canonicalId);
-      const shouldPreserveVolunteerData =
-        canonicalPerson.roles.includes("volunteer") ||
-        existingCanonical?.roles.includes("volunteer") ||
-        duplicate?.roles.includes("volunteer");
-      const mergedCanonical = shouldPreserveVolunteerData
-        ? mergeVolunteerPerson(existingCanonical, {
-            ...canonicalPerson,
-            helpPeriods: existingCanonical?.helpPeriods ?? duplicate?.helpPeriods ?? [],
-          })
+      // The merge response is a PersonOut, which carries no help periods, so
+      // taking it verbatim would blank them out of the cache. Keep the ones the
+      // survivor already had — the merge does not touch its own rows — but do
+      // not copy the duplicate's across. The server re-points those now, and
+      // showing them here regardless is what hid the cascade delete last time.
+      // The refetch queued in the mutation's onSettled brings back the real set.
+      const mergedCanonical = canonicalPerson.roles.includes("volunteer")
+        ? { ...canonicalPerson, helpPeriods: existingCanonical?.helpPeriods ?? [] }
         : canonicalPerson;
 
       queryClient.setQueryData<Person[]>(peopleQueryKey, (prev) =>

--- a/frontend/tests/hooks/useAdminPeopleActions.test.tsx
+++ b/frontend/tests/hooks/useAdminPeopleActions.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Merging people must not invent volunteer help periods in the cache.
+ *
+ * The merge endpoint used to let Postgres cascade-delete the duplicate's help
+ * periods, and this hook hid it: it patched the duplicate's periods onto the
+ * survivor, so the admin saw a correct-looking merge over a corrupted record.
+ * The server transfers those rows now, and the cache must show what the server
+ * says rather than a hopeful reconstruction of it.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import { useAdminPeopleActions } from "@/hooks/useAdminPeopleActions";
+import { server } from "@/mocks/server";
+import type { Person } from "@/types/person";
+import { createTestQueryClientHarness } from "../utils/queryClient";
+
+const PEOPLE_KEY = ["admin", "people"];
+const MEMBERS_KEY = ["admin", "members"];
+const REGISTRATIONS_KEY = ["admin", "registrations"];
+const EXHIBITORS_KEY = ["admin", "exhibitors"];
+
+function makePerson(overrides: Partial<Person> & { id: string }): Person {
+  return {
+    name: "Sofie De Smet",
+    email: "",
+    phone: "",
+    address: "Dorpsstraat 12",
+    roles: ["member"],
+    nationalRegisterNumber: null,
+    eidDocumentNumber: null,
+    visitsPerMonth: null,
+    clubName: "",
+    notes: "",
+    active: true,
+    helpPeriods: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const CANONICAL = makePerson({
+  id: "per_canonical",
+  roles: ["member", "volunteer"],
+  helpPeriods: [{ id: 1, firstHelpDay: "2024-03-15", lastHelpDay: "2024-03-17" }],
+});
+
+const DUPLICATE = makePerson({
+  id: "per_duplicate",
+  email: "sofie@example.com",
+  roles: ["volunteer"],
+  helpPeriods: [
+    { id: 2, firstHelpDay: "2025-10-10", lastHelpDay: null },
+    { id: 3, firstHelpDay: "2026-02-01", lastHelpDay: "2026-02-03" },
+  ],
+});
+
+/** What POST /api/people/{id}/merge/{id} returns: a PersonOut, no help periods. */
+const MERGE_RESPONSE = {
+  id: CANONICAL.id,
+  name: CANONICAL.name,
+  email: "sofie@example.com",
+  phone: "",
+  address: CANONICAL.address,
+  roles: ["member", "volunteer"],
+  national_register_number: "91010112345",
+  eid_document_number: "bex123456",
+  visits_per_month: null,
+  club_name: "",
+  notes: "",
+  active: true,
+  created_at: CANONICAL.createdAt,
+  updated_at: "2026-08-05T12:00:00Z",
+};
+
+function renderMergeHook(people: Person[]) {
+  const { queryClient, Wrapper } = createTestQueryClientHarness();
+  // Nothing observes these queries, and the harness defaults to gcTime 0, which
+  // collects the seeded cache before the assertions can read it.
+  queryClient.setDefaultOptions({ queries: { retry: false, gcTime: Infinity } });
+  // Keep the refetch out of the way: this is about what the hook writes itself.
+  const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+  queryClient.setQueryData<Person[]>(PEOPLE_KEY, people);
+
+  const { result } = renderHook(
+    () =>
+      useAdminPeopleActions({
+        authHeaders: () => ({ "Content-Type": "application/json" }),
+        exhibitorsQueryKey: EXHIBITORS_KEY,
+        membersQueryKey: MEMBERS_KEY,
+        people,
+        peopleQueryKey: PEOPLE_KEY,
+        queryClient,
+        registrationsQueryKey: REGISTRATIONS_KEY,
+        setDetailRegistration: vi.fn(),
+      }),
+    { wrapper: Wrapper },
+  );
+
+  return { queryClient, result, invalidateQueries };
+}
+
+describe("useAdminPeopleActions — merge", () => {
+  it("keeps the survivor's own help periods and does not adopt the duplicate's", async () => {
+    server.use(
+      http.post("/api/people/:canonicalId/merge/:duplicateId", () =>
+        HttpResponse.json(MERGE_RESPONSE),
+      ),
+    );
+    const { queryClient, result, invalidateQueries } = renderMergeHook([CANONICAL, DUPLICATE]);
+
+    await act(async () => {
+      await result.current.handleMergePeople(CANONICAL.id, DUPLICATE.id);
+    });
+
+    const people = queryClient.getQueryData<Person[]>(PEOPLE_KEY) ?? [];
+    expect(people.map((person) => person.id)).toEqual([CANONICAL.id]);
+    // The duplicate's two periods are transferred server-side; showing them here
+    // before the refetch confirms it is exactly what masked the cascade delete.
+    expect(people[0]?.helpPeriods).toEqual(CANONICAL.helpPeriods);
+    // ...and the refetch that supplies the transferred periods is still queued.
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: PEOPLE_KEY });
+    });
+  });
+
+  it("takes the merged field values from the server, not from the stale cache", async () => {
+    server.use(
+      http.post("/api/people/:canonicalId/merge/:duplicateId", () =>
+        HttpResponse.json(MERGE_RESPONSE),
+      ),
+    );
+    const { queryClient, result } = renderMergeHook([CANONICAL, DUPLICATE]);
+
+    await act(async () => {
+      await result.current.handleMergePeople(CANONICAL.id, DUPLICATE.id);
+    });
+
+    const survivor = (queryClient.getQueryData<Person[]>(PEOPLE_KEY) ?? [])[0];
+    // The merge fills the canonical's blank email from the duplicate and adopts
+    // its identity numbers; the cached blanks must not win.
+    expect(survivor?.email).toBe("sofie@example.com");
+    expect(survivor?.nationalRegisterNumber).toBe("91010112345");
+    expect(survivor?.eidDocumentNumber).toBe("bex123456");
+  });
+
+  it("leaves help periods alone when the survivor is not a volunteer", async () => {
+    const plainCanonical = makePerson({ id: "per_canonical" });
+    const plainDuplicate = makePerson({ id: "per_duplicate" });
+    server.use(
+      http.post("/api/people/:canonicalId/merge/:duplicateId", () =>
+        HttpResponse.json({ ...MERGE_RESPONSE, roles: ["member"] }),
+      ),
+    );
+    const { queryClient, result } = renderMergeHook([plainCanonical, plainDuplicate]);
+
+    await act(async () => {
+      await result.current.handleMergePeople(plainCanonical.id, plainDuplicate.id);
+    });
+
+    const survivor = (queryClient.getQueryData<Person[]>(PEOPLE_KEY) ?? [])[0];
+    expect(survivor?.roles).toEqual(["member"]);
+    expect(survivor?.helpPeriods).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #797.

Stacked on #796, which already carries the two primary fixes from the issue: the two-flush ordering that stopped the UNIQUE identity swap from failing, and the `VolunteerPeriod` re-point that stopped `db.delete(duplicate)` from cascading the survivor's help periods away. Both are covered by `backend/tests/test_people_merge.py` there. This PR is the two follow-ups the issue flagged as "reconsider separately", so the base is #796's branch and the diff is just these changes.

## 1. The 409 no longer blames related records for a duplicate value

`integrity_error_handler` mapped every `IntegrityError` to *"Cannot complete this operation because related records exist."* — a foreign-key story. The merge failure was a unique violation, so the one message an admin saw pointed at the wrong thing entirely and the real cause stayed in the server log.

The handler now reads the SQLSTATE the driver reports (the asyncpg dialect copies it onto the wrapped error as both `pgcode` and `sqlstate`; psycopg sets `pgcode`) and picks wording to match:

| SQLSTATE | detail |
|---|---|
| `23503` foreign key | *…because related records exist.* (unchanged) |
| `23505` unique | *…because another record already uses one of these values.* |
| `23502` not null | *…because a required field is missing.* |
| `23514` check | *…because a value fails a database constraint.* |
| none / unknown | *…because it violates a database constraint.* |

Status stays 409 in every case, and the log line now carries the SQLSTATE. The fallback is deliberately neutral: a driver that reports no SQLSTATE should not be described as a foreign-key problem.

## 2. The client stops inventing the survivor's help periods

`handleMergePeople` patched the duplicate's help periods onto the survivor after a successful merge. That is precisely what made the cascade delete invisible — the rows were gone from the database while the admin watched them carry over, and they only vanished on the next refetch.

The merge response is a `PersonOut`, which has no `help_periods`, so taking it verbatim would blank the row instead. The hook now keeps the survivor's *own* cached periods — the merge does not touch those rows — and leaves the duplicate's to the refetch already queued in the mutation's `onSettled`. Under-reporting for a moment cannot hide a server-side regression; over-reporting did.

Dropping `mergeVolunteerPerson` from this path fixes a smaller bug alongside it: it preferred `existing?.email ?? volunteer.email`, and since `Person.email` is `""` rather than `null` when blank, a canonical whose empty email had just been filled from the duplicate kept showing the stale blank until the refetch landed. The server response is authoritative for those fields now.

## Tests

- `backend/tests/test_integrity_error_handler.py` — new. Drives the handler directly with each SQLSTATE; asserts a unique violation is not described as a related-records problem, that the foreign-key wording is unchanged, and that a missing SQLSTATE falls back without guessing.
- `frontend/tests/hooks/useAdminPeopleActions.test.tsx` — new. Asserts the merged survivor keeps its own help periods and does not adopt the duplicate's, that the refetch is still queued, that server field values beat stale cached ones, and that a non-volunteer survivor is unaffected.

Verified against a local Postgres 16: `uv run pytest` 462 passed, `uv run ruff check` and `uv run ty check` clean; `pnpm test` 506 passed, `pnpm typecheck` and `pnpm lint` clean.

## Note on review order

The base is `claude/admin-dashboard-bugs-ia2d43`, so GitHub will retarget this to `main` once #796 merges. #797 should close with this PR, not with #796 — the merge itself is fixed there, but the two follow-ups it asks for are here.

---
_Generated by [Claude Code](https://claude.ai/code/session_018CbRCq5VNpZpzpomCAaSMh)_