### PR TITLE
feat(admin): read per-event check-in stats from the API, and wire table-type delete

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -337,6 +337,8 @@
   "admin_table_type_name_required": "Name is required",
   "admin_table_type_capacity_min": "Max capacity must be a whole number of 1 or more",
   "admin_table_type_dimensions_positive": "Width and length must be positive numbers",
+  "admin_table_type_delete_confirm": "Permanently delete this table type? This cannot be undone.",
+  "admin_error_delete_table_type": "Failed to delete table type.",
   "admin_no_table_types": "No table types defined yet.",
   "admin_venue_add": "Add venue",
   "admin_venue_name_label": "Venue name",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -337,6 +337,8 @@
   "admin_table_type_name_required": "Le nom est obligatoire",
   "admin_table_type_capacity_min": "La capacité maximale doit être un nombre entier supérieur ou égal à 1",
   "admin_table_type_dimensions_positive": "La largeur et la longueur doivent être des nombres positifs",
+  "admin_table_type_delete_confirm": "Supprimer définitivement ce type de table ? Cette action est irréversible.",
+  "admin_error_delete_table_type": "Échec de la suppression du type de table.",
   "admin_no_table_types": "Aucun type de table défini.",
   "admin_venue_add": "Ajouter un lieu",
   "admin_venue_name_label": "Nom du lieu",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -337,6 +337,8 @@
   "admin_table_type_name_required": "Naam is verplicht",
   "admin_table_type_capacity_min": "Max. capaciteit moet een geheel getal van 1 of meer zijn",
   "admin_table_type_dimensions_positive": "Breedte en lengte moeten positieve getallen zijn",
+  "admin_table_type_delete_confirm": "Dit tafeltype definitief verwijderen? Dit kan niet ongedaan worden gemaakt.",
+  "admin_error_delete_table_type": "Tafeltype verwijderen mislukt.",
   "admin_no_table_types": "Nog geen tafeltypen gedefinieerd.",
   "admin_venue_add": "Locatie toevoegen",
   "admin_venue_name_label": "Naam locatie",

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -215,6 +215,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
     handleDeleteLayout,
     handleDeleteRoom,
     handleDeleteTable,
+    handleDeleteTableType,
     handleDeleteVenue,
     handleMoveArea,
     handleMoveTable,
@@ -579,6 +580,7 @@ export default function AdminDashboard({ visible }: AdminDashboardProps) {
                     onUpdate={handleUpdateTableType}
                     onArchive={handleArchiveTableType}
                     onRestore={handleRestoreTableType}
+                    onDelete={handleDeleteTableType}
                   />
                 )}
                 {canManageAdminSections && activeKey === "directory" && (

--- a/frontend/src/components/admin/RegistrationList.tsx
+++ b/frontend/src/components/admin/RegistrationList.tsx
@@ -23,7 +23,12 @@ import { exportToCsv } from "@/utils/csvExport";
 import RegistrationCreateModal from "./RegistrationCreateModal";
 import { ColumnVisibilityDropdown } from "./ColumnVisibilityDropdown";
 import { loadColVis, saveColVis } from "@/utils/columnVisibility";
-import { downloadRegistrationsCsv, fetchRegistrations } from "@/utils/adminFetch";
+import {
+  downloadRegistrationsCsv,
+  fetchEventCheckInStats,
+  fetchRegistrations,
+} from "@/utils/adminFetch";
+import { queryKeys } from "@/utils/queryKeys";
 import { toLocalDateKey } from "@/utils/dateUtils";
 import { isRegistrationInEdition } from "@/utils/adminUtils";
 import type { ActiveEdition } from "@/hooks/useActiveEdition";
@@ -173,6 +178,12 @@ export default function RegistrationList({
     queryKey: ["admin", "registrations", "search", debouncedQ],
     queryFn: () => fetchRegistrations(authHeaders, debouncedQ),
     enabled: debouncedQ.length > 0,
+    staleTime: 30 * 1000,
+    retry: false,
+  });
+  const checkInStatsQuery = useQuery({
+    queryKey: queryKeys.admin.eventCheckInStats,
+    queryFn: () => fetchEventCheckInStats(authHeaders),
     staleTime: 30 * 1000,
     retry: false,
   });
@@ -655,6 +666,14 @@ export default function RegistrationList({
 
   // Built from every registration, not the filtered rows: capacity is a property
   // of the event, so it must not shift when someone searches or filters by status.
+  //
+  // The counts themselves come from GET /api/events/checkin-stats — the endpoint
+  // built for exactly this, and the one the Android entrance display reads — so
+  // both surfaces report the same numbers, counted server-side over every
+  // registration rather than over whatever this client happens to hold. The
+  // local tally below still supplies each event's title and capacity, which the
+  // stats endpoint doesn't carry, and stands in for the counts until the query
+  // settles (or if it fails), since it measures the same thing.
   const eventCapacityStats = useMemo(() => {
     const statsByEvent = new Map<
       string,
@@ -686,10 +705,20 @@ export default function RegistrationList({
       }
     }
 
+    for (const serverStats of checkInStatsQuery.data ?? []) {
+      const existing = statsByEvent.get(serverStats.eventId);
+      statsByEvent.set(serverStats.eventId, {
+        checkedIn: serverStats.checkedIn,
+        total: serverStats.total,
+        title: existing?.title ?? serverStats.eventId,
+        maxCapacity: existing?.maxCapacity,
+      });
+    }
+
     return [...statsByEvent.entries()]
       .map(([eventId, stats]) => ({ eventId, ...stats }))
       .sort((a, b) => a.title.localeCompare(b.title));
-  }, [registrations]);
+  }, [registrations, checkInStatsQuery.data]);
 
   const handleExportCsv = useCallback(() => {
     const rows = table.getRowModel().rows.map(({ original: reg }) => ({

--- a/frontend/src/components/admin/TableTypeManagement.tsx
+++ b/frontend/src/components/admin/TableTypeManagement.tsx
@@ -24,6 +24,7 @@ interface TableTypeManagementProps {
   onUpdate: (id: string, data: Partial<Omit<TableType, "id">>) => Promise<void>;
   onArchive: (id: string) => Promise<void>;
   onRestore: (id: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
 }
 
 const emptyForm = {
@@ -44,6 +45,7 @@ export default function TableTypeManagement({
   onUpdate,
   onArchive,
   onRestore,
+  onDelete,
 }: TableTypeManagementProps) {
   const [showModal, setShowModal] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -133,6 +135,21 @@ export default function TableTypeManagement({
       }
     },
     [onRestore],
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      if (!window.confirm(m.admin_table_type_delete_confirm())) return;
+      setDeleteError(null);
+      try {
+        await onDelete(id);
+      } catch (err) {
+        // The API refuses while tables still use the type; surface that instead
+        // of leaving the button looking inert.
+        setDeleteError(err instanceof Error ? err.message : m.admin_content_error_save());
+      }
+    },
+    [onDelete],
   );
 
   const columns = useMemo(
@@ -227,22 +244,33 @@ export default function TableTypeManagement({
                     <i className="bi bi-archive" aria-hidden="true" />
                   </Button>
                 ) : (
-                  <Button
-                    size="sm"
-                    variant="outline-success"
-                    onClick={() => handleRestore(tt.id)}
-                    aria-label={m.admin_content_restore()}
-                    title={m.admin_content_restore()}
-                  >
-                    <i className="bi bi-arrow-counterclockwise" aria-hidden="true" />
-                  </Button>
+                  <>
+                    <Button
+                      size="sm"
+                      variant="outline-success"
+                      onClick={() => handleRestore(tt.id)}
+                      aria-label={m.admin_content_restore()}
+                      title={m.admin_content_restore()}
+                    >
+                      <i className="bi bi-arrow-counterclockwise" aria-hidden="true" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline-danger"
+                      onClick={() => handleDelete(tt.id)}
+                      aria-label={`${m.admin_delete()} ${tt.name}`}
+                      title={m.admin_delete()}
+                    >
+                      <i className="bi bi-trash" aria-hidden="true" />
+                    </Button>
+                  </>
                 )}
               </div>
             );
           },
         }),
       ]),
-    [openEdit, handleArchive, handleRestore],
+    [openEdit, handleArchive, handleRestore, handleDelete],
   );
 
   const table = useAppTable(

--- a/frontend/src/hooks/useAdminVenueActions.ts
+++ b/frontend/src/hooks/useAdminVenueActions.ts
@@ -51,6 +51,7 @@ export function useAdminVenueActions({
     deleteAreaMutation,
     deleteLayoutMutation,
     deleteTableMutation,
+    deleteTableTypeMutation,
     deleteVenueMutation,
     moveAreaMutation,
     moveTableMutation,
@@ -425,6 +426,16 @@ export function useAdminVenueActions({
     [handleUpdateTableType],
   );
 
+  const handleDeleteTableType = useCallback(
+    async (id: string) => {
+      await deleteTableTypeMutation.mutateAsync(id);
+      queryClient.setQueryData<TableType[]>(tableTypesQueryKey, (prev) =>
+        prev ? prev.filter((tt) => tt.id !== id) : prev,
+      );
+    },
+    [deleteTableTypeMutation, queryClient, tableTypesQueryKey],
+  );
+
   return {
     handleAddArea,
     handleAddLayout,
@@ -441,6 +452,7 @@ export function useAdminVenueActions({
     handleDeleteLayout,
     handleDeleteRoom,
     handleDeleteTable,
+    handleDeleteTableType,
     handleDeleteVenue,
     handleMoveArea,
     handleMoveTable,

--- a/frontend/src/hooks/useVenueMutations.ts
+++ b/frontend/src/hooks/useVenueMutations.ts
@@ -619,6 +619,19 @@ export function useVenueMutations({
     retry: false,
   });
 
+  const deleteTableTypeMutation = useMutation({
+    mutationFn: (typeId: string) =>
+      fetchVoidOrThrowWithUnauthorized(
+        `/api/table-types/${typeId}`,
+        { method: "DELETE", headers: authHeaders() },
+        m.admin_error_delete_table_type(),
+      ),
+    onSettled: () => {
+      void invalidateAdmin(queryClient, [tableTypesQueryKey]);
+    },
+    retry: false,
+  });
+
   return {
     createTableMutation,
     changeTableTypeMutation,
@@ -643,5 +656,6 @@ export function useVenueMutations({
     deleteAreaMutation,
     createTableTypeMutation,
     updateTableTypeMutation,
+    deleteTableTypeMutation,
   };
 }

--- a/frontend/src/mocks/handlers/admin.ts
+++ b/frontend/src/mocks/handlers/admin.ts
@@ -661,6 +661,34 @@ export const adminHandlers = [
   // ──────────────────────────────────────────────────────────────
   // Events (admin)
   // ──────────────────────────────────────────────────────────────
+
+  // Must stay ahead of "/api/events/:id", which would otherwise swallow it.
+  http.get("/api/events/checkin-stats", ({ request }) => {
+    const authError = requireAuth(request);
+    if (authError) return authError;
+    const editionId = new URL(request.url).searchParams.get("edition_id");
+    const totals = new Map<string, { total: number; checked_in: number }>();
+
+    for (const registration of sharedStore.registrations) {
+      const eventId = registration.event_id;
+      if (typeof eventId !== "string" || eventId.length === 0) continue;
+      if (registration.status === "cancelled") continue;
+      if (editionId) {
+        const event = events.find((e) => e.id === eventId);
+        if (!event || event.edition_id !== editionId) continue;
+      }
+      const guests = typeof registration.guest_count === "number" ? registration.guest_count : 0;
+      const entry = totals.get(eventId) ?? { total: 0, checked_in: 0 };
+      entry.total += guests;
+      if (registration.checked_in === true) entry.checked_in += guests;
+      totals.set(eventId, entry);
+    }
+
+    return HttpResponse.json(
+      [...totals.entries()].map(([event_id, entry]) => ({ event_id, ...entry })),
+    );
+  }),
+
   http.get("/api/events/:id", ({ request, params }) => {
     const authError = requireAuth(request);
     if (authError) return authError;

--- a/frontend/src/state/LiveUpdatesProvider.tsx
+++ b/frontend/src/state/LiveUpdatesProvider.tsx
@@ -47,6 +47,11 @@ export function LiveUpdatesProvider(): null {
 
           if (!canPatchRegistration || !isAdminRegistrationsKey) {
             queryClient.invalidateQueries({ queryKey: key });
+          } else {
+            // Patching keeps the collection's rows fresh, but the server-counted
+            // check-in stats nested under this key are skipped along with it —
+            // a check-in changes them, so refetch them explicitly.
+            queryClient.invalidateQueries({ queryKey: queryKeys.admin.eventCheckInStats });
           }
         }
 

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -93,6 +93,19 @@ export interface AuditEntry {
   details: Record<string, unknown>;
 }
 
+/**
+ * Per-event check-in progress, as counted by the backend.
+ *
+ * Guest counts, not booking counts — a booking can carry several guests, and a
+ * headcount is what a capacity limit and an entrance display both care about.
+ * Cancelled bookings are excluded on both sides.
+ */
+export interface EventCheckInStats {
+  eventId: string;
+  total: number;
+  checkedIn: number;
+}
+
 export interface EditionAttendanceStats {
   editionId: string;
   year: number;

--- a/frontend/src/utils/adminApiMappers.ts
+++ b/frontend/src/utils/adminApiMappers.ts
@@ -7,6 +7,7 @@ import type {
   Venue,
   AuditEntry,
   EditionAttendanceStats,
+  EventCheckInStats,
 } from "@/types/admin";
 import type { Person } from "@/types/person";
 
@@ -21,6 +22,17 @@ export function apiAuditEntryToAuditEntry(d: Record<string, unknown>): AuditEntr
     resourceId: d.resource_id as string,
     requestId: (d.request_id ?? null) as string | null,
     details: (d.details ?? {}) as Record<string, unknown>,
+  };
+}
+
+/** Map FastAPI snake_case per-event check-in stats response to frontend camelCase type */
+export function apiEventCheckInStatsToEventCheckInStats(
+  d: Record<string, unknown>,
+): EventCheckInStats {
+  return {
+    eventId: d.event_id as string,
+    total: d.total as number,
+    checkedIn: d.checked_in as number,
   };
 }
 

--- a/frontend/src/utils/adminFetch.ts
+++ b/frontend/src/utils/adminFetch.ts
@@ -7,6 +7,7 @@ import type {
   Venue,
   AuditEntry,
   EditionAttendanceStats,
+  EventCheckInStats,
 } from "@/types/admin";
 import { apiToRegistration } from "@/types/registrationMapper";
 import type { Registration } from "@/types/registration";
@@ -26,6 +27,7 @@ import {
   apiAreaToArea,
   apiAuditEntryToAuditEntry,
   apiEditionStatsToEditionAttendanceStats,
+  apiEventCheckInStatsToEventCheckInStats,
   mergePeopleWithVolunteers,
 } from "@/utils/adminApiMappers";
 
@@ -226,6 +228,23 @@ export async function fetchAuditResourceTypes(
     m.admin_error_load_data(),
   );
   return Array.isArray(payload) ? payload : [];
+}
+
+/**
+ * Per-event check-in progress, counted by the backend rather than from whatever
+ * registrations the client happens to hold. Optionally scoped to one edition.
+ */
+export async function fetchEventCheckInStats(
+  authHeaders: () => Record<string, string>,
+  editionId?: string,
+): Promise<EventCheckInStats[]> {
+  const suffix = editionId ? `?edition_id=${encodeURIComponent(editionId)}` : "";
+  return fetchArrayOrThrow(
+    `/api/events/checkin-stats${suffix}`,
+    { headers: authHeaders() },
+    m.admin_error_load_data(),
+    apiEventCheckInStatsToEventCheckInStats,
+  );
 }
 
 export async function fetchEditionStats(

--- a/frontend/src/utils/queryKeys.ts
+++ b/frontend/src/utils/queryKeys.ts
@@ -8,6 +8,12 @@ export const queryKeys = {
     /** The admin dashboard's active edition — any type, unlike the public one. */
     activeEdition: ["admin", "active-edition"] as const,
     registrations: ["admin", "registrations"] as const,
+    /**
+     * Nested under `registrations` on purpose: these counts are derived from
+     * registrations, so every invalidation of that key — mutations, live-stream
+     * events, reconnect recovery — refreshes them without a separate wiring.
+     */
+    eventCheckInStats: ["admin", "registrations", "checkin-stats"] as const,
     tables: ["admin", "tables"] as const,
     venues: ["admin", "venues"] as const,
     rooms: ["admin", "rooms"] as const,

--- a/frontend/tests/components/admin.RegistrationListCapacityPanel.test.tsx
+++ b/frontend/tests/components/admin.RegistrationListCapacityPanel.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * The admin's per-event capacity panel reads GET /api/events/checkin-stats —
+ * the endpoint built for it, and the same one the Android entrance display uses
+ * — instead of counting whatever registrations this client happens to hold.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import RegistrationList from "@/components/admin/RegistrationList";
+import type { ActiveEdition } from "@/hooks/useActiveEdition";
+import type { Registration } from "@/types/registration";
+import { server } from "@/mocks/server";
+import { createTestQueryClient } from "../utils/queryClient";
+
+vi.mock("@/paraglide/messages", () => ({
+  m: new Proxy({} as Record<string, (...args: unknown[]) => string>, {
+    get(_target, key: string) {
+      return (...args: unknown[]) => (args.length ? `${key}(${JSON.stringify(args[0])})` : key);
+    },
+  }),
+}));
+
+const activeEdition: ActiveEdition = {
+  id: "edition-1",
+  year: 2026,
+  editionType: "bourse",
+  month: "october",
+  dates: [],
+  venue: {
+    venueName: "MEC Staf Versluys",
+    address: "Kapelstraat 76",
+    city: "Bredene",
+    postalCode: "8450",
+    country: "BE",
+    coordinates: { lat: 0, lng: 0 },
+  },
+  events: [],
+  producers: [],
+  sponsors: [],
+};
+
+function buildRegistration(overrides: Partial<Registration> = {}): Registration {
+  return {
+    id: "reg-1",
+    personId: "person-1",
+    person: {
+      id: "person-1",
+      name: "Jane Doe",
+      email: "jane@example.com",
+      phone: "+32 470 00 00 00",
+    },
+    eventId: "event-1",
+    event: {
+      id: "event-1",
+      editionId: "edition-1",
+      title: "Collectors Bourse",
+      description: "",
+      date: "2026-11-21",
+      startTime: "10:00",
+      category: "bourse",
+      products: [],
+      registrationRequired: true,
+      maxCapacity: 40,
+      active: true,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      edition: {
+        id: "edition-1",
+        year: 2026,
+        month: "november",
+        editionType: "bourse",
+        active: true,
+      },
+    },
+    guestCount: 2,
+    orderItems: [],
+    notes: "",
+    accessibilityNote: "",
+    status: "confirmed",
+    paymentStatus: "unpaid",
+    checkedIn: false,
+    strapIssued: false,
+    checkInToken: "token-abc",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderRegistrationList(registrations: Registration[]) {
+  const queryClient = createTestQueryClient();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RegistrationList
+        registrations={registrations}
+        tables={[]}
+        exhibitors={[]}
+        filter="all"
+        onFilterChange={vi.fn()}
+        onUpdateStatus={vi.fn()}
+        onUpdatePayment={vi.fn()}
+        onAssignTable={vi.fn()}
+        onViewDetail={vi.fn()}
+        onCheckIn={vi.fn()}
+        onIssueStrap={vi.fn()}
+        onAddRegistration={vi.fn()}
+        authHeaders={() => ({ Authorization: "Bearer test-token" })}
+        activeEdition={activeEdition}
+        applyActiveEditionFilterRequest={0}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("RegistrationList — per-event capacity panel", () => {
+  it("reports the server's guest counts, not the ones derivable from the loaded registrations", async () => {
+    server.use(
+      http.get("/api/events/checkin-stats", () =>
+        HttpResponse.json([{ event_id: "event-1", total: 30, checked_in: 12 }]),
+      ),
+    );
+
+    renderRegistrationList([buildRegistration()]);
+
+    // The one loaded registration would tally 0/2 on its own.
+    expect(screen.getByText(/admin_checked_in: 0\/2/)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(/admin_checked_in: 12\/30/)).toBeInTheDocument());
+    // Capacity comes from the event, which the stats endpoint doesn't carry.
+    expect(screen.getByText("event_capacity: 30/40")).toBeInTheDocument();
+  });
+
+  it("falls back to the locally derived counts when the stats request fails", async () => {
+    server.use(
+      http.get("/api/events/checkin-stats", () => HttpResponse.json(null, { status: 500 })),
+    );
+
+    renderRegistrationList([
+      buildRegistration(),
+      buildRegistration({ id: "reg-2", checkedIn: true, guestCount: 3 }),
+    ]);
+
+    await waitFor(() => expect(screen.getByText(/admin_checked_in: 3\/5/)).toBeInTheDocument());
+  });
+
+  it("scopes each event's counts separately", async () => {
+    server.use(
+      http.get("/api/events/checkin-stats", () =>
+        HttpResponse.json([
+          { event_id: "event-1", total: 30, checked_in: 12 },
+          { event_id: "event-2", total: 8, checked_in: 8 },
+        ]),
+      ),
+    );
+
+    renderRegistrationList([
+      buildRegistration(),
+      buildRegistration({
+        id: "reg-2",
+        eventId: "event-2",
+        event: {
+          ...buildRegistration().event!,
+          id: "event-2",
+          title: "Capsule Exchange",
+          maxCapacity: undefined,
+        },
+      }),
+    ]);
+
+    // Each event's counts stay labelled with the event they belong to.
+    await waitFor(() =>
+      expect(screen.getByText(/admin_checked_in: 12\/30/)).toHaveTextContent("Collectors Bourse"),
+    );
+    expect(screen.getByText(/admin_checked_in: 8\/8/)).toHaveTextContent("Capsule Exchange");
+  });
+});

--- a/frontend/tests/components/admin.TableTypeManagement.test.tsx
+++ b/frontend/tests/components/admin.TableTypeManagement.test.tsx
@@ -39,6 +39,7 @@ interface RenderOverrides {
   onUpdate?: (id: string, data: Partial<Omit<TableType, "id">>) => Promise<void>;
   onArchive?: (id: string) => Promise<void>;
   onRestore?: (id: string) => Promise<void>;
+  onDelete?: (id: string) => Promise<void>;
 }
 
 function renderTableTypeManagement(overrides: RenderOverrides = {}) {
@@ -46,6 +47,7 @@ function renderTableTypeManagement(overrides: RenderOverrides = {}) {
   const onUpdate = overrides.onUpdate ?? vi.fn().mockResolvedValue(undefined);
   const onArchive = overrides.onArchive ?? vi.fn().mockResolvedValue(undefined);
   const onRestore = overrides.onRestore ?? vi.fn().mockResolvedValue(undefined);
+  const onDelete = overrides.onDelete ?? vi.fn().mockResolvedValue(undefined);
 
   render(
     <TableTypeManagement
@@ -54,10 +56,11 @@ function renderTableTypeManagement(overrides: RenderOverrides = {}) {
       onUpdate={onUpdate}
       onArchive={onArchive}
       onRestore={onRestore}
+      onDelete={onDelete}
     />,
   );
 
-  return { onAdd, onUpdate, onArchive, onRestore };
+  return { onAdd, onUpdate, onArchive, onRestore, onDelete };
 }
 
 describe("TableTypeManagement", () => {
@@ -190,5 +193,53 @@ describe("TableTypeManagement", () => {
 
     expect(confirmSpy).not.toHaveBeenCalled();
     expect(onRestore).toHaveBeenCalledWith("tt-2");
+  });
+
+  it("offers delete on archived rows only, and asks for confirmation first", () => {
+    const confirmSpy = vi.fn().mockReturnValue(true);
+    vi.stubGlobal("confirm", confirmSpy);
+    const { onDelete } = renderTableTypeManagement();
+
+    const activeRow = screen.getByText("Standard Rectangle").closest("tr") as HTMLElement;
+    expect(
+      within(activeRow).queryByRole("button", { name: /admin_delete/ }),
+    ).not.toBeInTheDocument();
+
+    const archivedRow = screen.getByText("Retired Round").closest("tr") as HTMLElement;
+    fireEvent.click(
+      within(archivedRow).getByRole("button", { name: "admin_delete Retired Round" }),
+    );
+
+    expect(confirmSpy).toHaveBeenCalledWith("admin_table_type_delete_confirm");
+    expect(onDelete).toHaveBeenCalledWith("tt-2");
+  });
+
+  it("does not delete when the confirmation is declined", () => {
+    vi.stubGlobal("confirm", vi.fn().mockReturnValue(false));
+    const { onDelete } = renderTableTypeManagement();
+
+    const archivedRow = screen.getByText("Retired Round").closest("tr") as HTMLElement;
+    fireEvent.click(
+      within(archivedRow).getByRole("button", { name: "admin_delete Retired Round" }),
+    );
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the API's refusal when tables still use the type", async () => {
+    vi.stubGlobal("confirm", vi.fn().mockReturnValue(true));
+    const onDelete = vi
+      .fn()
+      .mockRejectedValue(new Error("Cannot delete: tables are still using this type."));
+    renderTableTypeManagement({ onDelete });
+
+    const archivedRow = screen.getByText("Retired Round").closest("tr") as HTMLElement;
+    fireEvent.click(
+      within(archivedRow).getByRole("button", { name: "admin_delete Retired Round" }),
+    );
+
+    expect(
+      await screen.findByText("Cannot delete: tables are still using this type."),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/tests/state/LiveUpdatesProvider.test.tsx
+++ b/frontend/tests/state/LiveUpdatesProvider.test.tsx
@@ -1,4 +1,6 @@
 import { act, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAuth } from "@/contexts/AuthContext";
 import { LiveUpdatesProvider } from "@/state/LiveUpdatesProvider";
@@ -19,6 +21,16 @@ vi.mock("@/utils/liveStream", () => ({
       options.signal.addEventListener("abort", () => resolve(), { once: true });
     });
   }),
+}));
+
+// Patching needs a registered collection, which these tests don't stand up —
+// so it's mocked, defaulting to "cannot patch" (the real behaviour here) and
+// flipped on for the one test that exercises the patch branch.
+let canPatch = false;
+
+vi.mock("@/state/adminRegistrationsCollection", () => ({
+  canPatchAdminRegistrationLiveEvent: () => canPatch,
+  patchAdminRegistrationLiveEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
 // ---------------------------------------------------------------------------
@@ -43,6 +55,7 @@ function makeEnvelope(overrides: Partial<LiveEnvelope> = {}): LiveEnvelope {
 
 describe("LiveUpdatesProvider", () => {
   beforeEach(() => {
+    canPatch = false;
     vi.mocked(useAuth).mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -113,6 +126,30 @@ describe("LiveUpdatesProvider", () => {
 
     expect(spy).toHaveBeenCalledWith({ queryKey: ["admin", "registrations"] });
     expect(spy).toHaveBeenCalledWith({ queryKey: ["admin", "tables"] });
+  });
+
+  it("refreshes the check-in stats when a registration event is patched instead of invalidated", async () => {
+    capturedOptions = null;
+    canPatch = true;
+    // Own client rather than the shared harness: that one sets gcTime to 0, so
+    // an observer-less cache entry is collected before the event arrives.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    // The patch path only runs once the registrations query has succeeded.
+    queryClient.setQueryData(["admin", "registrations"], []);
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    render(<LiveUpdatesProvider />, { wrapper: Wrapper });
+    await waitFor(() => expect(capturedOptions).not.toBeNull());
+
+    act(() => capturedOptions!.onInvalidate(makeEnvelope({ topic: "check_in" })));
+
+    expect(spy).not.toHaveBeenCalledWith({ queryKey: ["admin", "registrations"] });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: ["admin", "registrations", "checkin-stats"],
+    });
   });
 
   it("calls invalidateQueries for all live keys on reconnect", async () => {


### PR DESCRIPTION
Stacked on `claude/admin-dashboard-bugs-ia2d43` (#796), which already closes items 1–4 and 6 of #798. This picks up the two that survived it: item 5, and the table-type half of item 4.

Frontend only — both endpoints already exist, are already guarded, and already have backend tests.

## 5. Per-event check-in stats reached only Android

`GET /api/events/checkin-stats` returns per-event guest and check-in counts. The Android entrance display consumed it; the web admin's capacity panel counted whatever registrations the client happened to hold (`RegistrationList.tsx`'s `eventCapacityStats`). #796 aligned what the two *mean* — both count guests, not bookings — but left the admin computing its own.

The panel now reads the endpoint. The local tally stays for the two things the stats response doesn't carry — each event's title and `max_capacity` — and stands in for the counts until the query settles, or if it fails, since it measures the same thing. No error banner for that case: falling back is not a degraded state, it's the same number by a slower route.

**Invalidation.** The query key is `["admin", "registrations", "checkin-stats"]` — nested under the registrations key on purpose, so mutations (`useRegistrationAdminMutations`), live-stream envelopes and reconnect recovery all refresh it with no extra wiring. One path skipped it: when a live registration event can be applied incrementally to the collection, `LiveUpdatesProvider` deliberately does *not* invalidate the registrations key, and the nested stats went along with it. That branch now invalidates the stats key explicitly — a check-in is exactly the event that changes these numbers.

## 4 (second half). Table types could be archived but never deleted

`DELETE /api/table-types/{type_id}` was implemented, audited, and guarded — 409 `Cannot delete: tables are still using this type.` — with no caller anywhere. The issue flagged it as possibly deliberate. Wiring it up rather than dropping it: the guard is the thing that made deletion risky, and it's already there, so archive-only was an accident of the UI, the same shape as rooms in #796.

`TableTypeManagement` now offers delete on archived rows only (mirroring `VenueManagement`'s room delete), behind a `window.confirm`, and surfaces the API's refusal in the existing error banner instead of leaving the button looking inert.

## Testing

| Suite | Covers |
|---|---|
| `admin.RegistrationListCapacityPanel.test.tsx` (new) | Panel reports the server's counts over the locally derivable ones; capacity still comes from the event; falls back to the local tally on a failed request; counts stay attached to the right event across two events |
| `admin.TableTypeManagement.test.tsx` | Delete offered on archived rows only, confirmation required, declining does nothing, the 409 refusal is surfaced |
| `LiveUpdatesProvider.test.tsx` | A patched registration event refreshes the check-in stats without invalidating the registrations key |

Frontend 513 passing; typecheck, lint and build clean. Added an MSW handler for `/api/events/checkin-stats` (ahead of `/api/events/:id`, which would otherwise swallow it) that applies the same counting rules as the backend.

New message keys `admin_table_type_delete_confirm` and `admin_error_delete_table_type` in all three locales.

Closes the remainder of #798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WRrw84TKqQPVifYai4jsX

---
_Generated by [Claude Code](https://claude.ai/code/session_016WRrw84TKqQPVifYai4jsX)_