### PR TITLE
Add integration clients, extract services

### DIFF
--- a/backend/alembic/versions/006_add_integration_clients.py
+++ b/backend/alembic/versions/006_add_integration_clients.py
@@ -32,6 +32,7 @@ def upgrade() -> None:
         sa.Column("id", sa.String(64), primary_key=True),
         sa.Column("name", sa.String(120), nullable=False),
         sa.Column("key_hash", sa.String(128), nullable=False),
+        sa.Column("key_preview", sa.String(8), nullable=False),
         sa.Column("allowed_role", sa.String(20), nullable=False),
         sa.Column("created_by_actor", sa.String(255), nullable=False),
         sa.Column("rate_limit_per_minute", sa.Integer(), nullable=False, server_default="120"),
@@ -39,6 +40,8 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
         sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("rate_limit_window_started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("rate_limit_window_count", sa.Integer(), nullable=False, server_default="0"),
     )
     op.create_index(
         "ix_integration_clients_key_hash",

--- a/backend/alembic/versions/006_add_integration_clients.py
+++ b/backend/alembic/versions/006_add_integration_clients.py
@@ -1,0 +1,53 @@
+"""Add integration_clients table for managed MCP automation credentials.
+
+Adds a database-backed credential store for machine automation (see issue
+#807): an admin issues a credential scoped to exactly one Champagnefestival
+role tier (never more privileged than their own), only its hash is stored,
+and it can be listed/revoked/rotated with last-used tracking. This
+complements — does not replace — Keycloak client-credentials, which remain
+fully supported.
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-08-07
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "integration_clients",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("name", sa.String(120), nullable=False),
+        sa.Column("key_hash", sa.String(128), nullable=False),
+        sa.Column("allowed_role", sa.String(20), nullable=False),
+        sa.Column("created_by_actor", sa.String(255), nullable=False),
+        sa.Column("rate_limit_per_minute", sa.Integer(), nullable=False, server_default="120"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_integration_clients_key_hash",
+        "integration_clients",
+        ["key_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_integration_clients_key_hash", table_name="integration_clients")
+    op.drop_table("integration_clients")

--- a/backend/alembic/versions/007_add_audit_provenance.py
+++ b/backend/alembic/versions/007_add_audit_provenance.py
@@ -1,0 +1,54 @@
+"""Add structured authentication provenance to audit entries.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-08-09
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "007"
+down_revision: str | None = "006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "audit_entries",
+        sa.Column("auth_source", sa.String(32), nullable=False, server_default="unknown"),
+    )
+    op.add_column("audit_entries", sa.Column("subject", sa.String(255), nullable=True))
+    op.add_column("audit_entries", sa.Column("integration_client_id", sa.String(64), nullable=True))
+    op.execute(
+        sa.text(
+            """UPDATE audit_entries
+               SET auth_source = CASE
+                       WHEN actor = 'anonymous' THEN 'none'
+                       WHEN actor LIKE 'integration:%' THEN 'integration'
+                       ELSE 'keycloak'
+                   END,
+                   subject = CASE WHEN actor = 'anonymous' THEN NULL ELSE actor END,
+                   integration_client_id = CASE
+                       WHEN actor LIKE 'integration:%' THEN substring(actor FROM 13)
+                       ELSE NULL
+                   END"""
+        )
+    )
+    op.alter_column("audit_entries", "auth_source", server_default=None)
+    op.create_index("ix_audit_entries_auth_source", "audit_entries", ["auth_source"])
+    op.create_index("ix_audit_entries_integration_client_id", "audit_entries", ["integration_client_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_entries_integration_client_id", table_name="audit_entries")
+    op.drop_index("ix_audit_entries_auth_source", table_name="audit_entries")
+    op.drop_column("audit_entries", "integration_client_id")
+    op.drop_column("audit_entries", "subject")
+    op.drop_column("audit_entries", "auth_source")

--- a/backend/app/audit.py
+++ b/backend/app/audit.py
@@ -8,6 +8,15 @@ from app.models import AuditEntry
 from app.utils import make_id
 
 
+def audit_provenance(actor: str) -> tuple[str, str | None, str | None]:
+    """Derive structured provenance from the established actor vocabulary."""
+    if actor == "anonymous":
+        return "none", None, None
+    if actor.startswith("integration:"):
+        return "integration", actor, actor.removeprefix("integration:")
+    return "keycloak", actor, None
+
+
 async def write_audit_entry(
     db: AsyncSession,
     *,
@@ -22,10 +31,14 @@ async def write_audit_entry(
 
     Does not commit — caller commits as part of the same transaction.
     """
+    auth_source, subject, integration_client_id = audit_provenance(actor)
     db.add(
         AuditEntry(
             id=make_id("aud"),
             actor=actor,
+            auth_source=auth_source,
+            subject=subject,
+            integration_client_id=integration_client_id,
             action=action,
             resource_type=resource_type,
             resource_id=resource_id,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.config import settings
 from app.database import create_tables
-from app.mcp_server import build_keycloak_auth, create_mcp_server, get_mcp_capabilities
+from app.mcp.capabilities import get_mcp_capabilities
+from app.mcp_server import build_keycloak_auth, create_mcp_server
 from app.middleware import add_cors_middleware, add_rate_limit_middleware, add_trusted_host_middleware
 from app.observability import request_metrics_middleware
 from app.routers import (

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.config import settings
 from app.database import create_tables
-from app.mcp_server import build_keycloak_auth, create_mcp_server
+from app.mcp_server import build_keycloak_auth, create_mcp_server, get_mcp_capabilities
 from app.middleware import add_cors_middleware, add_rate_limit_middleware, add_trusted_host_middleware
 from app.observability import request_metrics_middleware
 from app.routers import (
@@ -26,6 +26,7 @@ from app.routers import (
     exhibitors,
     faq,
     health,
+    integration_clients,
     layouts,
     live,
     me,
@@ -175,6 +176,23 @@ app.include_router(live.router)
 app.include_router(health.router)
 app.include_router(faq.router)
 app.include_router(settings_router.router)
+app.include_router(integration_clients.router)
+
+
+@app.get("/api/mcp/capabilities")
+async def mcp_capabilities() -> dict[str, object]:
+    """Public capabilities manifest for the MCP server (issue #807).
+
+    Reports whether the MCP server is mounted and, when it is, the live
+    registered tool set with each tool's required role tier — generated
+    directly from ``mcp.list_tools()`` so it can never drift from what's
+    actually registered (see ``app.mcp_server.get_mcp_capabilities``).
+    """
+    if _mcp is None:
+        return {"enabled": False, "mount_path": "/mcp", "version": None, "tools": []}
+    manifest = await get_mcp_capabilities(_mcp)
+    return {"enabled": True, "mount_path": "/mcp", "version": _mcp.version, **manifest}
+
 
 if _mcp_app is not None:
     app.mount("/mcp", _mcp_app)

--- a/backend/app/mcp/admin/__init__.py
+++ b/backend/app/mcp/admin/__init__.py
@@ -18,6 +18,26 @@ Convention for partial updates (mirrors the REST ``*Update`` schemas):
 Domain errors (not found, conflict, invalid input) are raised as plain
 ``ValueError`` — there is no HTTP response to hang a status code off, and
 FastMCP surfaces the exception message to the calling agent either way.
+
+Shared-service extraction (issue #807)
+---------------------------------------
+Validation, locking, cascade guards, and audit-detail construction are being
+moved out of this package and its ``app.routers`` counterpart into
+``app/services/<domain>_service.py`` modules, so both surfaces call the same
+code instead of maintaining parallel copies (see ``app/services/errors.py``
+for the shared exception convention). Both this module and its REST router
+become thin adapters around the service.
+
+Migrated so far: ``layouts``, ``tables``, ``areas``, ``venues``, ``rooms``,
+``table_types``.
+
+Not yet migrated (still duplicated between this package and
+``app.routers``): ``editions``, ``events``, ``exhibitors``, ``faq``,
+``members``, ``people``, ``registrations``, ``settings``, ``volunteers``.
+``audit`` is read-only and has no mutation logic to share. Follow the pattern
+in ``app/services/layouts_service.py`` (the most complex migrated domain) or
+``app/services/venues_service.py`` (a simpler CRUD-with-cascade-guard
+example) when migrating the rest.
 """
 
 from __future__ import annotations

--- a/backend/app/mcp/admin/areas.py
+++ b/backend/app/mcp/admin/areas.py
@@ -1,19 +1,17 @@
 """Admin (write) MCP tool implementations for floor-plan area management.
 
-Mirrors ``app.routers.areas``.
+Mirrors ``app.routers.areas``. Business logic lives in
+``app.services.areas_service`` and is shared with the REST router.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import select
-
-from app.audit import write_audit_entry
-from app.mcp.utils import get_or_error, validate_with_schema
-from app.models import Area, Exhibitor, Layout
+from app.mcp.utils import validate_with_schema
 from app.schemas import AreaCreate, AreaUpdate
-from app.utils import area_to_dict, make_id
+from app.services import areas_service
+from app.services.errors import ServiceError
 
 
 async def create_area(
@@ -43,57 +41,23 @@ async def create_area(
         rotation=rotation,
     )
     async with session_factory() as db:
-        lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
-        if lay.scalar_one_or_none() is None:
-            raise ValueError(f"Layout '{body.layout_id}' not found.")
-
-        if body.exhibitor_id is not None:
-            ex = await db.execute(select(Exhibitor).where(Exhibitor.id == body.exhibitor_id))
-            exhibitor = ex.scalar_one_or_none()
-            if exhibitor is None:
-                raise ValueError(f"Exhibitor '{body.exhibitor_id}' not found.")
-            if not exhibitor.active:
-                raise ValueError(f"Exhibitor '{body.exhibitor_id}' is inactive.")
-
-        a = Area(
-            id=make_id("area"),
-            layout_id=body.layout_id,
-            label=body.label,
-            icon=body.icon,
-            exhibitor_id=body.exhibitor_id,
-            width_m=body.width_m,
-            length_m=body.length_m,
-            x=body.x,
-            y=body.y,
-            rotation=body.rotation,
-        )
-        db.add(a)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="area_created",
-            resource_type="area",
-            resource_id=a.id,
-            details={"label": a.label, "layout_id": a.layout_id},
-        )
-        await db.commit()
-        await db.refresh(a)
-        return area_to_dict(a)
+        try:
+            return await areas_service.create_area(db, actor=actor, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def list_areas(session_factory: Any, layout_id: str | None = None) -> dict:
     async with session_factory() as db:
-        stmt = select(Area).order_by(Area.created_at)
-        if layout_id:
-            stmt = stmt.where(Area.layout_id == layout_id)
-        result = await db.execute(stmt)
-        return {"areas": [area_to_dict(a) for a in result.scalars().all()]}
+        return {"areas": await areas_service.list_areas(db, layout_id)}
 
 
 async def get_area(session_factory: Any, area_id: str) -> dict:
     async with session_factory() as db:
-        a = await get_or_error(db, Area, area_id, f"Area '{area_id}' not found.")
-        return area_to_dict(a)
+        try:
+            return await areas_service.get_area(db, area_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def update_area(
@@ -138,56 +102,15 @@ async def update_area(
 
     body = validate_with_schema(AreaUpdate, **provided)
     async with session_factory() as db:
-        a = await get_or_error(db, Area, area_id, f"Area '{area_id}' not found.")
-
-        if body.label is not None:
-            a.label = body.label
-        if body.icon is not None:
-            a.icon = body.icon
-        if body.x is not None:
-            a.x = body.x
-        if body.y is not None:
-            a.y = body.y
-        if body.width_m is not None:
-            a.width_m = body.width_m
-        if body.length_m is not None:
-            a.length_m = body.length_m
-        if body.rotation is not None:
-            a.rotation = body.rotation
-        if "exhibitor_id" in body.model_fields_set:
-            if body.exhibitor_id is not None:
-                ex = await db.execute(select(Exhibitor).where(Exhibitor.id == body.exhibitor_id))
-                exhibitor = ex.scalar_one_or_none()
-                if exhibitor is None:
-                    raise ValueError("Exhibitor not found.")
-                if not exhibitor.active:
-                    raise ValueError("Exhibitor is inactive.")
-            a.exhibitor_id = body.exhibitor_id
-
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="area_updated",
-            resource_type="area",
-            resource_id=a.id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        await db.commit()
-        await db.refresh(a)
-        return area_to_dict(a)
+        try:
+            return await areas_service.update_area(db, actor=actor, area_id=area_id, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def delete_area(session_factory: Any, actor: str, area_id: str) -> dict:
     async with session_factory() as db:
-        a = await get_or_error(db, Area, area_id, f"Area '{area_id}' not found.")
-        await db.delete(a)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="area_deleted",
-            resource_type="area",
-            resource_id=area_id,
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": area_id}
+        try:
+            return await areas_service.delete_area(db, actor=actor, area_id=area_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc

--- a/backend/app/mcp/admin/audit.py
+++ b/backend/app/mcp/admin/audit.py
@@ -22,6 +22,9 @@ def _entry_to_dict(entry: AuditEntry) -> dict:
         "id": entry.id,
         "timestamp": entry.timestamp.isoformat(),
         "actor": entry.actor,
+        "auth_source": entry.auth_source,
+        "subject": entry.subject,
+        "integration_client_id": entry.integration_client_id,
         "action": entry.action,
         "resource_type": entry.resource_type,
         "resource_id": entry.resource_id,
@@ -41,6 +44,7 @@ async def list_audit_entries(
     until: str | None = None,
     limit: int | None = None,
     offset: int = 0,
+    before_id: str | None = None,
 ) -> dict:
     """List audit entries, newest first, with optional filters.
 
@@ -74,13 +78,27 @@ async def list_audit_entries(
             if until_dt.tzinfo is None:
                 until_dt = until_dt.replace(tzinfo=UTC)
             stmt = stmt.where(AuditEntry.timestamp <= until_dt)
+        if before_id is not None:
+            cursor = await db.get(AuditEntry, before_id)
+            if cursor is None:
+                raise ValueError("audit cursor does not exist")
+            stmt = stmt.where(
+                (AuditEntry.timestamp < cursor.timestamp)
+                | ((AuditEntry.timestamp == cursor.timestamp) & (AuditEntry.id < cursor.id))
+            )
         # Secondary sort key: entries written in the same transaction can share a
         # timestamp, and an unstable order would let offset-based paging repeat
         # or skip rows across calls.
         stmt = stmt.order_by(AuditEntry.timestamp.desc(), AuditEntry.id.desc())
-        stmt = stmt.offset(offset).limit(effective_limit)
+        if before_id is None:
+            stmt = stmt.offset(offset)
+        stmt = stmt.limit(effective_limit)
         result = await db.execute(stmt)
-        return {"entries": [_entry_to_dict(e) for e in result.scalars().all()]}
+        entries = list(result.scalars().all())
+        return {
+            "entries": [_entry_to_dict(entry) for entry in entries],
+            "next_before_id": entries[-1].id if len(entries) == effective_limit else None,
+        }
 
 
 async def list_audit_resource_types(session_factory: Any) -> dict:

--- a/backend/app/mcp/admin/integration_clients.py
+++ b/backend/app/mcp/admin/integration_clients.py
@@ -1,0 +1,58 @@
+"""Admin (write) MCP tool implementations for managed integration clients.
+
+Mirrors ``app.routers.integration_clients``. Business logic lives in
+``app.services.integration_clients_service`` and is shared with the REST
+router — see issue #807.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services import integration_clients_service as ics
+from app.services.errors import ServiceError
+
+
+async def create_integration_client(
+    session_factory: Any,
+    actor: str,
+    *,
+    name: str,
+    allowed_role: str,
+    rate_limit_per_minute: int = ics.DEFAULT_RATE_LIMIT_PER_MINUTE,
+) -> dict:
+    async with session_factory() as db:
+        try:
+            client_dict, raw_key = await ics.create_integration_client(
+                db,
+                actor=actor,
+                creator_role="admin",  # _require_admin() already gated this call
+                name=name,
+                allowed_role=allowed_role,
+                rate_limit_per_minute=rate_limit_per_minute,
+            )
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
+        return {**client_dict, "key": raw_key}
+
+
+async def list_integration_clients(session_factory: Any) -> dict:
+    async with session_factory() as db:
+        return {"integration_clients": await ics.list_integration_clients(db)}
+
+
+async def revoke_integration_client(session_factory: Any, actor: str, client_id: str) -> dict:
+    async with session_factory() as db:
+        try:
+            return await ics.revoke_integration_client(db, actor=actor, client_id=client_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
+
+
+async def rotate_integration_client(session_factory: Any, actor: str, client_id: str) -> dict:
+    async with session_factory() as db:
+        try:
+            client_dict, raw_key = await ics.rotate_integration_client(db, actor=actor, client_id=client_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
+        return {**client_dict, "key": raw_key}

--- a/backend/app/mcp/admin/layouts.py
+++ b/backend/app/mcp/admin/layouts.py
@@ -67,9 +67,7 @@ async def copy_layout(
     )
     async with session_factory() as db:
         try:
-            return await layouts_service.copy_layout(
-                db, actor=actor, source_layout_id=source_layout_id, body=body
-            )
+            return await layouts_service.copy_layout(db, actor=actor, source_layout_id=source_layout_id, body=body)
         except ServiceError as exc:
             raise ValueError(str(exc)) from exc
 

--- a/backend/app/mcp/admin/layouts.py
+++ b/backend/app/mcp/admin/layouts.py
@@ -1,10 +1,9 @@
 """Admin (write) MCP tool implementations for floor-plan layout management.
 
-Mirrors ``app.routers.layouts``. ``copy_layout`` reuses the router's geometry
-helpers directly (``_table_in_any_area``, ``_resolve_layout_day``) rather than
-re-deriving the pixel-space containment math, so floor-plan copies classify
-tables inside/outside areas identically to the REST endpoint and the
-frontend editor.
+Mirrors ``app.routers.layouts``. Business logic lives in
+``app.services.layouts_service`` and is shared with the REST router — this
+module validates MCP-style keyword arguments into the same Pydantic schema
+REST uses, then delegates and translates ``ServiceError`` into ``ValueError``.
 """
 
 from __future__ import annotations
@@ -12,15 +11,10 @@ from __future__ import annotations
 from datetime import date as dt_date
 from typing import Any
 
-from fastapi import HTTPException
-from sqlalchemy import select
-
-from app.audit import write_audit_entry
-from app.mcp.utils import as_value_error, get_or_error, validate_with_schema
-from app.models import Area, Exhibitor, Layout, Room, Table, TableType
-from app.routers.layouts import _layout_payloads, _resolve_layout_day, _table_in_any_area
+from app.mcp.utils import validate_with_schema
 from app.schemas import LayoutCopyCreate, LayoutCreate
-from app.utils import layout_to_dict, make_id
+from app.services import layouts_service
+from app.services.errors import ServiceError
 
 
 async def create_layout(
@@ -43,54 +37,9 @@ async def create_layout(
     )
     async with session_factory() as db:
         try:
-            resolved_day_id, resolved_date = await _resolve_layout_day(db, body)
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-
-        # Lock the room row so a concurrent room deletion (which refuses to proceed
-        # while layouts reference the room) can't race this insert: whichever
-        # transaction locks the room first is the one the other serializes behind.
-        # Also doubles as the room-existence check — an unchecked bogus room_id
-        # would otherwise surface as a raw FK IntegrityError instead of a clean
-        # ValueError, unlike every other create tool in this module.
-        locked_room = (
-            await db.execute(select(Room.id).where(Room.id == body.room_id).with_for_update())
-        ).scalar_one_or_none()
-        if locked_room is None:
-            raise ValueError(f"Room '{body.room_id}' not found.")
-
-        existing_stmt = select(Layout).where(
-            Layout.room_id == body.room_id,
-            Layout.day_id == resolved_day_id,
-        )
-        if body.edition_id is None:
-            existing_stmt = existing_stmt.where(Layout.edition_id.is_(None))
-        else:
-            existing_stmt = existing_stmt.where(Layout.edition_id == body.edition_id)
-
-        existing = (await db.execute(existing_stmt.limit(1))).scalar_one_or_none()
-        if existing is not None:
-            raise ValueError("A layout already exists for this room and day.")
-
-        lay = Layout(
-            id=make_id("lay"),
-            edition_id=body.edition_id,
-            room_id=body.room_id,
-            day_id=resolved_day_id,
-            label=body.label.strip(),
-        )
-        db.add(lay)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="layout_created",
-            resource_type="layout",
-            resource_id=lay.id,
-            details={"room_id": lay.room_id, "day_id": lay.day_id},
-        )
-        await db.commit()
-        await db.refresh(lay)
-        return layout_to_dict(lay, date=resolved_date)
+            return await layouts_service.create_layout(db, actor=actor, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def copy_layout(
@@ -117,170 +66,30 @@ async def copy_layout(
         copy_areas=copy_areas,
     )
     async with session_factory() as db:
-        source = await get_or_error(db, Layout, source_layout_id, f"Layout '{source_layout_id}' not found.")
         try:
-            resolved_day_id, resolved_date = await _resolve_layout_day(db, body)
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-
-        # See create_layout: lock the target room (also doubling as the
-        # existence check) so it can't be deleted out from under this insert.
-        locked_target_room = (
-            await db.execute(select(Room.id).where(Room.id == body.room_id).with_for_update())
-        ).scalar_one_or_none()
-        if locked_target_room is None:
-            raise ValueError(f"Room '{body.room_id}' not found.")
-
-        existing_stmt = select(Layout).where(
-            Layout.room_id == body.room_id,
-            Layout.day_id == resolved_day_id,
-        )
-        if body.edition_id is None:
-            existing_stmt = existing_stmt.where(Layout.edition_id.is_(None))
-        else:
-            existing_stmt = existing_stmt.where(Layout.edition_id == body.edition_id)
-        existing = (await db.execute(existing_stmt.limit(1))).scalar_one_or_none()
-        if existing is not None:
-            raise ValueError("A layout already exists for this room and day.")
-
-        room_stmt = select(Room).where(Room.id == source.room_id)
-        source_room = (await db.execute(room_stmt)).scalar_one_or_none()
-        if source_room is None:
-            raise ValueError("Source room not found.")
-
-        source_tables = (await db.execute(select(Table).where(Table.layout_id == source_layout_id))).scalars().all()
-        source_areas = (await db.execute(select(Area).where(Area.layout_id == source_layout_id))).scalars().all()
-
-        table_type_ids = {t.table_type_id for t in source_tables}
-        table_types: dict[str, TableType] = {}
-        if table_type_ids:
-            result = await db.execute(select(TableType).where(TableType.id.in_(table_type_ids)))
-            table_types = {tt.id: tt for tt in result.scalars().all()}
-
-        cloned = Layout(
-            id=make_id("lay"),
-            edition_id=body.edition_id,
-            room_id=body.room_id,
-            day_id=resolved_day_id,
-            label=body.label.strip(),
-        )
-        db.add(cloned)
-        await db.flush()
-
-        # Tables inside areas travel with copy_areas; tables outside areas travel with copy_tables.
-        all_areas = list(source_areas)
-        tables_inside: list[Table] = []
-        if body.copy_areas and all_areas:
-            tables_inside = [
-                table for table in source_tables if _table_in_any_area(table, all_areas, table_types, source_room)
-            ]
-
-        tables_outside: list[Table] = []
-        if body.copy_tables:
-            if body.copy_areas and all_areas:
-                tables_outside = [
-                    table
-                    for table in source_tables
-                    if not _table_in_any_area(table, all_areas, table_types, source_room)
-                ]
-            else:
-                tables_outside = list(source_tables)
-
-        tables_to_copy = tables_inside + tables_outside
-
-        for table in tables_to_copy:
-            db.add(
-                Table(
-                    id=make_id("tbl"),
-                    name=table.name,
-                    capacity=table.capacity,
-                    x=table.x,
-                    y=table.y,
-                    table_type_id=table.table_type_id,
-                    rotation=table.rotation,
-                    layout_id=cloned.id,
-                    reservation_ids=[],
-                )
+            return await layouts_service.copy_layout(
+                db, actor=actor, source_layout_id=source_layout_id, body=body
             )
-
-        if body.copy_areas:
-            # An area whose exhibitor was deactivated after the source area was
-            # created (or last updated) must not be silently carried into the copy —
-            # create_area/update_area both refuse to assign an inactive exhibitor,
-            # so the copy path can't create areas those tools would reject.
-            exhibitor_ids = {area.exhibitor_id for area in source_areas if area.exhibitor_id is not None}
-            if exhibitor_ids:
-                active_result = await db.execute(
-                    select(Exhibitor.id).where(Exhibitor.id.in_(exhibitor_ids), Exhibitor.active.is_(True))
-                )
-                active_ids = set(active_result.scalars().all())
-                inactive_ids = sorted(exhibitor_ids - active_ids)
-                if inactive_ids:
-                    raise ValueError(
-                        "Cannot copy: the following areas reference an inactive or "
-                        f"deleted exhibitor: {inactive_ids}. Update those areas first."
-                    )
-            for area in source_areas:
-                db.add(
-                    Area(
-                        id=make_id("area"),
-                        layout_id=cloned.id,
-                        label=area.label,
-                        icon=area.icon,
-                        exhibitor_id=area.exhibitor_id,
-                        width_m=area.width_m,
-                        length_m=area.length_m,
-                        x=area.x,
-                        y=area.y,
-                        rotation=area.rotation,
-                    )
-                )
-
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="layout_copied",
-            resource_type="layout",
-            resource_id=cloned.id,
-            details={"source_layout_id": source_layout_id, "room_id": cloned.room_id, "day_id": cloned.day_id},
-        )
-        await db.commit()
-        await db.refresh(cloned)
-        return layout_to_dict(cloned, date=resolved_date)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def list_layouts(session_factory: Any) -> dict:
     async with session_factory() as db:
-        result = await db.execute(select(Layout).order_by(Layout.created_at))
-        layouts = list(result.scalars().all())
-        return {"layouts": await _layout_payloads(db, layouts)}
+        return {"layouts": await layouts_service.list_layouts(db)}
 
 
 async def get_layout(session_factory: Any, layout_id: str) -> dict:
     async with session_factory() as db:
-        lay = await get_or_error(db, Layout, layout_id, f"Layout '{layout_id}' not found.")
-        payloads = await _layout_payloads(db, [lay])
-        return payloads[0]
+        try:
+            return await layouts_service.get_layout(db, layout_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def delete_layout(session_factory: Any, actor: str, layout_id: str) -> dict:
     async with session_factory() as db:
-        lay = await get_or_error(db, Layout, layout_id, f"Layout '{layout_id}' not found.")
-        # Lock the layout row so a concurrent table creation/copy (which validates
-        # the layout exists before inserting) can't race this delete: whichever
-        # transaction locks the layout first is the one the other serializes behind.
-        await db.execute(select(Layout.id).where(Layout.id == layout_id).with_for_update())
-        tables_in_use = await db.execute(select(Table).where(Table.layout_id == layout_id).limit(1))
-        if tables_in_use.scalars().first() is not None:
-            raise ValueError("Cannot delete: tables are still assigned to this layout.")
-        await db.delete(lay)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="layout_deleted",
-            resource_type="layout",
-            resource_id=layout_id,
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": layout_id}
+        try:
+            return await layouts_service.delete_layout(db, actor=actor, layout_id=layout_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc

--- a/backend/app/mcp/admin/rooms.py
+++ b/backend/app/mcp/admin/rooms.py
@@ -1,19 +1,17 @@
 """Admin (write) MCP tool implementations for room management.
 
-Mirrors ``app.routers.rooms``.
+Mirrors ``app.routers.rooms``. Business logic lives in
+``app.services.rooms_service`` and is shared with the REST router.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import select
-
-from app.audit import write_audit_entry
-from app.mcp.utils import get_or_error, validate_with_schema
-from app.models import Layout, Room, Venue
+from app.mcp.utils import validate_with_schema
 from app.schemas import RoomCreate, RoomUpdate
-from app.utils import make_id, room_to_dict
+from app.services import rooms_service
+from app.services.errors import ServiceError
 
 
 async def create_room(
@@ -37,43 +35,23 @@ async def create_room(
         active=active,
     )
     async with session_factory() as db:
-        venue = await db.execute(select(Venue).where(Venue.id == body.venue_id))
-        if venue.scalar_one_or_none() is None:
-            raise ValueError(f"Venue '{body.venue_id}' not found.")
-
-        r = Room(
-            id=make_id("room"),
-            venue_id=body.venue_id,
-            name=body.name,
-            width_m=body.width_m,
-            length_m=body.length_m,
-            color=body.color,
-            active=body.active,
-        )
-        db.add(r)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="room_created",
-            resource_type="room",
-            resource_id=r.id,
-            details={"name": r.name, "venue_id": r.venue_id},
-        )
-        await db.commit()
-        await db.refresh(r)
-        return room_to_dict(r)
+        try:
+            return await rooms_service.create_room(db, actor=actor, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def list_rooms(session_factory: Any) -> dict:
     async with session_factory() as db:
-        result = await db.execute(select(Room).order_by(Room.created_at))
-        return {"rooms": [room_to_dict(r) for r in result.scalars().all()]}
+        return {"rooms": await rooms_service.list_rooms(db)}
 
 
 async def get_room(session_factory: Any, room_id: str) -> dict:
     async with session_factory() as db:
-        r = await get_or_error(db, Room, room_id, f"Room '{room_id}' not found.")
-        return room_to_dict(r)
+        try:
+            return await rooms_service.get_room(db, room_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def update_room(
@@ -100,40 +78,15 @@ async def update_room(
     }
     body = validate_with_schema(RoomUpdate, **provided)
     async with session_factory() as db:
-        r = await get_or_error(db, Room, room_id, f"Room '{room_id}' not found.")
-        for field in body.model_fields_set:
-            setattr(r, field, getattr(body, field))
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="room_updated",
-            resource_type="room",
-            resource_id=r.id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        await db.commit()
-        await db.refresh(r)
-        return room_to_dict(r)
+        try:
+            return await rooms_service.update_room(db, actor=actor, room_id=room_id, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def delete_room(session_factory: Any, actor: str, room_id: str) -> dict:
     async with session_factory() as db:
-        r = await get_or_error(db, Room, room_id, f"Room '{room_id}' not found.")
-        # Lock the room row so a concurrent layout creation (see layouts.create_layout
-        # and copy_layout) can't insert a new layout for this room between our check
-        # and the delete below, which would otherwise cascade-delete it silently.
-        await db.execute(select(Room.id).where(Room.id == room_id).with_for_update())
-        layouts_in_use = await db.execute(select(Layout).where(Layout.room_id == room_id).limit(1))
-        if layouts_in_use.scalars().first() is not None:
-            raise ValueError("Cannot delete: layouts are still using this room.")
-        await db.delete(r)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="room_deleted",
-            resource_type="room",
-            resource_id=room_id,
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": room_id}
+        try:
+            return await rooms_service.delete_room(db, actor=actor, room_id=room_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc

--- a/backend/app/mcp/admin/table_types.py
+++ b/backend/app/mcp/admin/table_types.py
@@ -37,7 +37,10 @@ async def create_table_type(
         active=active,
     )
     async with session_factory() as db:
-        return await table_types_service.create_table_type(db, actor=actor, body=body)
+        try:
+            return await table_types_service.create_table_type(db, actor=actor, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def list_table_types(session_factory: Any) -> dict:

--- a/backend/app/mcp/admin/table_types.py
+++ b/backend/app/mcp/admin/table_types.py
@@ -1,19 +1,17 @@
 """Admin (write) MCP tool implementations for table type management.
 
-Mirrors ``app.routers.table_types``.
+Mirrors ``app.routers.table_types``. Business logic lives in
+``app.services.table_types_service`` and is shared with the REST router.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import select
-
-from app.audit import write_audit_entry
-from app.mcp.utils import get_or_error, validate_with_schema
-from app.models import Table, TableType
+from app.mcp.utils import validate_with_schema
 from app.schemas import TableTypeCreate, TableTypeUpdate
-from app.utils import make_id, table_type_to_dict
+from app.services import table_types_service
+from app.services.errors import ServiceError
 
 
 async def create_table_type(
@@ -28,10 +26,6 @@ async def create_table_type(
     max_capacity: int,
     active: bool = True,
 ) -> dict:
-    # TableTypeCreate.normalise_dimensions (a model_validator) forces
-    # length_m == width_m for round tables and swaps them if length_m <
-    # width_m for rectangular ones — running it here (rather than passing raw
-    # kwargs to the ORM row below) keeps that behaviour identical to REST.
     body = validate_with_schema(
         TableTypeCreate,
         name=name,
@@ -43,40 +37,20 @@ async def create_table_type(
         active=active,
     )
     async with session_factory() as db:
-        tt = TableType(
-            id=make_id("ttype"),
-            name=body.name,
-            shape=body.shape,
-            width_m=body.width_m,
-            length_m=body.length_m,
-            height_type=body.height_type,
-            max_capacity=body.max_capacity,
-            active=body.active,
-        )
-        db.add(tt)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="table_type_created",
-            resource_type="table_type",
-            resource_id=tt.id,
-            details={"name": tt.name, "shape": tt.shape},
-        )
-        await db.commit()
-        await db.refresh(tt)
-        return table_type_to_dict(tt)
+        return await table_types_service.create_table_type(db, actor=actor, body=body)
 
 
 async def list_table_types(session_factory: Any) -> dict:
     async with session_factory() as db:
-        result = await db.execute(select(TableType).order_by(TableType.created_at))
-        return {"table_types": [table_type_to_dict(tt) for tt in result.scalars().all()]}
+        return {"table_types": await table_types_service.list_table_types(db)}
 
 
 async def get_table_type(session_factory: Any, type_id: str) -> dict:
     async with session_factory() as db:
-        tt = await get_or_error(db, TableType, type_id, f"Table type '{type_id}' not found.")
-        return table_type_to_dict(tt)
+        try:
+            return await table_types_service.get_table_type(db, type_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def update_table_type(
@@ -107,60 +81,15 @@ async def update_table_type(
     }
     body = validate_with_schema(TableTypeUpdate, **provided)
     async with session_factory() as db:
-        tt = await get_or_error(db, TableType, type_id, f"Table type '{type_id}' not found.")
-        if body.name is not None:
-            tt.name = body.name
-        if body.shape is not None:
-            tt.shape = body.shape
-        if body.width_m is not None:
-            tt.width_m = body.width_m
-        if body.length_m is not None:
-            tt.length_m = body.length_m
-        # TableTypeUpdate has no model_validator (unlike TableTypeCreate), so the
-        # router re-derives the same dimension normalisation by hand after
-        # applying fields; replicate that here rather than relying on the schema.
-        if body.shape is not None or body.width_m is not None or body.length_m is not None:
-            if tt.shape == "round":
-                tt.length_m = tt.width_m
-            elif tt.length_m < tt.width_m:
-                tt.length_m, tt.width_m = tt.width_m, tt.length_m
-        if body.height_type is not None:
-            tt.height_type = body.height_type
-        if body.max_capacity is not None:
-            tt.max_capacity = body.max_capacity
-        if body.active is not None:
-            tt.active = body.active
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="table_type_updated",
-            resource_type="table_type",
-            resource_id=tt.id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        await db.commit()
-        await db.refresh(tt)
-        return table_type_to_dict(tt)
+        try:
+            return await table_types_service.update_table_type(db, actor=actor, type_id=type_id, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def delete_table_type(session_factory: Any, actor: str, type_id: str) -> dict:
     async with session_factory() as db:
-        tt = await get_or_error(db, TableType, type_id, f"Table type '{type_id}' not found.")
-        # Lock the table type row so a concurrent table creation (which validates
-        # the type exists before inserting) can't race this delete: whichever
-        # transaction locks the type first is the one the other serializes behind.
-        await db.execute(select(TableType.id).where(TableType.id == type_id).with_for_update())
-        in_use = await db.execute(select(Table).where(Table.table_type_id == type_id).limit(1))
-        if in_use.scalars().first() is not None:
-            raise ValueError("Cannot delete: tables are still using this type.")
-        await db.delete(tt)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="table_type_deleted",
-            resource_type="table_type",
-            resource_id=type_id,
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": type_id}
+        try:
+            return await table_types_service.delete_table_type(db, actor=actor, type_id=type_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc

--- a/backend/app/mcp/admin/tables.py
+++ b/backend/app/mcp/admin/tables.py
@@ -1,30 +1,17 @@
 """Admin (write) MCP tool implementations for table management.
 
-Mirrors ``app.routers.tables``.
+Mirrors ``app.routers.tables``. Business logic lives in
+``app.services.tables_service`` and is shared with the REST router.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.audit import write_audit_entry
-from app.live import live_bus
-from app.live import mapping as live_mapping
-from app.mcp.utils import get_or_error, validate_with_schema
-from app.models import Layout, Registration, Table, TableType
+from app.mcp.utils import validate_with_schema
 from app.schemas import TableCreate, TableUpdate
-from app.utils import make_id, table_to_dict
-
-logger = logging.getLogger(__name__)
-
-
-async def _get_layout_edition_id(db: AsyncSession, layout_id: str) -> str | None:
-    result = await db.execute(select(Layout.edition_id).where(Layout.id == layout_id))
-    return result.scalar_one_or_none()
+from app.services import tables_service
+from app.services.errors import ServiceError
 
 
 async def create_table(
@@ -50,67 +37,23 @@ async def create_table(
         layout_id=layout_id,
     )
     async with session_factory() as db:
-        tt = await db.execute(select(TableType).where(TableType.id == body.table_type_id))
-        if tt.scalar_one_or_none() is None:
-            raise ValueError(f"TableType '{body.table_type_id}' not found.")
-        lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
-        if lay.scalar_one_or_none() is None:
-            raise ValueError(f"Layout '{body.layout_id}' not found.")
-
-        t = Table(
-            id=make_id("tbl"),
-            name=body.name,
-            capacity=body.capacity,
-            x=body.x,
-            y=body.y,
-            table_type_id=body.table_type_id,
-            rotation=body.rotation,
-            layout_id=body.layout_id,
-        )
-        t.reservation_ids = []
-        db.add(t)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="table_created",
-            resource_type="table",
-            resource_id=t.id,
-            details={"layout_id": t.layout_id, "name": t.name},
-        )
-        await db.commit()
-        await db.refresh(t)
-        edition_id = await _get_layout_edition_id(db, t.layout_id)
         try:
-            await live_bus.publish(live_mapping.seating_changed(action="created", table_id=t.id, edition_id=edition_id))
-        except Exception:
-            logger.warning("live_bus.publish failed for table %s", t.id, exc_info=True)
-        # New tables have no reservations yet
-        return table_to_dict(t, [])
+            return await tables_service.create_table(db, actor=actor, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def list_tables(session_factory: Any) -> dict:
     async with session_factory() as db:
-        result = await db.execute(select(Table).order_by(Table.created_at))
-        tables = result.scalars().all()
-
-        table_res_map: dict[str, list[str]] = {}
-        table_ids = [t.id for t in tables]
-        if table_ids:
-            res_result = await db.execute(
-                select(Registration.id, Registration.table_id).where(Registration.table_id.in_(table_ids))
-            )
-            for res_id, tbl_id in res_result.all():
-                table_res_map.setdefault(tbl_id, []).append(res_id)
-
-        return {"tables": [table_to_dict(t, table_res_map.get(t.id, [])) for t in tables]}
+        return {"tables": await tables_service.list_tables(db)}
 
 
 async def get_table(session_factory: Any, table_id: str) -> dict:
     async with session_factory() as db:
-        t = await get_or_error(db, Table, table_id, f"Table '{table_id}' not found.")
-        res_result = await db.execute(select(Registration.id).where(Registration.table_id == table_id))
-        registration_ids = [row[0] for row in res_result.all()]
-        return table_to_dict(t, registration_ids)
+        try:
+            return await tables_service.get_table(db, table_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def update_table(
@@ -141,69 +84,15 @@ async def update_table(
     }
     body = validate_with_schema(TableUpdate, **provided)
     async with session_factory() as db:
-        t = await get_or_error(db, Table, table_id, f"Table '{table_id}' not found.")
-
-        if body.name is not None:
-            t.name = body.name
-        if body.capacity is not None:
-            t.capacity = body.capacity
-        if body.x is not None:
-            t.x = body.x
-        if body.y is not None:
-            t.y = body.y
-        if body.table_type_id is not None:
-            tt = await db.execute(select(TableType).where(TableType.id == body.table_type_id))
-            if tt.scalar_one_or_none() is None:
-                raise ValueError(f"TableType '{body.table_type_id}' not found.")
-            t.table_type_id = body.table_type_id
-        if "rotation" in body.model_fields_set and body.rotation is not None:
-            t.rotation = body.rotation
-        if "layout_id" in body.model_fields_set and body.layout_id is not None:
-            lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
-            if lay.scalar_one_or_none() is None:
-                raise ValueError(f"Layout '{body.layout_id}' not found.")
-            t.layout_id = body.layout_id
-
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="table_updated",
-            resource_type="table",
-            resource_id=table_id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        await db.commit()
-        await db.refresh(t)
-        edition_id = await _get_layout_edition_id(db, t.layout_id)
         try:
-            await live_bus.publish(
-                live_mapping.seating_changed(action="updated", table_id=table_id, edition_id=edition_id)
-            )
-        except Exception:
-            logger.warning("live_bus.publish failed for table %s", table_id, exc_info=True)
-        res_result = await db.execute(select(Registration.id).where(Registration.table_id == table_id))
-        registration_ids = [row[0] for row in res_result.all()]
-        return table_to_dict(t, registration_ids)
+            return await tables_service.update_table(db, actor=actor, table_id=table_id, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def delete_table(session_factory: Any, actor: str, table_id: str) -> dict:
     async with session_factory() as db:
-        t = await get_or_error(db, Table, table_id, f"Table '{table_id}' not found.")
-        edition_id = await _get_layout_edition_id(db, t.layout_id)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="table_deleted",
-            resource_type="table",
-            resource_id=table_id,
-            details={"layout_id": t.layout_id, "name": t.name},
-        )
-        await db.delete(t)
-        await db.commit()
         try:
-            await live_bus.publish(
-                live_mapping.seating_changed(action="deleted", table_id=table_id, edition_id=edition_id)
-            )
-        except Exception:
-            logger.warning("live_bus.publish failed for deleted table %s", table_id, exc_info=True)
-        return {"deleted": True, "id": table_id}
+            return await tables_service.delete_table(db, actor=actor, table_id=table_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc

--- a/backend/app/mcp/admin/venues.py
+++ b/backend/app/mcp/admin/venues.py
@@ -39,7 +39,10 @@ async def create_venue(
         active=active,
     )
     async with session_factory() as db:
-        return await venues_service.create_venue(db, actor=actor, body=body)
+        try:
+            return await venues_service.create_venue(db, actor=actor, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def list_venues(session_factory: Any) -> dict:

--- a/backend/app/mcp/admin/venues.py
+++ b/backend/app/mcp/admin/venues.py
@@ -1,19 +1,17 @@
 """Admin (write) MCP tool implementations for venue management.
 
-Mirrors ``app.routers.venues``.
+Mirrors ``app.routers.venues``. Business logic lives in
+``app.services.venues_service`` and is shared with the REST router.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import select
-
-from app.audit import write_audit_entry
-from app.mcp.utils import get_or_error, validate_with_schema
-from app.models import Edition, Room, Venue
+from app.mcp.utils import validate_with_schema
 from app.schemas import VenueCreate, VenueUpdate
-from app.utils import make_id, venue_to_dict
+from app.services import venues_service
+from app.services.errors import ServiceError
 
 
 async def create_venue(
@@ -41,41 +39,20 @@ async def create_venue(
         active=active,
     )
     async with session_factory() as db:
-        v = Venue(
-            id=make_id("venue"),
-            name=body.name,
-            address=body.address,
-            city=body.city,
-            postal_code=body.postal_code,
-            country=body.country,
-            lat=body.lat,
-            lng=body.lng,
-            active=body.active,
-        )
-        db.add(v)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="venue_created",
-            resource_type="venue",
-            resource_id=v.id,
-            details={"name": v.name},
-        )
-        await db.commit()
-        await db.refresh(v)
-        return venue_to_dict(v)
+        return await venues_service.create_venue(db, actor=actor, body=body)
 
 
 async def list_venues(session_factory: Any) -> dict:
     async with session_factory() as db:
-        result = await db.execute(select(Venue).order_by(Venue.created_at))
-        return {"venues": [venue_to_dict(v) for v in result.scalars().all()]}
+        return {"venues": await venues_service.list_venues(db)}
 
 
 async def get_venue(session_factory: Any, venue_id: str) -> dict:
     async with session_factory() as db:
-        v = await get_or_error(db, Venue, venue_id, f"Venue '{venue_id}' not found.")
-        return venue_to_dict(v)
+        try:
+            return await venues_service.get_venue(db, venue_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def update_venue(
@@ -108,43 +85,15 @@ async def update_venue(
     }
     body = validate_with_schema(VenueUpdate, **provided)
     async with session_factory() as db:
-        v = await get_or_error(db, Venue, venue_id, f"Venue '{venue_id}' not found.")
-        for field in body.model_fields_set:
-            setattr(v, field, getattr(body, field))
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="venue_updated",
-            resource_type="venue",
-            resource_id=v.id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        await db.commit()
-        await db.refresh(v)
-        return venue_to_dict(v)
+        try:
+            return await venues_service.update_venue(db, actor=actor, venue_id=venue_id, body=body)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 async def delete_venue(session_factory: Any, actor: str, venue_id: str) -> dict:
     async with session_factory() as db:
-        v = await get_or_error(db, Venue, venue_id, f"Venue '{venue_id}' not found.")
-        # Lock the venue row so a concurrent edition/room creation (which validates
-        # the venue exists before inserting) can't race this delete: whichever
-        # transaction locks the venue first is the one the other serializes behind.
-        await db.execute(select(Venue.id).where(Venue.id == venue_id).with_for_update())
-        in_use = await db.execute(select(Edition).where(Edition.venue_id == venue_id).limit(1))
-        if in_use.scalars().first() is not None:
-            raise ValueError("Cannot delete: editions are still using this venue.")
-        rooms_in_use = await db.execute(select(Room).where(Room.venue_id == venue_id).limit(1))
-        if rooms_in_use.scalars().first() is not None:
-            raise ValueError("Cannot delete: rooms are still using this venue.")
-        await db.delete(v)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="venue_deleted",
-            resource_type="venue",
-            resource_id=venue_id,
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": venue_id}
+        try:
+            return await venues_service.delete_venue(db, actor=actor, venue_id=venue_id)
+        except ServiceError as exc:
+            raise ValueError(str(exc)) from exc

--- a/backend/app/mcp/auth.py
+++ b/backend/app/mcp/auth.py
@@ -1,0 +1,36 @@
+"""FastMCP authentication composition for Champagnefestival."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.config import settings
+
+
+def build_keycloak_auth(session_factory: async_sessionmaker | None = None) -> Any:
+    """Compose Keycloak and managed integration-client authentication."""
+    mcp_base_url = settings.mcp_base_url
+    if not mcp_base_url:
+        return None
+    if not settings.oidc_issuer_url:
+        raise RuntimeError("OIDC_ISSUER_URL is required when MCP_BASE_URL enables the HTTP MCP server")
+
+    from fastmcp.server.auth import MultiAuth
+    from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
+
+    from app.mcp.integration_auth import IntegrationKeyTokenVerifier
+
+    if session_factory is None:
+        from app.database import async_session_factory
+
+        session_factory = async_session_factory
+
+    keycloak_provider = KeycloakAuthProvider(
+        realm_url=settings.oidc_issuer_url,
+        base_url=mcp_base_url,
+        audience=settings.oidc_audience or None,
+        required_scopes=[],
+    )
+    return MultiAuth(server=keycloak_provider, verifiers=[IntegrationKeyTokenVerifier(session_factory)])

--- a/backend/app/mcp/capabilities.py
+++ b/backend/app/mcp/capabilities.py
@@ -1,0 +1,75 @@
+"""Authoritative MCP capability metadata derived from live registration."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from fastmcp import FastMCP
+
+from app.mcp.utils import ROLE_ADMIN, ROLE_PUBLIC, ROLE_VOLUNTEER
+
+TOOL_EFFECT_READ = "read"
+TOOL_EFFECT_WRITE = "write"
+
+# Explicit authentication allowlists. Unknown tools default to admin.
+PUBLIC_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "get_active_edition",
+        "list_editions",
+        "get_event_schedule",
+        "get_venue_plan_summary",
+        "get_settings",
+        "whoami",
+    }
+)
+
+VOLUNTEER_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "find_guest",
+        "get_guest_registration",
+        "get_table_seating",
+        "resolve_table_reference",
+        "get_table_order_summary",
+        "get_guest_order_status",
+        "get_champagne_delivery_summary",
+        "get_undelivered_champagne_by_table",
+        "get_check_in_summary",
+    }
+)
+
+_READ_PREFIXES = ("find_", "get_", "list_", "resolve_")
+
+
+class _NamedTool(Protocol):
+    name: str
+
+
+def tool_required_role(tool_name: str) -> str:
+    """Return a tool's minimum role, defaulting unknown tools to admin."""
+    if tool_name in PUBLIC_TOOL_NAMES:
+        return ROLE_PUBLIC
+    if tool_name in VOLUNTEER_TOOL_NAMES:
+        return ROLE_VOLUNTEER
+    return ROLE_ADMIN
+
+
+def tool_effect(tool_name: str) -> str:
+    """Classify side effects conservatively; unknown names default to write."""
+    if tool_name == "whoami" or tool_name.startswith(_READ_PREFIXES):
+        return TOOL_EFFECT_READ
+    return TOOL_EFFECT_WRITE
+
+
+async def get_mcp_capabilities(mcp: FastMCP) -> dict[str, object]:
+    """Build capability metadata from the server's live registered tools."""
+    tools: list[_NamedTool] = await mcp.list_tools()
+    return {
+        "tools": [
+            {
+                "name": tool.name,
+                "effect": tool_effect(tool.name),
+                "required_role": tool_required_role(tool.name),
+            }
+            for tool in sorted(tools, key=lambda tool: tool.name)
+        ],
+    }

--- a/backend/app/mcp/capabilities.py
+++ b/backend/app/mcp/capabilities.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Protocol
-
 from fastmcp import FastMCP
 
 from app.mcp.utils import ROLE_ADMIN, ROLE_PUBLIC, ROLE_VOLUNTEER
@@ -40,10 +38,6 @@ VOLUNTEER_TOOL_NAMES: frozenset[str] = frozenset(
 _READ_PREFIXES = ("find_", "get_", "list_", "resolve_")
 
 
-class _NamedTool(Protocol):
-    name: str
-
-
 def tool_required_role(tool_name: str) -> str:
     """Return a tool's minimum role, defaulting unknown tools to admin."""
     if tool_name in PUBLIC_TOOL_NAMES:
@@ -62,7 +56,7 @@ def tool_effect(tool_name: str) -> str:
 
 async def get_mcp_capabilities(mcp: FastMCP) -> dict[str, object]:
     """Build capability metadata from the server's live registered tools."""
-    tools: list[_NamedTool] = await mcp.list_tools()
+    tools = await mcp.list_tools()
     return {
         "tools": [
             {

--- a/backend/app/mcp/integration_auth.py
+++ b/backend/app/mcp/integration_auth.py
@@ -1,0 +1,52 @@
+"""FastMCP ``TokenVerifier`` for database-backed integration-client credentials.
+
+Combined with the Keycloak provider via ``MultiAuth`` in
+``app.mcp_server.build_keycloak_auth`` so an MCP caller can present either a
+Keycloak-issued JWT or an integration-client key — see issue #807.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastmcp.server.auth import AccessToken, TokenVerifier
+
+from app.services.integration_clients_service import authenticate_integration_client
+
+logger = logging.getLogger(__name__)
+
+
+class IntegrationKeyTokenVerifier(TokenVerifier):
+    """Verifies a bearer token against the ``integration_clients`` table.
+
+    On success, synthesises an ``AccessToken`` whose ``claims`` shape matches
+    a Keycloak-issued JWT closely enough that
+    ``ChampagneFestivalMcpBackend._resolve_role()``/``_actor()`` work
+    unchanged for both auth sources — no changes needed to any of the 80+
+    existing tool methods:
+    ``{"sub": "integration:<id>", "realm_access": {"roles": [allowed_role]}}``.
+    """
+
+    def __init__(self, session_factory: Any) -> None:
+        super().__init__()
+        self._session_factory = session_factory
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        async with self._session_factory() as db:
+            client = await authenticate_integration_client(db, token)
+            if client is None:
+                return None
+            subject = f"integration:{client.id}"
+            return AccessToken(
+                token=token,
+                client_id=subject,
+                scopes=[],
+                claims={
+                    "sub": subject,
+                    "realm_access": {"roles": [client.allowed_role]},
+                    "auth_source": "integration",
+                    "integration_client_id": client.id,
+                    "integration_client_name": client.name,
+                },
+            )

--- a/backend/app/mcp/utils.py
+++ b/backend/app/mcp/utils.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Edition, Person, Registration
+from app.services.errors import ServiceError
 
 ROLE_ADMIN = "admin"
 ROLE_VOLUNTEER = "volunteer"
@@ -50,15 +51,18 @@ def validate_with_schema(schema_cls: type[SchemaT], **kwargs: Any) -> SchemaT:
         raise ValueError("; ".join(messages)) from exc
 
 
-def as_value_error(exc: HTTPException) -> ValueError:
-    """Convert a reused router helper's ``HTTPException`` into a ``ValueError``.
+def as_value_error(exc: HTTPException | ServiceError) -> ValueError:
+    """Convert a reused router helper's error into a ``ValueError``.
 
     Several REST routers factor validation (existence checks, business rules) into
-    private helpers that raise ``HTTPException`` for FastAPI's benefit. Admin MCP tools
-    reuse those helpers rather than duplicating the logic, then convert here so every
-    error an MCP caller sees is a plain ``ValueError``.
+    private helpers that raise ``HTTPException`` for FastAPI's benefit; shared
+    ``app.services.*_service`` operations raise ``ServiceError`` instead so both
+    the REST and MCP adapters can translate the same exception. Admin MCP tools
+    reuse those helpers/services rather than duplicating the logic, then convert
+    here so every error an MCP caller sees is a plain ``ValueError``.
     """
-    return ValueError(exc.detail)
+    detail = exc.detail if isinstance(exc, HTTPException) else exc.message
+    return ValueError(detail)
 
 
 async def get_active_edition_obj(db: Any, edition_type: str | None = "festival") -> Edition | None:

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -1577,7 +1577,9 @@ class ChampagneFestivalMcpBackend:
     async def revoke_integration_client(self, client_id: str) -> dict:
         """Revoke (disable) a managed integration client. Requires the ``admin`` role."""
         self._require_admin()
-        return await mcp_admin_integration_clients.revoke_integration_client(self.session_factory, self._actor(), client_id)
+        return await mcp_admin_integration_clients.revoke_integration_client(
+            self.session_factory, self._actor(), client_id
+        )
 
     async def rotate_integration_client(self, client_id: str) -> dict:
         """Replace an active integration client's credential with a freshly generated one.
@@ -1586,7 +1588,9 @@ class ChampagneFestivalMcpBackend:
         Requires the ``admin`` role.
         """
         self._require_admin()
-        return await mcp_admin_integration_clients.rotate_integration_client(self.session_factory, self._actor(), client_id)
+        return await mcp_admin_integration_clients.rotate_integration_client(
+            self.session_factory, self._actor(), client_id
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -32,7 +32,6 @@ from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_access_token
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
-from app.config import settings
 from app.mcp import check_in as mcp_check_in
 from app.mcp import delivery as mcp_delivery
 from app.mcp import orders as mcp_orders
@@ -55,78 +54,16 @@ from app.mcp.admin import table_types as mcp_admin_table_types
 from app.mcp.admin import tables as mcp_admin_tables
 from app.mcp.admin import venues as mcp_admin_venues
 from app.mcp.admin import volunteers as mcp_admin_volunteers
-from app.mcp.utils import ROLE_ADMIN, ROLE_PUBLIC, ROLE_VOLUNTEER
+from app.mcp.auth import build_keycloak_auth as build_keycloak_auth
+from app.mcp.capabilities import (
+    ROLE_ADMIN,
+    ROLE_PUBLIC,
+    ROLE_VOLUNTEER,
+)
 from app.services.integration_clients_service import DEFAULT_RATE_LIMIT_PER_MINUTE
 from app.version import APP_VERSION
 
 logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Capability manifest (see #807 — identity/capability discovery)
-# ---------------------------------------------------------------------------
-
-# Tools reachable with no authentication at all. Kept as an explicit allowlist
-# (rather than inferred) so a new public tool is a deliberate choice, not an
-# accident of forgetting to call _require_volunteer/_require_admin.
-PUBLIC_TOOL_NAMES: frozenset[str] = frozenset(
-    {
-        "get_active_edition",
-        "list_editions",
-        "get_event_schedule",
-        "get_venue_plan_summary",
-        "get_settings",
-        "whoami",
-    }
-)
-
-# Tools requiring the 'volunteer' or 'admin' role (_require_volunteer).
-VOLUNTEER_TOOL_NAMES: frozenset[str] = frozenset(
-    {
-        "find_guest",
-        "get_guest_registration",
-        "get_table_seating",
-        "resolve_table_reference",
-        "get_table_order_summary",
-        "get_guest_order_status",
-        "get_champagne_delivery_summary",
-        "get_undelivered_champagne_by_table",
-        "get_check_in_summary",
-    }
-)
-
-
-def _tool_required_role(tool_name: str) -> str:
-    """Return the minimum role required to call *tool_name*.
-
-    Every tool not explicitly listed in ``PUBLIC_TOOL_NAMES`` or
-    ``VOLUNTEER_TOOL_NAMES`` defaults to ``admin`` — the safe default for the
-    dozens of write/management tools, and for any future tool whose author
-    forgets to update this manifest (it will simply advertise as more
-    restricted than necessary, never less).
-    """
-    if tool_name in PUBLIC_TOOL_NAMES:
-        return ROLE_PUBLIC
-    if tool_name in VOLUNTEER_TOOL_NAMES:
-        return ROLE_VOLUNTEER
-    return ROLE_ADMIN
-
-
-async def get_mcp_capabilities(mcp: FastMCP) -> dict[str, object]:
-    """Build the capabilities manifest from the *live* registered tool set.
-
-    Reads directly off ``mcp.list_tools()`` rather than a hand-maintained
-    tuple, so the manifest can never drift from what's actually registered —
-    only each tool's advertised ``required_role`` depends on the (tested)
-    ``PUBLIC_TOOL_NAMES``/``VOLUNTEER_TOOL_NAMES`` allowlists above.
-    """
-    tools = await mcp.list_tools()
-    return {
-        "tools": [
-            {"name": tool.name, "required_role": _tool_required_role(tool.name)}
-            for tool in sorted(tools, key=lambda t: t.name)
-        ],
-    }
-
 
 # ---------------------------------------------------------------------------
 # Backend wrapper
@@ -1517,6 +1454,7 @@ class ChampagneFestivalMcpBackend:
         until: str | None = None,
         limit: int | None = None,
         offset: int = 0,
+        before_id: str | None = None,
     ) -> dict:
         """List audit entries (newest first), with optional filters. Requires the ``admin`` role.
 
@@ -1534,6 +1472,7 @@ class ChampagneFestivalMcpBackend:
             until=until,
             limit=limit,
             offset=offset,
+            before_id=before_id,
         )
 
     async def list_audit_resource_types(self) -> dict:
@@ -1728,61 +1667,6 @@ def create_mcp_server(
     mcp.tool(backend.rotate_integration_client)
 
     return mcp
-
-
-# ---------------------------------------------------------------------------
-# Auth helper
-# ---------------------------------------------------------------------------
-
-
-def build_keycloak_auth(session_factory: async_sessionmaker | None = None) -> Any:
-    """Build the MCP authentication provider from application settings.
-
-    Combines Keycloak OIDC (interactive users and Keycloak service accounts)
-    with a database-backed managed integration-client verifier (issue #807)
-    via FastMCP's :class:`MultiAuth`, so an MCP caller can authenticate with
-    either. Both resolve through the same
-    ``ChampagneFestivalMcpBackend._resolve_role()``/``_actor()`` methods, since
-    ``IntegrationKeyTokenVerifier`` synthesises Keycloak-shaped claims (see
-    ``app.mcp.integration_auth``) — none of the 80+ existing tool methods
-    needed to change.
-
-    Requires ``OIDC_ISSUER_URL`` and ``MCP_BASE_URL`` to be set.
-    Returns ``None`` when the HTTP MCP server is not configured. Local stdio
-    mode passes ``auth=None`` directly and does not call this helper.
-
-    Parameters
-    ----------
-    session_factory:
-        An ``async_sessionmaker`` for the integration-client verifier's
-        database lookups. Defaults to the application's shared
-        ``async_session_factory``.
-    """
-    mcp_base_url = settings.mcp_base_url
-    if not mcp_base_url:
-        return None
-
-    if not settings.oidc_issuer_url:
-        raise RuntimeError("OIDC_ISSUER_URL is required when MCP_BASE_URL enables the HTTP MCP server")
-
-    from fastmcp.server.auth import MultiAuth
-    from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
-
-    from app.mcp.integration_auth import IntegrationKeyTokenVerifier
-
-    if session_factory is None:
-        from app.database import async_session_factory as _default_factory
-
-        session_factory = _default_factory
-
-    keycloak_provider = KeycloakAuthProvider(
-        realm_url=settings.oidc_issuer_url,
-        base_url=mcp_base_url,
-        audience=settings.oidc_audience or None,
-        required_scopes=[],
-    )
-    integration_verifier = IntegrationKeyTokenVerifier(session_factory)
-    return MultiAuth(server=keycloak_provider, verifiers=[integration_verifier])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -44,6 +44,7 @@ from app.mcp.admin import editions as mcp_admin_editions
 from app.mcp.admin import events as mcp_admin_events
 from app.mcp.admin import exhibitors as mcp_admin_exhibitors
 from app.mcp.admin import faq as mcp_admin_faq
+from app.mcp.admin import integration_clients as mcp_admin_integration_clients
 from app.mcp.admin import layouts as mcp_admin_layouts
 from app.mcp.admin import members as mcp_admin_members
 from app.mcp.admin import people as mcp_admin_people
@@ -55,8 +56,76 @@ from app.mcp.admin import tables as mcp_admin_tables
 from app.mcp.admin import venues as mcp_admin_venues
 from app.mcp.admin import volunteers as mcp_admin_volunteers
 from app.mcp.utils import ROLE_ADMIN, ROLE_PUBLIC, ROLE_VOLUNTEER
+from app.services.integration_clients_service import DEFAULT_RATE_LIMIT_PER_MINUTE
+from app.version import APP_VERSION
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Capability manifest (see #807 — identity/capability discovery)
+# ---------------------------------------------------------------------------
+
+# Tools reachable with no authentication at all. Kept as an explicit allowlist
+# (rather than inferred) so a new public tool is a deliberate choice, not an
+# accident of forgetting to call _require_volunteer/_require_admin.
+PUBLIC_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "get_active_edition",
+        "list_editions",
+        "get_event_schedule",
+        "get_venue_plan_summary",
+        "get_settings",
+        "whoami",
+    }
+)
+
+# Tools requiring the 'volunteer' or 'admin' role (_require_volunteer).
+VOLUNTEER_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "find_guest",
+        "get_guest_registration",
+        "get_table_seating",
+        "resolve_table_reference",
+        "get_table_order_summary",
+        "get_guest_order_status",
+        "get_champagne_delivery_summary",
+        "get_undelivered_champagne_by_table",
+        "get_check_in_summary",
+    }
+)
+
+
+def _tool_required_role(tool_name: str) -> str:
+    """Return the minimum role required to call *tool_name*.
+
+    Every tool not explicitly listed in ``PUBLIC_TOOL_NAMES`` or
+    ``VOLUNTEER_TOOL_NAMES`` defaults to ``admin`` — the safe default for the
+    dozens of write/management tools, and for any future tool whose author
+    forgets to update this manifest (it will simply advertise as more
+    restricted than necessary, never less).
+    """
+    if tool_name in PUBLIC_TOOL_NAMES:
+        return ROLE_PUBLIC
+    if tool_name in VOLUNTEER_TOOL_NAMES:
+        return ROLE_VOLUNTEER
+    return ROLE_ADMIN
+
+
+async def get_mcp_capabilities(mcp: FastMCP) -> dict[str, object]:
+    """Build the capabilities manifest from the *live* registered tool set.
+
+    Reads directly off ``mcp.list_tools()`` rather than a hand-maintained
+    tuple, so the manifest can never drift from what's actually registered —
+    only each tool's advertised ``required_role`` depends on the (tested)
+    ``PUBLIC_TOOL_NAMES``/``VOLUNTEER_TOOL_NAMES`` allowlists above.
+    """
+    tools = await mcp.list_tools()
+    return {
+        "tools": [
+            {"name": tool.name, "required_role": _tool_required_role(tool.name)}
+            for tool in sorted(tools, key=lambda t: t.name)
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -134,9 +203,37 @@ class ChampagneFestivalMcpBackend:
         sub = claims.get("sub")
         return str(sub) if sub is not None else "anonymous"
 
+    def _auth_source(self) -> str:
+        """Return ``'keycloak'``, ``'integration'``, or ``'none'`` for the current caller.
+
+        ``IntegrationKeyTokenVerifier`` stamps ``claims['auth_source'] =
+        'integration'`` on tokens it verifies (see ``app.mcp.integration_auth``);
+        a Keycloak-issued JWT never carries that claim, so its absence on an
+        authenticated token means Keycloak.
+        """
+        token = get_access_token()
+        if token is None:
+            return "none"
+        claims: dict[str, Any] = getattr(token, "claims", {})
+        return "integration" if claims.get("auth_source") == "integration" else "keycloak"
+
     # ------------------------------------------------------------------
     # Tools — public (no auth)
     # ------------------------------------------------------------------
+
+    async def whoami(self) -> dict:
+        """Return the caller's resolved identity: auth source, subject, and effective role.
+
+        No authentication required — an unauthenticated caller gets
+        ``{"auth_source": "none", "subject": None, "role": "public"}``. Never
+        exposes token material (the bearer token itself, or raw JWT claims).
+        """
+        auth_source = self._auth_source()
+        return {
+            "auth_source": auth_source,
+            "subject": self._actor() if auth_source != "none" else None,
+            "role": self._resolve_role(),
+        }
 
     async def get_active_edition(self) -> dict:
         """Return the current or next upcoming active festival edition.
@@ -1447,6 +1544,50 @@ class ChampagneFestivalMcpBackend:
         self._require_admin()
         return await mcp_admin_audit.list_audit_resource_types(self.session_factory)
 
+    # -- Integration clients (managed automation credentials) ------------
+
+    async def create_integration_client(
+        self,
+        name: str,
+        allowed_role: str,
+        rate_limit_per_minute: int = DEFAULT_RATE_LIMIT_PER_MINUTE,
+    ) -> dict:
+        """Create a managed integration-client credential for MCP automation.
+
+        Returns the new client's details plus its raw key — shown exactly
+        once here, never recoverable afterward (only its hash is stored).
+        ``allowed_role`` must be ``"admin"`` or ``"volunteer"``; a credential
+        can never be created more privileged than the caller's own tier.
+        Requires the ``admin`` role.
+        """
+        self._require_admin()
+        return await mcp_admin_integration_clients.create_integration_client(
+            self.session_factory,
+            self._actor(),
+            name=name,
+            allowed_role=allowed_role,
+            rate_limit_per_minute=rate_limit_per_minute,
+        )
+
+    async def list_integration_clients(self) -> dict:
+        """List all managed integration clients (never includes key material). Requires the ``admin`` role."""
+        self._require_admin()
+        return await mcp_admin_integration_clients.list_integration_clients(self.session_factory)
+
+    async def revoke_integration_client(self, client_id: str) -> dict:
+        """Revoke (disable) a managed integration client. Requires the ``admin`` role."""
+        self._require_admin()
+        return await mcp_admin_integration_clients.revoke_integration_client(self.session_factory, self._actor(), client_id)
+
+    async def rotate_integration_client(self, client_id: str) -> dict:
+        """Replace an active integration client's credential with a freshly generated one.
+
+        Returns the client's details plus the new raw key (shown exactly once).
+        Requires the ``admin`` role.
+        """
+        self._require_admin()
+        return await mcp_admin_integration_clients.rotate_integration_client(self.session_factory, self._actor(), client_id)
+
 
 # ---------------------------------------------------------------------------
 # Factory
@@ -1488,9 +1629,11 @@ def create_mcp_server(
             "registrations, and the audit trail."
         ),
         auth=auth,
+        version=APP_VERSION,
     )
 
     # Register all tools
+    mcp.tool(backend.whoami)
     mcp.tool(backend.get_active_edition)
     mcp.tool(backend.list_editions)
     mcp.tool(backend.get_event_schedule)
@@ -1575,21 +1718,41 @@ def create_mcp_server(
     mcp.tool(backend.delete_registration)
     mcp.tool(backend.list_audit_entries)
     mcp.tool(backend.list_audit_resource_types)
+    mcp.tool(backend.create_integration_client)
+    mcp.tool(backend.list_integration_clients)
+    mcp.tool(backend.revoke_integration_client)
+    mcp.tool(backend.rotate_integration_client)
 
     return mcp
 
 
 # ---------------------------------------------------------------------------
-# Keycloak auth helper
+# Auth helper
 # ---------------------------------------------------------------------------
 
 
-def build_keycloak_auth() -> Any:
-    """Build a :class:`KeycloakAuthProvider` from application settings.
+def build_keycloak_auth(session_factory: async_sessionmaker | None = None) -> Any:
+    """Build the MCP authentication provider from application settings.
+
+    Combines Keycloak OIDC (interactive users and Keycloak service accounts)
+    with a database-backed managed integration-client verifier (issue #807)
+    via FastMCP's :class:`MultiAuth`, so an MCP caller can authenticate with
+    either. Both resolve through the same
+    ``ChampagneFestivalMcpBackend._resolve_role()``/``_actor()`` methods, since
+    ``IntegrationKeyTokenVerifier`` synthesises Keycloak-shaped claims (see
+    ``app.mcp.integration_auth``) — none of the 80+ existing tool methods
+    needed to change.
 
     Requires ``OIDC_ISSUER_URL`` and ``MCP_BASE_URL`` to be set.
     Returns ``None`` when the HTTP MCP server is not configured. Local stdio
     mode passes ``auth=None`` directly and does not call this helper.
+
+    Parameters
+    ----------
+    session_factory:
+        An ``async_sessionmaker`` for the integration-client verifier's
+        database lookups. Defaults to the application's shared
+        ``async_session_factory``.
     """
     mcp_base_url = settings.mcp_base_url
     if not mcp_base_url:
@@ -1598,14 +1761,24 @@ def build_keycloak_auth() -> Any:
     if not settings.oidc_issuer_url:
         raise RuntimeError("OIDC_ISSUER_URL is required when MCP_BASE_URL enables the HTTP MCP server")
 
+    from fastmcp.server.auth import MultiAuth
     from fastmcp.server.auth.providers.keycloak import KeycloakAuthProvider
 
-    return KeycloakAuthProvider(
+    from app.mcp.integration_auth import IntegrationKeyTokenVerifier
+
+    if session_factory is None:
+        from app.database import async_session_factory as _default_factory
+
+        session_factory = _default_factory
+
+    keycloak_provider = KeycloakAuthProvider(
         realm_url=settings.oidc_issuer_url,
         base_url=mcp_base_url,
         audience=settings.oidc_audience or None,
         required_scopes=[],
     )
+    integration_verifier = IntegrationKeyTokenVerifier(session_factory)
+    return MultiAuth(server=keycloak_provider, verifiers=[integration_verifier])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -461,6 +461,36 @@ class AuditEntry(Base):
     details: Mapped[dict] = mapped_column(JSON, default=dict)
 
 
+class IntegrationClient(Base):
+    """A managed, database-backed credential for machine automation (MCP).
+
+    Unlike Keycloak client-credentials (which remain fully supported), this is
+    an operator-issued credential scoped to exactly one Champagnefestival role
+    tier — never more privileged than the admin who created it. Only the
+    ``key_hash`` is stored; the raw key is shown once at creation/rotation time
+    (see ``app.services.integration_clients_service``).
+    """
+
+    __tablename__ = "integration_clients"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    key_hash: Mapped[str] = mapped_column(String(128), nullable=False, unique=True, index=True)
+    allowed_role: Mapped[str] = mapped_column(String(20), nullable=False)
+    """'admin' | 'volunteer' — the single Champagnefestival role tier this credential
+    resolves to via ChampagneFestivalMcpBackend._resolve_role(). Fixed at creation;
+    never 'public' (a public-only credential has no reason to exist) and never
+    more privileged than created_by_actor's own tier at creation time."""
+    created_by_actor: Mapped[str] = mapped_column(String(255), nullable=False)
+    """OIDC 'sub' claim of the admin who created this credential (audit/ownership)."""
+    rate_limit_per_minute: Mapped[int] = mapped_column(Integer, nullable=False, default=120)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
 class AppSettings(Base):
     """Site-wide settings. Always exactly one row, with a fixed id."""
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -454,6 +454,9 @@ class AuditEntry(Base):
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow, index=True)
     actor: Mapped[str] = mapped_column(String(255), index=True)
     """OIDC ``sub`` claim, client IP for token-gated ops, or 'anonymous'."""
+    auth_source: Mapped[str] = mapped_column(String(32), nullable=False, default="unknown", index=True)
+    subject: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    integration_client_id: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
     action: Mapped[str] = mapped_column(String(50), index=True)
     resource_type: Mapped[str] = mapped_column(String(50), index=True)
     resource_id: Mapped[str] = mapped_column(String(64), index=True)
@@ -476,6 +479,7 @@ class IntegrationClient(Base):
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     key_hash: Mapped[str] = mapped_column(String(128), nullable=False, unique=True, index=True)
+    key_preview: Mapped[str] = mapped_column(String(8), nullable=False)
     allowed_role: Mapped[str] = mapped_column(String(20), nullable=False)
     """'admin' | 'volunteer' — the single Champagnefestival role tier this credential
     resolves to via ChampagneFestivalMcpBackend._resolve_role(). Fixed at creation;
@@ -489,6 +493,8 @@ class IntegrationClient(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rate_limit_window_started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rate_limit_window_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
 
 class AppSettings(Base):

--- a/backend/app/routers/areas.py
+++ b/backend/app/routers/areas.py
@@ -1,15 +1,18 @@
-"""Area management endpoints (admin only)."""
+"""Area management endpoints (admin only).
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import select
+Business logic lives in ``app.services.areas_service`` and is shared with
+``app.mcp.admin.areas`` — this router is a thin adapter that translates
+``ServiceError`` into ``HTTPException`` (see #807).
+"""
+
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.models import Area, Exhibitor, Layout
 from app.schemas import AreaCreate, AreaOut, AreaUpdate
-from app.utils import area_to_dict, get_or_404, make_id
+from app.services import areas_service
+from app.services.errors import ServiceError, to_http_exception
 
 router = APIRouter(
     prefix="/api/areas",
@@ -25,43 +28,12 @@ async def create_area(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
-    if lay.scalar_one_or_none() is None:
-        raise HTTPException(status_code=404, detail=f"Layout '{body.layout_id}' not found.")
-
-    if body.exhibitor_id is not None:
-        ex = await db.execute(select(Exhibitor).where(Exhibitor.id == body.exhibitor_id))
-        exhibitor = ex.scalar_one_or_none()
-        if exhibitor is None:
-            raise HTTPException(status_code=404, detail=f"Exhibitor '{body.exhibitor_id}' not found.")
-        if not exhibitor.active:
-            raise HTTPException(status_code=400, detail=f"Exhibitor '{body.exhibitor_id}' is inactive.")
-
-    a = Area(
-        id=make_id("area"),
-        layout_id=body.layout_id,
-        label=body.label,
-        icon=body.icon,
-        exhibitor_id=body.exhibitor_id,
-        width_m=body.width_m,
-        length_m=body.length_m,
-        x=body.x,
-        y=body.y,
-        rotation=body.rotation,
-    )
-    db.add(a)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="area_created",
-        resource_type="area",
-        resource_id=a.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"label": a.label, "layout_id": a.layout_id},
-    )
-    await db.commit()
-    await db.refresh(a)
-    return area_to_dict(a)
+    try:
+        return await areas_service.create_area(
+            db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.get("", response_model=list[AreaOut])
@@ -69,16 +41,15 @@ async def list_areas(
     layout_id: str | None = Query(default=None, description="Filter by layout ID"),
     db: AsyncSession = Depends(get_db),
 ) -> list[dict]:
-    stmt = select(Area).order_by(Area.created_at)
-    if layout_id:
-        stmt = stmt.where(Area.layout_id == layout_id)
-    result = await db.execute(stmt)
-    return [area_to_dict(a) for a in result.scalars().all()]
+    return await areas_service.list_areas(db, layout_id)
 
 
 @router.get("/{area_id}", response_model=AreaOut)
 async def get_area(area_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    return area_to_dict(await get_or_404(db, Area, area_id, "Area not found."))
+    try:
+        return await areas_service.get_area(db, area_id)
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.put("/{area_id}", response_model=AreaOut)
@@ -89,44 +60,12 @@ async def update_area(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    a = await get_or_404(db, Area, area_id, "Area not found.")
-
-    if body.label is not None:
-        a.label = body.label
-    if body.icon is not None:
-        a.icon = body.icon
-    if body.x is not None:
-        a.x = body.x
-    if body.y is not None:
-        a.y = body.y
-    if body.width_m is not None:
-        a.width_m = body.width_m
-    if body.length_m is not None:
-        a.length_m = body.length_m
-    if body.rotation is not None:
-        a.rotation = body.rotation
-    if "exhibitor_id" in body.model_fields_set:
-        if body.exhibitor_id is not None:
-            ex = await db.execute(select(Exhibitor).where(Exhibitor.id == body.exhibitor_id))
-            exhibitor = ex.scalar_one_or_none()
-            if exhibitor is None:
-                raise HTTPException(status_code=404, detail="Exhibitor not found.")
-            if not exhibitor.active:
-                raise HTTPException(status_code=400, detail="Exhibitor is inactive.")
-        a.exhibitor_id = body.exhibitor_id
-
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="area_updated",
-        resource_type="area",
-        resource_id=a.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
-    )
-    await db.commit()
-    await db.refresh(a)
-    return area_to_dict(a)
+    try:
+        return await areas_service.update_area(
+            db, actor=actor, area_id=area_id, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.delete("/{area_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -136,15 +75,9 @@ async def delete_area(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    a = await get_or_404(db, Area, area_id, "Area not found.")
-    await db.delete(a)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="area_deleted",
-        resource_type="area",
-        resource_id=area_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={},
-    )
-    await db.commit()
+    try:
+        await areas_service.delete_area(
+            db, actor=actor, area_id=area_id, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc

--- a/backend/app/routers/audit.py
+++ b/backend/app/routers/audit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,6 +30,7 @@ async def list_audit_entries(
     action: str | None = Query(default=None),
     since: datetime | None = Query(default=None, description="Only entries at or after this timestamp"),
     until: datetime | None = Query(default=None, description="Only entries at or before this timestamp"),
+    before_id: str | None = Query(default=None, description="Exclusive keyset cursor from the previous page"),
     pagination: Pagination = Depends(),
 ) -> list[AuditEntry]:
     stmt = select(AuditEntry)
@@ -49,8 +50,17 @@ async def list_audit_entries(
         if until.tzinfo is None:
             until = until.replace(tzinfo=UTC)
         stmt = stmt.where(AuditEntry.timestamp <= until)
-    stmt = stmt.order_by(AuditEntry.timestamp.desc())
-    stmt = apply_pagination(stmt, pagination)
+    if before_id is not None:
+        cursor = await db.get(AuditEntry, before_id)
+        if cursor is None:
+            raise HTTPException(status_code=422, detail="audit cursor does not exist")
+        stmt = stmt.where(
+            (AuditEntry.timestamp < cursor.timestamp)
+            | ((AuditEntry.timestamp == cursor.timestamp) & (AuditEntry.id < cursor.id))
+        )
+    stmt = stmt.order_by(AuditEntry.timestamp.desc(), AuditEntry.id.desc())
+    effective_pagination = Pagination(page=1 if before_id else pagination.page, limit=pagination.limit or 100)
+    stmt = apply_pagination(stmt, effective_pagination)
     result = await db.execute(stmt)
     return list(result.scalars().all())
 

--- a/backend/app/routers/integration_clients.py
+++ b/backend/app/routers/integration_clients.py
@@ -1,0 +1,82 @@
+"""Managed integration-client credential endpoints (admin only).
+
+Create/list/revoke/rotate database-backed automation credentials for MCP —
+see issue #807 and ``app.services.integration_clients_service``. Business
+logic (including audit-entry construction) is shared with
+``app.mcp.admin.integration_clients``.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_actor_id, require_admin
+from app.database import get_db
+from app.schemas import IntegrationClientCreate, IntegrationClientCreatedOut, IntegrationClientOut
+from app.services import integration_clients_service as ics
+from app.services.errors import ServiceError, to_http_exception
+
+router = APIRouter(
+    prefix="/api/integration-clients",
+    tags=["integration-clients"],
+    dependencies=[Depends(require_admin)],
+)
+
+
+@router.post("", response_model=IntegrationClientCreatedOut, status_code=status.HTTP_201_CREATED)
+async def create_integration_client(
+    body: IntegrationClientCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> dict:
+    try:
+        client_dict, raw_key = await ics.create_integration_client(
+            db,
+            actor=actor,
+            creator_role="admin",  # require_admin already gated this request
+            name=body.name,
+            allowed_role=body.allowed_role,
+            rate_limit_per_minute=body.rate_limit_per_minute,
+            request_id=getattr(request.state, "request_id", None),
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
+    return {**client_dict, "key": raw_key}
+
+
+@router.get("", response_model=list[IntegrationClientOut])
+async def list_integration_clients(db: AsyncSession = Depends(get_db)) -> list[dict]:
+    return await ics.list_integration_clients(db)
+
+
+@router.post("/{client_id}/revoke", response_model=IntegrationClientOut)
+async def revoke_integration_client(
+    client_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> dict:
+    try:
+        return await ics.revoke_integration_client(
+            db, actor=actor, client_id=client_id, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
+
+
+@router.post("/{client_id}/rotate", response_model=IntegrationClientCreatedOut)
+async def rotate_integration_client(
+    client_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> dict:
+    try:
+        client_dict, raw_key = await ics.rotate_integration_client(
+            db, actor=actor, client_id=client_id, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
+    return {**client_dict, "key": raw_key}

--- a/backend/app/routers/layouts.py
+++ b/backend/app/routers/layouts.py
@@ -1,51 +1,24 @@
-"""Layout snapshot management endpoints (admin only)."""
+"""Layout snapshot management endpoints (admin only).
 
-import math
-from datetime import date
+Business logic lives in ``app.services.layouts_service`` and is shared with
+``app.mcp.admin.layouts`` — this router is a thin adapter that translates
+``ServiceError`` into ``HTTPException`` (see #807).
+"""
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.models import Area, Edition, Exhibitor, Layout, Room, Table, TableType
 from app.schemas import LayoutCopyCreate, LayoutCreate, LayoutOut
-from app.utils import get_or_404, layout_to_dict, make_id
-
-# Mirror the rendering constants from frontend/src/utils/layoutUtils.ts so that
-# the backend containment check matches the frontend's hit-testing exactly.
-_PX_PER_M: int = 28
-_MIN_CANVAS_WIDTH_PX: int = 280
-_MIN_CANVAS_HEIGHT_PX: int = 180
-_MIN_AREA_WIDTH_PX: int = 40
-_MIN_AREA_HEIGHT_PX: int = 24
-_MIN_TABLE_SIZE_PX: int = 32
+from app.services import layouts_service
+from app.services.errors import ServiceError, to_http_exception
 
 router = APIRouter(
     prefix="/api/layouts",
     tags=["layouts"],
     dependencies=[Depends(require_admin)],
 )
-
-
-def _js_round(x: float) -> int:
-    """Round a non-negative float the same way JS Math.round does.
-
-    Python's built-in round() uses banker's rounding (round half to even),
-    whereas JS Math.round always rounds 0.5 up (towards +∞).  For the
-    positive pixel values we deal with here the difference is:
-      Python: round(0.5) == 0   JS: Math.round(0.5) == 1
-    Using math.floor(x + 0.5) reproduces the JS behaviour for x >= 0.
-    """
-    return math.floor(x + 0.5)
-
-
-# ---------------------------------------------------------------------------
-# Create layout
-# ---------------------------------------------------------------------------
 
 
 @router.post("", response_model=LayoutOut, status_code=status.HTTP_201_CREATED)
@@ -55,49 +28,12 @@ async def create_layout(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    resolved_day_id, resolved_date = await _resolve_layout_day(db, body)
-
-    # Lock the room row so a concurrent room deletion (which refuses to proceed
-    # while layouts reference the room) can't race this insert: whichever
-    # transaction locks the room first is the one the other serializes behind.
-    await db.execute(select(Room.id).where(Room.id == body.room_id).with_for_update())
-
-    existing_stmt = select(Layout).where(
-        Layout.room_id == body.room_id,
-        Layout.day_id == resolved_day_id,
-    )
-    if body.edition_id is None:
-        existing_stmt = existing_stmt.where(Layout.edition_id.is_(None))
-    else:
-        existing_stmt = existing_stmt.where(Layout.edition_id == body.edition_id)
-
-    existing = (await db.execute(existing_stmt.limit(1))).scalar_one_or_none()
-    if existing is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="A layout already exists for this room and day.",
+    try:
+        return await layouts_service.create_layout(
+            db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
         )
-
-    lay = Layout(
-        id=make_id("lay"),
-        edition_id=body.edition_id,
-        room_id=body.room_id,
-        day_id=resolved_day_id,
-        label=body.label.strip(),
-    )
-    db.add(lay)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="layout_created",
-        resource_type="layout",
-        resource_id=lay.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"room_id": lay.room_id, "day_id": lay.day_id},
-    )
-    await db.commit()
-    await db.refresh(lay)
-    return layout_to_dict(lay, date=resolved_date)
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.post("/{source_layout_id}/copy", response_model=LayoutOut, status_code=status.HTTP_201_CREATED)
@@ -108,139 +44,16 @@ async def copy_layout(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    source = await get_or_404(db, Layout, source_layout_id, "Layout not found.")
-    resolved_day_id, resolved_date = await _resolve_layout_day(db, body)
-
-    # See create_layout: lock the target room so it can't be deleted out from
-    # under this insert.
-    await db.execute(select(Room.id).where(Room.id == body.room_id).with_for_update())
-
-    existing_stmt = select(Layout).where(
-        Layout.room_id == body.room_id,
-        Layout.day_id == resolved_day_id,
-    )
-    if body.edition_id is None:
-        existing_stmt = existing_stmt.where(Layout.edition_id.is_(None))
-    else:
-        existing_stmt = existing_stmt.where(Layout.edition_id == body.edition_id)
-    existing = (await db.execute(existing_stmt.limit(1))).scalar_one_or_none()
-    if existing is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="A layout already exists for this room and day.",
+    try:
+        return await layouts_service.copy_layout(
+            db,
+            actor=actor,
+            source_layout_id=source_layout_id,
+            body=body,
+            request_id=getattr(request.state, "request_id", None),
         )
-
-    room_stmt = select(Room).where(Room.id == source.room_id)
-    source_room = (await db.execute(room_stmt)).scalar_one_or_none()
-    if source_room is None:
-        raise HTTPException(status_code=404, detail="Source room not found.")
-
-    source_tables = (await db.execute(select(Table).where(Table.layout_id == source_layout_id))).scalars().all()
-    source_areas = (await db.execute(select(Area).where(Area.layout_id == source_layout_id))).scalars().all()
-
-    table_type_ids = {t.table_type_id for t in source_tables}
-    table_types: dict[str, TableType] = {}
-    if table_type_ids:
-        result = await db.execute(select(TableType).where(TableType.id.in_(table_type_ids)))
-        table_types = {tt.id: tt for tt in result.scalars().all()}
-
-    cloned = Layout(
-        id=make_id("lay"),
-        edition_id=body.edition_id,
-        room_id=body.room_id,
-        day_id=resolved_day_id,
-        label=body.label.strip(),
-    )
-    db.add(cloned)
-    await db.flush()
-
-    # Tables inside areas travel with copy_areas; tables outside areas travel with copy_tables.
-    all_areas = list(source_areas)
-    tables_inside: list[Table] = []
-    if body.copy_areas and all_areas:
-        tables_inside = [
-            table for table in source_tables if _table_in_any_area(table, all_areas, table_types, source_room)
-        ]
-
-    tables_outside: list[Table] = []
-    if body.copy_tables:
-        if body.copy_areas and all_areas:
-            tables_outside = [
-                table for table in source_tables if not _table_in_any_area(table, all_areas, table_types, source_room)
-            ]
-        else:
-            tables_outside = list(source_tables)
-
-    tables_to_copy = tables_inside + tables_outside
-
-    for table in tables_to_copy:
-        db.add(
-            Table(
-                id=make_id("tbl"),
-                name=table.name,
-                capacity=table.capacity,
-                x=table.x,
-                y=table.y,
-                table_type_id=table.table_type_id,
-                rotation=table.rotation,
-                layout_id=cloned.id,
-                reservation_ids=[],
-            )
-        )
-
-    if body.copy_areas:
-        # An area whose exhibitor was deactivated after the source area was created
-        # (or last updated) must not be silently carried into the copy — create_area
-        # and update_area both refuse to assign an inactive exhibitor, so the copy
-        # path can't create areas those tools would reject.
-        exhibitor_ids = {area.exhibitor_id for area in source_areas if area.exhibitor_id is not None}
-        if exhibitor_ids:
-            active_result = await db.execute(
-                select(Exhibitor.id).where(Exhibitor.id.in_(exhibitor_ids), Exhibitor.active.is_(True))
-            )
-            active_ids = set(active_result.scalars().all())
-            inactive_ids = sorted(exhibitor_ids - active_ids)
-            if inactive_ids:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=(
-                        "Cannot copy: the following areas reference an inactive or "
-                        f"deleted exhibitor: {inactive_ids}. Update those areas first."
-                    ),
-                )
-        for area in source_areas:
-            db.add(
-                Area(
-                    id=make_id("area"),
-                    layout_id=cloned.id,
-                    label=area.label,
-                    icon=area.icon,
-                    exhibitor_id=area.exhibitor_id,
-                    width_m=area.width_m,
-                    length_m=area.length_m,
-                    x=area.x,
-                    y=area.y,
-                    rotation=area.rotation,
-                )
-            )
-
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="layout_copied",
-        resource_type="layout",
-        resource_id=cloned.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"source_layout_id": source_layout_id, "room_id": cloned.room_id, "day_id": cloned.day_id},
-    )
-    await db.commit()
-    await db.refresh(cloned)
-    return layout_to_dict(cloned, date=resolved_date)
-
-
-# ---------------------------------------------------------------------------
-# List layouts
-# ---------------------------------------------------------------------------
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.get("", response_model=list[LayoutOut])
@@ -249,28 +62,15 @@ async def list_layouts(
     limit: int | None = Query(default=None, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
 ) -> list[dict]:
-    stmt = select(Layout).order_by(Layout.created_at).offset(offset)
-    if limit is not None:
-        stmt = stmt.limit(limit)
-    result = await db.execute(stmt)
-    layouts = result.scalars().all()
-    return await _layout_payloads(db, list(layouts))
-
-
-# ---------------------------------------------------------------------------
-# Get single layout
-# ---------------------------------------------------------------------------
+    return await layouts_service.list_layouts(db, limit=limit, offset=offset)
 
 
 @router.get("/{layout_id}", response_model=LayoutOut)
 async def get_layout(layout_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    payloads = await _layout_payloads(db, [await get_or_404(db, Layout, layout_id, "Layout not found.")])
-    return payloads[0]
-
-
-# ---------------------------------------------------------------------------
-# Delete layout
-# ---------------------------------------------------------------------------
+    try:
+        return await layouts_service.get_layout(db, layout_id)
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.delete("/{layout_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -280,124 +80,9 @@ async def delete_layout(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    lay = await get_or_404(db, Layout, layout_id, "Layout not found.")
-    # Lock the layout row so a concurrent table creation/copy (which validates the
-    # layout exists before inserting) can't race this delete: whichever
-    # transaction locks the layout first is the one the other serializes behind.
-    await db.execute(select(Layout.id).where(Layout.id == layout_id).with_for_update())
-    tables_in_use = await db.execute(select(Table).where(Table.layout_id == layout_id).limit(1))
-    if tables_in_use.scalars().first() is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Cannot delete: tables are still assigned to this layout.",
+    try:
+        await layouts_service.delete_layout(
+            db, actor=actor, layout_id=layout_id, request_id=getattr(request.state, "request_id", None)
         )
-    await db.delete(lay)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="layout_deleted",
-        resource_type="layout",
-        resource_id=layout_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={},
-    )
-    await db.commit()
-
-
-# ---------------------------------------------------------------------------
-# Helper
-# ---------------------------------------------------------------------------
-
-
-async def _layout_payloads(db: AsyncSession, layouts: list[Layout]) -> list[dict]:
-    edition_ids = {layout.edition_id for layout in layouts if layout.edition_id}
-    edition_dates_by_id: dict[str, list] = {}
-    if edition_ids:
-        result = await db.execute(
-            select(Edition).options(selectinload(Edition.events)).where(Edition.id.in_(edition_ids))
-        )
-        for edition in result.scalars().all():
-            edition_dates_by_id[edition.id] = sorted({event.date for event in edition.events})
-
-    payloads: list[dict] = []
-    for layout in layouts:
-        date = None
-        if layout.edition_id and layout.edition_id in edition_dates_by_id:
-            dates = edition_dates_by_id[layout.edition_id]
-            if 1 <= layout.day_id <= len(dates):
-                date = dates[layout.day_id - 1]
-        payloads.append(layout_to_dict(layout, date=date))
-    return payloads
-
-
-async def _resolve_layout_day(db: AsyncSession, body: LayoutCreate) -> tuple[int, date | None]:
-    if body.date is None:
-        return body.day_id or 1, None
-    if not body.edition_id:
-        raise HTTPException(status_code=400, detail="edition_id is required when date is provided.")
-
-    result = await db.execute(
-        select(Edition).options(selectinload(Edition.events)).where(Edition.id == body.edition_id)
-    )
-    edition = result.scalar_one_or_none()
-    if edition is None:
-        raise HTTPException(status_code=404, detail="Edition not found.")
-
-    unique_dates = sorted({event.date for event in edition.events})
-    if body.date not in unique_dates:
-        raise HTTPException(
-            status_code=400,
-            detail="Layout date must match one of the edition event dates.",
-        )
-    return unique_dates.index(body.date) + 1, body.date
-
-
-def _table_in_any_area(
-    table: Table,
-    areas: list[Area],
-    table_types: dict[str, TableType],
-    room: Room,
-) -> bool:
-    """Return True if the table's centre falls inside any of the given areas.
-
-    All geometry is computed in pixel space using the same rounding and minimum
-    rendered dimensions as the frontend (layoutUtils.ts / getAreaSizePx /
-    getTableSizePx), so the result matches what the user sees in the editor.
-    """
-    # Effective canvas dimensions (pixels) — match getCanvasSizePx
-    canvas_w = max(_MIN_CANVAS_WIDTH_PX, room.width_m * _PX_PER_M)
-    canvas_h = max(_MIN_CANVAS_HEIGHT_PX, room.length_m * _PX_PER_M)
-
-    # Effective table size (pixels) — match getTableSizePx
-    table_type = table_types.get(table.table_type_id)
-    table_w_px = max(_MIN_TABLE_SIZE_PX, _js_round((table_type.width_m if table_type else 1.0) * _PX_PER_M))
-    table_h_px = max(_MIN_TABLE_SIZE_PX, _js_round((table_type.length_m if table_type else 1.0) * _PX_PER_M))
-
-    # Table centre in canvas pixels
-    table_cx = (table.x / 100.0) * canvas_w + table_w_px / 2.0
-    table_cy = (table.y / 100.0) * canvas_h + table_h_px / 2.0
-
-    for area in areas:
-        # Effective area size (pixels) — match getAreaSizePx
-        area_w_px = max(_MIN_AREA_WIDTH_PX, _js_round(area.width_m * _PX_PER_M))
-        area_h_px = max(_MIN_AREA_HEIGHT_PX, _js_round(area.length_m * _PX_PER_M))
-
-        # Area centre in canvas pixels
-        area_left = (area.x / 100.0) * canvas_w
-        area_top = (area.y / 100.0) * canvas_h
-        area_cx = area_left + area_w_px / 2.0
-        area_cy = area_top + area_h_px / 2.0
-
-        # Rotate table centre into area-local space (negate rotation to invert)
-        radians = -((area.rotation or 0) * math.pi / 180.0)
-        cos_v = math.cos(radians)
-        sin_v = math.sin(radians)
-
-        dx = table_cx - area_cx
-        dy = table_cy - area_cy
-        lx = cos_v * dx - sin_v * dy
-        ly = sin_v * dx + cos_v * dy
-
-        if abs(lx) <= area_w_px / 2.0 and abs(ly) <= area_h_px / 2.0:
-            return True
-    return False
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc

--- a/backend/app/routers/rooms.py
+++ b/backend/app/routers/rooms.py
@@ -1,26 +1,24 @@
-"""Room management endpoints (admin only)."""
+"""Room management endpoints (admin only).
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy import select
+Business logic lives in ``app.services.rooms_service`` and is shared with
+``app.mcp.admin.rooms`` — this router is a thin adapter that translates
+``ServiceError`` into ``HTTPException`` (see #807).
+"""
+
+from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.models import Layout, Room, Venue
 from app.schemas import RoomCreate, RoomOut, RoomUpdate
-from app.utils import get_or_404, make_id, room_to_dict
+from app.services import rooms_service
+from app.services.errors import ServiceError, to_http_exception
 
 router = APIRouter(
     prefix="/api/rooms",
     tags=["rooms"],
     dependencies=[Depends(require_admin)],
 )
-
-
-# ---------------------------------------------------------------------------
-# Create room
-# ---------------------------------------------------------------------------
 
 
 @router.post("", response_model=RoomOut, status_code=status.HTTP_201_CREATED)
@@ -30,58 +28,25 @@ async def create_room(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    venue = await db.execute(select(Venue).where(Venue.id == body.venue_id))
-    if venue.scalar_one_or_none() is None:
-        raise HTTPException(status_code=404, detail=f"Venue '{body.venue_id}' not found.")
-
-    r = Room(
-        id=make_id("room"),
-        venue_id=body.venue_id,
-        name=body.name,
-        width_m=body.width_m,
-        length_m=body.length_m,
-        color=body.color,
-        active=body.active,
-    )
-    db.add(r)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="room_created",
-        resource_type="room",
-        resource_id=r.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"name": r.name, "venue_id": r.venue_id},
-    )
-    await db.commit()
-    await db.refresh(r)
-    return room_to_dict(r)
-
-
-# ---------------------------------------------------------------------------
-# List rooms
-# ---------------------------------------------------------------------------
+    try:
+        return await rooms_service.create_room(
+            db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.get("", response_model=list[RoomOut])
 async def list_rooms(db: AsyncSession = Depends(get_db)) -> list[dict]:
-    result = await db.execute(select(Room).order_by(Room.created_at))
-    return [room_to_dict(r) for r in result.scalars().all()]
-
-
-# ---------------------------------------------------------------------------
-# Get single room
-# ---------------------------------------------------------------------------
+    return await rooms_service.list_rooms(db)
 
 
 @router.get("/{room_id}", response_model=RoomOut)
 async def get_room(room_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    return room_to_dict(await get_or_404(db, Room, room_id, "Room not found."))
-
-
-# ---------------------------------------------------------------------------
-# Update room
-# ---------------------------------------------------------------------------
+    try:
+        return await rooms_service.get_room(db, room_id)
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.put("/{room_id}", response_model=RoomOut)
@@ -92,36 +57,12 @@ async def update_room(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    r = await get_or_404(db, Room, room_id, "Room not found.")
-
-    if body.name is not None:
-        r.name = body.name
-    if body.width_m is not None:
-        r.width_m = body.width_m
-    if body.length_m is not None:
-        r.length_m = body.length_m
-    if body.color is not None:
-        r.color = body.color
-    if body.active is not None:
-        r.active = body.active
-
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="room_updated",
-        resource_type="room",
-        resource_id=r.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
-    )
-    await db.commit()
-    await db.refresh(r)
-    return room_to_dict(r)
-
-
-# ---------------------------------------------------------------------------
-# Delete room
-# ---------------------------------------------------------------------------
+    try:
+        return await rooms_service.update_room(
+            db, actor=actor, room_id=room_id, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.delete("/{room_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -131,28 +72,9 @@ async def delete_room(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    r = await get_or_404(db, Room, room_id, "Room not found.")
-    # Lock the room row so a concurrent layout creation (see layouts.create_layout
-    # and copy_layout) can't insert a new layout for this room between our check
-    # and the delete below, which would otherwise cascade-delete it silently.
-    await db.execute(select(Room.id).where(Room.id == room_id).with_for_update())
-    # Layouts cascade from rooms, and tables/areas cascade from layouts, so an
-    # unguarded delete would silently destroy a whole floor plan. Mirror the
-    # venue endpoint and make the caller clear the layouts first.
-    layouts_in_use = await db.execute(select(Layout).where(Layout.room_id == room_id).limit(1))
-    if layouts_in_use.scalars().first() is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Cannot delete: layouts are still using this room.",
+    try:
+        await rooms_service.delete_room(
+            db, actor=actor, room_id=room_id, request_id=getattr(request.state, "request_id", None)
         )
-    await db.delete(r)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="room_deleted",
-        resource_type="room",
-        resource_id=room_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={},
-    )
-    await db.commit()
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc

--- a/backend/app/routers/table_types.py
+++ b/backend/app/routers/table_types.py
@@ -28,9 +28,12 @@ async def create_table_type(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    return await table_types_service.create_table_type(
-        db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
-    )
+    try:
+        return await table_types_service.create_table_type(
+            db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.get("", response_model=list[TableTypeOut])

--- a/backend/app/routers/table_types.py
+++ b/backend/app/routers/table_types.py
@@ -1,15 +1,18 @@
-"""Table type management endpoints (admin only)."""
+"""Table type management endpoints (admin only).
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import select
+Business logic lives in ``app.services.table_types_service`` and is shared
+with ``app.mcp.admin.table_types`` — this router is a thin adapter that
+translates ``ServiceError`` into ``HTTPException`` (see #807).
+"""
+
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.models import Table, TableType
 from app.schemas import TableTypeCreate, TableTypeOut, TableTypeUpdate
-from app.utils import get_or_404, make_id, table_type_to_dict
+from app.services import table_types_service
+from app.services.errors import ServiceError, to_http_exception
 
 router = APIRouter(
     prefix="/api/table-types",
@@ -25,29 +28,9 @@ async def create_table_type(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    tt = TableType(
-        id=make_id("ttype"),
-        name=body.name,
-        shape=body.shape,
-        width_m=body.width_m,
-        length_m=body.length_m,
-        height_type=body.height_type,
-        max_capacity=body.max_capacity,
-        active=body.active,
+    return await table_types_service.create_table_type(
+        db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
     )
-    db.add(tt)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="table_type_created",
-        resource_type="table_type",
-        resource_id=tt.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"name": tt.name, "shape": tt.shape},
-    )
-    await db.commit()
-    await db.refresh(tt)
-    return table_type_to_dict(tt)
 
 
 @router.get("", response_model=list[TableTypeOut])
@@ -56,16 +39,15 @@ async def list_table_types(
     limit: int | None = Query(default=None, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
 ) -> list[dict]:
-    stmt = select(TableType).order_by(TableType.created_at).offset(offset)
-    if limit is not None:
-        stmt = stmt.limit(limit)
-    result = await db.execute(stmt)
-    return [table_type_to_dict(tt) for tt in result.scalars().all()]
+    return await table_types_service.list_table_types(db, limit=limit, offset=offset)
 
 
 @router.get("/{type_id}", response_model=TableTypeOut)
 async def get_table_type(type_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    return table_type_to_dict(await get_or_404(db, TableType, type_id, "Table type not found."))
+    try:
+        return await table_types_service.get_table_type(db, type_id)
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.put("/{type_id}", response_model=TableTypeOut)
@@ -76,39 +58,12 @@ async def update_table_type(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    tt = await get_or_404(db, TableType, type_id, "Table type not found.")
-    if body.name is not None:
-        tt.name = body.name
-    if body.shape is not None:
-        tt.shape = body.shape
-    if body.width_m is not None:
-        tt.width_m = body.width_m
-    if body.length_m is not None:
-        tt.length_m = body.length_m
-    # Only normalise dimensions when shape or at least one dimension was updated.
-    if body.shape is not None or body.width_m is not None or body.length_m is not None:
-        if tt.shape == "round":
-            tt.length_m = tt.width_m
-        elif tt.length_m < tt.width_m:
-            tt.length_m, tt.width_m = tt.width_m, tt.length_m
-    if body.height_type is not None:
-        tt.height_type = body.height_type
-    if body.max_capacity is not None:
-        tt.max_capacity = body.max_capacity
-    if body.active is not None:
-        tt.active = body.active
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="table_type_updated",
-        resource_type="table_type",
-        resource_id=tt.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
-    )
-    await db.commit()
-    await db.refresh(tt)
-    return table_type_to_dict(tt)
+    try:
+        return await table_types_service.update_table_type(
+            db, actor=actor, type_id=type_id, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.delete("/{type_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -118,25 +73,9 @@ async def delete_table_type(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    tt = await get_or_404(db, TableType, type_id, "Table type not found.")
-    # Lock the table type row so a concurrent table creation (which validates the
-    # type exists before inserting) can't race this delete: whichever transaction
-    # locks the type first is the one the other serializes behind.
-    await db.execute(select(TableType.id).where(TableType.id == type_id).with_for_update())
-    in_use = await db.execute(select(Table).where(Table.table_type_id == type_id).limit(1))
-    if in_use.scalars().first() is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Cannot delete: tables are still using this type.",
+    try:
+        await table_types_service.delete_table_type(
+            db, actor=actor, type_id=type_id, request_id=getattr(request.state, "request_id", None)
         )
-    await db.delete(tt)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="table_type_deleted",
-        resource_type="table_type",
-        resource_id=type_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={},
-    )
-    await db.commit()
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc

--- a/backend/app/routers/tables.py
+++ b/backend/app/routers/tables.py
@@ -1,32 +1,24 @@
-"""Table management endpoints (admin only)."""
+"""Table management endpoints (admin only).
 
-import logging
+Business logic lives in ``app.services.tables_service`` and is shared with
+``app.mcp.admin.tables`` — this router is a thin adapter that translates
+``ServiceError`` into ``HTTPException`` (see #807).
+"""
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.live import live_bus
-from app.live import mapping as live_mapping
-from app.models import Layout, Registration, Table, TableType
 from app.schemas import TableCreate, TableOut, TableUpdate
-from app.utils import get_or_404, make_id, table_to_dict
-
-logger = logging.getLogger(__name__)
+from app.services import tables_service
+from app.services.errors import ServiceError, to_http_exception
 
 router = APIRouter(
     prefix="/api/tables",
     tags=["tables"],
     dependencies=[Depends(require_admin)],
 )
-
-
-# ---------------------------------------------------------------------------
-# Create table
-# ---------------------------------------------------------------------------
 
 
 @router.post("", response_model=TableOut, status_code=status.HTTP_201_CREATED)
@@ -36,85 +28,25 @@ async def create_table(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    tt = await db.execute(select(TableType).where(TableType.id == body.table_type_id))
-    if tt.scalar_one_or_none() is None:
-        raise HTTPException(status_code=404, detail=f"TableType '{body.table_type_id}' not found.")
-    lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
-    if lay.scalar_one_or_none() is None:
-        raise HTTPException(status_code=404, detail=f"Layout '{body.layout_id}' not found.")
-
-    t = Table(
-        id=make_id("tbl"),
-        name=body.name,
-        capacity=body.capacity,
-        x=body.x,
-        y=body.y,
-        table_type_id=body.table_type_id,
-        rotation=body.rotation,
-        layout_id=body.layout_id,
-    )
-    t.reservation_ids = []
-    db.add(t)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="table_created",
-        resource_type="table",
-        resource_id=t.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"layout_id": t.layout_id, "name": t.name},
-    )
-    await db.commit()
-    await db.refresh(t)
-    edition_id = await _get_layout_edition_id(db, t.layout_id)
     try:
-        await live_bus.publish(live_mapping.seating_changed(action="created", table_id=t.id, edition_id=edition_id))
-    except Exception:
-        logger.warning("live_bus.publish failed for table %s", t.id, exc_info=True)
-    # New tables have no reservations yet
-    return table_to_dict(t, [])
-
-
-# ---------------------------------------------------------------------------
-# List tables
-# ---------------------------------------------------------------------------
+        return await tables_service.create_table(
+            db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.get("", response_model=list[TableOut])
 async def list_tables(db: AsyncSession = Depends(get_db)) -> list[dict]:
-    result = await db.execute(select(Table).order_by(Table.created_at))
-    tables = result.scalars().all()
-
-    # Compute registration_ids from the Registration.table_id FK (source of truth),
-    # scoped to the tables actually being returned.
-    table_res_map: dict[str, list[str]] = {}
-    table_ids = [t.id for t in tables]
-    if table_ids:
-        res_result = await db.execute(
-            select(Registration.id, Registration.table_id).where(Registration.table_id.in_(table_ids))
-        )
-        for res_id, tbl_id in res_result.all():
-            table_res_map.setdefault(tbl_id, []).append(res_id)
-
-    return [table_to_dict(t, table_res_map.get(t.id, [])) for t in tables]
-
-
-# ---------------------------------------------------------------------------
-# Get single table
-# ---------------------------------------------------------------------------
+    return await tables_service.list_tables(db)
 
 
 @router.get("/{table_id}", response_model=TableOut)
 async def get_table(table_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    t = await get_or_404(db, Table, table_id, "Table not found.")
-    res_result = await db.execute(select(Registration.id).where(Registration.table_id == table_id))
-    registration_ids = [row[0] for row in res_result.all()]
-    return table_to_dict(t, registration_ids)
-
-
-# ---------------------------------------------------------------------------
-# Update table
-# ---------------------------------------------------------------------------
+    try:
+        return await tables_service.get_table(db, table_id)
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.put("/{table_id}", response_model=TableOut)
@@ -125,57 +57,12 @@ async def update_table(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    t = await get_or_404(db, Table, table_id, "Table not found.")
-
-    # All fields in TableUpdate are Optional[…], so an absent key and an
-    # explicit null both arrive here as None and are simply skipped.  Only
-    # fields with a real value are applied to the row.
-    if body.name is not None:
-        t.name = body.name
-    if body.capacity is not None:
-        t.capacity = body.capacity
-    if body.x is not None:
-        t.x = body.x
-    if body.y is not None:
-        t.y = body.y
-    if body.table_type_id is not None:
-        tt = await db.execute(select(TableType).where(TableType.id == body.table_type_id))
-        if tt.scalar_one_or_none() is None:
-            raise HTTPException(status_code=404, detail=f"TableType '{body.table_type_id}' not found.")
-        t.table_type_id = body.table_type_id
-    # Zero-valid fields: must use model_fields_set so that an explicit zero
-    # degrees (rotation=0) is honoured even though the value is falsy.
-    if "rotation" in body.model_fields_set and body.rotation is not None:
-        t.rotation = body.rotation
-    if "layout_id" in body.model_fields_set and body.layout_id is not None:
-        lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
-        if lay.scalar_one_or_none() is None:
-            raise HTTPException(status_code=404, detail=f"Layout '{body.layout_id}' not found.")
-        t.layout_id = body.layout_id
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="table_updated",
-        resource_type="table",
-        resource_id=table_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
-    )
-    await db.commit()
-    await db.refresh(t)
-    edition_id = await _get_layout_edition_id(db, t.layout_id)
     try:
-        await live_bus.publish(live_mapping.seating_changed(action="updated", table_id=table_id, edition_id=edition_id))
-    except Exception:
-        logger.warning("live_bus.publish failed for table %s", table_id, exc_info=True)
-    res_result = await db.execute(select(Registration.id).where(Registration.table_id == table_id))
-    registration_ids = [row[0] for row in res_result.all()]
-    return table_to_dict(t, registration_ids)
-
-
-# ---------------------------------------------------------------------------
-# Delete table
-# ---------------------------------------------------------------------------
+        return await tables_service.update_table(
+            db, actor=actor, table_id=table_id, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.delete("/{table_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -185,25 +72,9 @@ async def delete_table(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    t = await get_or_404(db, Table, table_id, "Table not found.")
-    edition_id = await _get_layout_edition_id(db, t.layout_id)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="table_deleted",
-        resource_type="table",
-        resource_id=table_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"layout_id": t.layout_id, "name": t.name},
-    )
-    await db.delete(t)
-    await db.commit()
     try:
-        await live_bus.publish(live_mapping.seating_changed(action="deleted", table_id=table_id, edition_id=edition_id))
-    except Exception:
-        logger.warning("live_bus.publish failed for deleted table %s", table_id, exc_info=True)
-
-
-async def _get_layout_edition_id(db: AsyncSession, layout_id: str) -> str | None:
-    result = await db.execute(select(Layout.edition_id).where(Layout.id == layout_id))
-    return result.scalar_one_or_none()
+        await tables_service.delete_table(
+            db, actor=actor, table_id=table_id, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc

--- a/backend/app/routers/venues.py
+++ b/backend/app/routers/venues.py
@@ -1,15 +1,18 @@
-"""Venue management endpoints."""
+"""Venue management endpoints.
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import select
+Business logic lives in ``app.services.venues_service`` and is shared with
+``app.mcp.admin.venues`` — this router is a thin adapter that translates
+``ServiceError`` into ``HTTPException`` (see #807).
+"""
+
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.models import Edition, Room, Venue
 from app.schemas import VenueCreate, VenueOut, VenueUpdate
-from app.utils import get_or_404, make_id, venue_to_dict
+from app.services import venues_service
+from app.services.errors import ServiceError, to_http_exception
 
 router = APIRouter(
     prefix="/api/venues",
@@ -25,29 +28,9 @@ async def create_venue(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    v = Venue(
-        id=make_id("venue"),
-        name=body.name,
-        address=body.address,
-        city=body.city,
-        postal_code=body.postal_code,
-        country=body.country,
-        lat=body.lat,
-        lng=body.lng,
+    return await venues_service.create_venue(
+        db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
     )
-    db.add(v)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="venue_created",
-        resource_type="venue",
-        resource_id=v.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"name": v.name},
-    )
-    await db.commit()
-    await db.refresh(v)
-    return venue_to_dict(v)
 
 
 @router.get("", response_model=list[VenueOut])
@@ -57,16 +40,15 @@ async def list_venues(
     limit: int | None = Query(default=None, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
 ) -> list[dict]:
-    stmt = select(Venue).order_by(Venue.created_at).offset(offset)
-    if limit is not None:
-        stmt = stmt.limit(limit)
-    result = await db.execute(stmt)
-    return [venue_to_dict(v) for v in result.scalars().all()]
+    return await venues_service.list_venues(db, limit=limit, offset=offset)
 
 
 @router.get("/{venue_id}", response_model=VenueOut, dependencies=[Depends(require_admin)])
 async def get_venue(venue_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    return venue_to_dict(await get_or_404(db, Venue, venue_id, "Venue not found."))
+    try:
+        return await venues_service.get_venue(db, venue_id)
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.put("/{venue_id}", response_model=VenueOut)
@@ -78,35 +60,12 @@ async def update_venue(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    v = await get_or_404(db, Venue, venue_id, "Venue not found.")
-    if body.name is not None:
-        v.name = body.name
-    if body.address is not None:
-        v.address = body.address
-    if body.city is not None:
-        v.city = body.city
-    if body.postal_code is not None:
-        v.postal_code = body.postal_code
-    if body.country is not None:
-        v.country = body.country
-    if body.lat is not None:
-        v.lat = body.lat
-    if body.lng is not None:
-        v.lng = body.lng
-    if body.active is not None:
-        v.active = body.active
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="venue_updated",
-        resource_type="venue",
-        resource_id=v.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
-    )
-    await db.commit()
-    await db.refresh(v)
-    return venue_to_dict(v)
+    try:
+        return await venues_service.update_venue(
+            db, actor=actor, venue_id=venue_id, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.delete("/{venue_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -117,31 +76,9 @@ async def delete_venue(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    v = await get_or_404(db, Venue, venue_id, "Venue not found.")
-    # Lock the venue row so a concurrent edition/room creation (which validates
-    # the venue exists before inserting) can't race this delete: whichever
-    # transaction locks the venue first is the one the other serializes behind.
-    await db.execute(select(Venue.id).where(Venue.id == venue_id).with_for_update())
-    in_use = await db.execute(select(Edition).where(Edition.venue_id == venue_id).limit(1))
-    if in_use.scalars().first() is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Cannot delete: editions are still using this venue.",
+    try:
+        await venues_service.delete_venue(
+            db, actor=actor, venue_id=venue_id, request_id=getattr(request.state, "request_id", None)
         )
-    rooms_in_use = await db.execute(select(Room).where(Room.venue_id == venue_id).limit(1))
-    if rooms_in_use.scalars().first() is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Cannot delete: rooms are still using this venue.",
-        )
-    await db.delete(v)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="venue_deleted",
-        resource_type="venue",
-        resource_id=venue_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={},
-    )
-    await db.commit()
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc

--- a/backend/app/routers/venues.py
+++ b/backend/app/routers/venues.py
@@ -28,9 +28,12 @@ async def create_venue(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    return await venues_service.create_venue(
-        db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
-    )
+    try:
+        return await venues_service.create_venue(
+            db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.get("", response_model=list[VenueOut])

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -953,6 +953,40 @@ class AuditEntryOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class IntegrationClientCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    allowed_role: Literal["admin", "volunteer"]
+    """Fixed at creation; never more privileged than the creating admin's own tier
+    (in practice always 'admin' here, since only admins can call this)."""
+    rate_limit_per_minute: int = Field(default=120, ge=1, le=6000)
+
+
+class IntegrationClientOut(BaseModel):
+    """Admin listing/detail shape — never includes the key hash or raw key."""
+
+    id: str
+    name: str
+    allowed_role: str
+    created_by_actor: str
+    rate_limit_per_minute: int
+    is_active: bool
+    created_at: datetime
+    last_used_at: datetime | None
+    revoked_at: datetime | None
+
+    model_config = {"from_attributes": True}
+
+
+class IntegrationClientCreatedOut(IntegrationClientOut):
+    """Returned only from create/rotate: carries the one-time raw key.
+
+    The raw key is never stored and never retrievable again after this
+    response — only its hash persists.
+    """
+
+    key: str
+
+
 class AppSettingsUpdate(BaseModel):
     maintenance_mode: bool | None = None
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -943,6 +943,9 @@ class AuditEntryOut(BaseModel):
     id: str
     timestamp: datetime
     actor: str
+    auth_source: str
+    subject: str | None
+    integration_client_id: str | None
     action: str
     resource_type: str
     resource_id: str
@@ -965,6 +968,7 @@ class IntegrationClientOut(BaseModel):
 
     id: str
     name: str
+    key_preview: str
     allowed_role: str
     created_by_actor: str
     rate_limit_per_minute: int

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -638,10 +638,9 @@ class TableTypeCreate(BaseModel):
 
     @model_validator(mode="after")
     def normalise_dimensions(self) -> Self:
-        if self.shape == "round":
-            self.length_m = self.width_m
-        elif self.length_m < self.width_m:
-            self.length_m, self.width_m = self.width_m, self.length_m
+        from app.utils import normalise_table_type_dimensions
+
+        self.width_m, self.length_m = normalise_table_type_dimensions(self.shape, self.width_m, self.length_m)
         return self
 
 

--- a/backend/app/services/areas_service.py
+++ b/backend/app/services/areas_service.py
@@ -89,24 +89,33 @@ async def update_area(
     if a is None:
         raise NotFoundError(f"Area '{area_id}' not found.")
 
+    fields_changed: list[str] = []
     if body.label is not None:
         a.label = body.label
+        fields_changed.append("label")
     if body.icon is not None:
         a.icon = body.icon
+        fields_changed.append("icon")
     if body.x is not None:
         a.x = body.x
+        fields_changed.append("x")
     if body.y is not None:
         a.y = body.y
+        fields_changed.append("y")
     if body.width_m is not None:
         a.width_m = body.width_m
+        fields_changed.append("width_m")
     if body.length_m is not None:
         a.length_m = body.length_m
+        fields_changed.append("length_m")
     if body.rotation is not None:
         a.rotation = body.rotation
+        fields_changed.append("rotation")
     if "exhibitor_id" in body.model_fields_set:
         if body.exhibitor_id is not None:
             await _check_exhibitor_assignable(db, body.exhibitor_id)
         a.exhibitor_id = body.exhibitor_id
+        fields_changed.append("exhibitor_id")
 
     await write_audit_entry(
         db,
@@ -115,7 +124,7 @@ async def update_area(
         resource_type="area",
         resource_id=a.id,
         request_id=request_id,
-        details={"fields_changed": sorted(body.model_fields_set)},
+        details={"fields_changed": sorted(fields_changed)},
     )
     await db.commit()
     await db.refresh(a)

--- a/backend/app/services/areas_service.py
+++ b/backend/app/services/areas_service.py
@@ -1,0 +1,140 @@
+"""Shared application-service operations for floor-plan areas.
+
+Used by both ``app.routers.areas`` (REST) and ``app.mcp.admin.areas`` (MCP).
+See ``app/services/layouts_service.py`` for the pattern this follows and
+``app/services/errors.py`` for the exception convention each adapter
+translates at its own boundary.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.models import Area, Exhibitor, Layout
+from app.schemas import AreaCreate, AreaUpdate
+from app.services.errors import NotFoundError, ValidationFailedError
+from app.utils import area_to_dict, make_id
+
+
+async def _check_exhibitor_assignable(db: AsyncSession, exhibitor_id: int) -> None:
+    ex = await db.execute(select(Exhibitor).where(Exhibitor.id == exhibitor_id))
+    exhibitor = ex.scalar_one_or_none()
+    if exhibitor is None:
+        raise NotFoundError(f"Exhibitor '{exhibitor_id}' not found.")
+    if not exhibitor.active:
+        raise ValidationFailedError(f"Exhibitor '{exhibitor_id}' is inactive.")
+
+
+async def create_area(db: AsyncSession, *, actor: str, body: AreaCreate, request_id: str | None = None) -> dict:
+    lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
+    if lay.scalar_one_or_none() is None:
+        raise NotFoundError(f"Layout '{body.layout_id}' not found.")
+
+    if body.exhibitor_id is not None:
+        await _check_exhibitor_assignable(db, body.exhibitor_id)
+
+    a = Area(
+        id=make_id("area"),
+        layout_id=body.layout_id,
+        label=body.label,
+        icon=body.icon,
+        exhibitor_id=body.exhibitor_id,
+        width_m=body.width_m,
+        length_m=body.length_m,
+        x=body.x,
+        y=body.y,
+        rotation=body.rotation,
+    )
+    db.add(a)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="area_created",
+        resource_type="area",
+        resource_id=a.id,
+        request_id=request_id,
+        details={"label": a.label, "layout_id": a.layout_id},
+    )
+    await db.commit()
+    await db.refresh(a)
+    return area_to_dict(a)
+
+
+async def list_areas(db: AsyncSession, layout_id: str | None = None) -> list[dict]:
+    stmt = select(Area).order_by(Area.created_at)
+    if layout_id:
+        stmt = stmt.where(Area.layout_id == layout_id)
+    result = await db.execute(stmt)
+    return [area_to_dict(a) for a in result.scalars().all()]
+
+
+async def get_area(db: AsyncSession, area_id: str) -> dict:
+    a = await db.get(Area, area_id)
+    if a is None:
+        raise NotFoundError(f"Area '{area_id}' not found.")
+    return area_to_dict(a)
+
+
+async def update_area(
+    db: AsyncSession,
+    *,
+    actor: str,
+    area_id: str,
+    body: AreaUpdate,
+    request_id: str | None = None,
+) -> dict:
+    a = await db.get(Area, area_id)
+    if a is None:
+        raise NotFoundError(f"Area '{area_id}' not found.")
+
+    if body.label is not None:
+        a.label = body.label
+    if body.icon is not None:
+        a.icon = body.icon
+    if body.x is not None:
+        a.x = body.x
+    if body.y is not None:
+        a.y = body.y
+    if body.width_m is not None:
+        a.width_m = body.width_m
+    if body.length_m is not None:
+        a.length_m = body.length_m
+    if body.rotation is not None:
+        a.rotation = body.rotation
+    if "exhibitor_id" in body.model_fields_set:
+        if body.exhibitor_id is not None:
+            await _check_exhibitor_assignable(db, body.exhibitor_id)
+        a.exhibitor_id = body.exhibitor_id
+
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="area_updated",
+        resource_type="area",
+        resource_id=a.id,
+        request_id=request_id,
+        details={"fields_changed": sorted(body.model_fields_set)},
+    )
+    await db.commit()
+    await db.refresh(a)
+    return area_to_dict(a)
+
+
+async def delete_area(db: AsyncSession, *, actor: str, area_id: str, request_id: str | None = None) -> dict:
+    a = await db.get(Area, area_id)
+    if a is None:
+        raise NotFoundError(f"Area '{area_id}' not found.")
+    await db.delete(a)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="area_deleted",
+        resource_type="area",
+        resource_id=area_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": area_id}

--- a/backend/app/services/errors.py
+++ b/backend/app/services/errors.py
@@ -1,0 +1,56 @@
+"""Shared error types for application services.
+
+Application services (``app/services/*_service.py``) implement validation,
+locking, and cascade-guard logic once, but REST (``app/routers/*.py``) and MCP
+(``app/mcp/admin/*.py``) each have their own error convention: FastAPI wants an
+``HTTPException`` with a status code, MCP tools want a plain ``ValueError``
+whose message reaches the calling agent. Services raise one of the exceptions
+below instead of either of those, and each adapter translates it at its own
+boundary (see ``app.services.errors.to_http_exception`` and
+``app.mcp.utils.as_value_error`` — MCP adapters can also just do
+``raise ValueError(str(exc)) from exc``).
+"""
+
+from __future__ import annotations
+
+
+class ServiceError(Exception):
+    """Base class for errors raised by application services.
+
+    ``status_code`` mirrors the HTTP status the REST adapter should return.
+    ``str(exc)`` (and ``exc.message``) is the human-readable detail shared
+    verbatim by both adapters.
+    """
+
+    def __init__(self, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+class NotFoundError(ServiceError):
+    """Raised when a referenced resource does not exist (404)."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, status_code=404)
+
+
+class ConflictError(ServiceError):
+    """Raised when an operation conflicts with existing state (409)."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, status_code=409)
+
+
+class ValidationFailedError(ServiceError):
+    """Raised for a business-rule validation failure that isn't a 404/409 (400)."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, status_code=400)
+
+
+def to_http_exception(exc: ServiceError):
+    """Convert a ``ServiceError`` into a FastAPI ``HTTPException`` for REST adapters."""
+    from fastapi import HTTPException
+
+    return HTTPException(status_code=exc.status_code, detail=exc.message)

--- a/backend/app/services/integration_clients_service.py
+++ b/backend/app/services/integration_clients_service.py
@@ -94,8 +94,12 @@ async def create_integration_client(
         raise ValidationFailedError("Only an admin caller may create an admin-tier integration client.")
     if not name.strip():
         raise ValidationFailedError("name must not be blank.")
+    if len(name.strip()) > 120:
+        raise ValidationFailedError("name must not exceed 120 characters.")
     if rate_limit_per_minute <= 0:
         raise ValidationFailedError("rate_limit_per_minute must be greater than 0.")
+    if rate_limit_per_minute > 6000:
+        raise ValidationFailedError("rate_limit_per_minute must not exceed 6000.")
 
     raw_key = _generate_raw_key()
     client = IntegrationClient(

--- a/backend/app/services/integration_clients_service.py
+++ b/backend/app/services/integration_clients_service.py
@@ -16,7 +16,6 @@ keyed hash would only add a secret to manage without a security benefit.
 
 from __future__ import annotations
 
-import collections
 import hashlib
 import secrets
 from datetime import UTC, datetime, timedelta
@@ -38,13 +37,6 @@ every public MCP tool already works with no authentication at all."""
 DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 _LAST_USED_UPDATE_INTERVAL = timedelta(minutes=5)
 
-# In-process sliding-window request timestamps, keyed by client id. Mirrors
-# app.ratelimit's per-IP limiter: process-local, so a multi-worker deployment
-# multiplies the effective limit by worker count. Acceptable for an
-# operator-issued automation credential; replace with a shared store if
-# strict enforcement across workers becomes necessary.
-_request_log: dict[str, collections.deque[datetime]] = {}
-
 
 def _hash_key(raw_key: str) -> str:
     return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
@@ -59,6 +51,7 @@ def integration_client_to_dict(client: IntegrationClient) -> dict:
     return {
         "id": client.id,
         "name": client.name,
+        "key_preview": client.key_preview,
         "allowed_role": client.allowed_role,
         "created_by_actor": client.created_by_actor,
         "rate_limit_per_minute": client.rate_limit_per_minute,
@@ -106,6 +99,7 @@ async def create_integration_client(
         id=make_id("ic"),
         name=name.strip(),
         key_hash=_hash_key(raw_key),
+        key_preview=raw_key[-8:],
         allowed_role=allowed_role,
         created_by_actor=actor,
         rate_limit_per_minute=rate_limit_per_minute,
@@ -172,6 +166,7 @@ async def rotate_integration_client(
         raise ConflictError(f"Integration client '{client_id}' is revoked; create a new one instead.")
     raw_key = _generate_raw_key()
     client.key_hash = _hash_key(raw_key)
+    client.key_preview = raw_key[-8:]
     client.last_used_at = None
     await write_audit_entry(
         db,
@@ -192,16 +187,24 @@ async def get_client_by_token_hash(db: AsyncSession, token_hash: str) -> Integra
     return result.scalar_one_or_none()
 
 
-def check_rate_limit(client_id: str, limit_per_minute: int) -> bool:
-    """In-process sliding-window rate limit for one client. Returns True if within limit."""
-    now = datetime.now(UTC)
-    cutoff = now - timedelta(minutes=1)
-    bucket = _request_log.setdefault(client_id, collections.deque())
-    while bucket and bucket[0] < cutoff:
-        bucket.popleft()
-    if len(bucket) >= limit_per_minute:
+async def check_rate_limit(db: AsyncSession, client_id: str) -> bool:
+    """Consume one database-backed fixed-window request across all workers."""
+    client = await db.scalar(select(IntegrationClient).where(IntegrationClient.id == client_id).with_for_update())
+    if client is None:
         return False
-    bucket.append(now)
+    now = datetime.now(UTC)
+    started = client.rate_limit_window_started_at
+    if started is not None and started.tzinfo is None:
+        started = started.replace(tzinfo=UTC)
+    if started is None or now - started >= timedelta(minutes=1):
+        client.rate_limit_window_started_at = now
+        client.rate_limit_window_count = 1
+    elif client.rate_limit_window_count >= client.rate_limit_per_minute:
+        await db.rollback()
+        return False
+    else:
+        client.rate_limit_window_count += 1
+    await db.commit()
     return True
 
 
@@ -220,7 +223,7 @@ async def authenticate_integration_client(db: AsyncSession, raw_token: str) -> I
     client = await get_client_by_token_hash(db, _hash_key(raw_token))
     if client is None or not client.is_active:
         return None
-    if not check_rate_limit(client.id, client.rate_limit_per_minute):
+    if not await check_rate_limit(db, client.id):
         return None
 
     now = datetime.now(UTC)

--- a/backend/app/services/integration_clients_service.py
+++ b/backend/app/services/integration_clients_service.py
@@ -1,0 +1,229 @@
+"""Managed integration-client credentials for machine automation (issue #807).
+
+Adapts daynest's database-backed integration-client pattern to
+Champagnefestival's stateless-JWT role model: there is no local ``User``
+table to own a client, so each ``IntegrationClient`` instead records
+``created_by_actor`` (the admin's OIDC ``sub``) and a single ``allowed_role``
+fixed at creation. A credential can never be created with a role tier more
+privileged than its creator's own tier — see ``create_integration_client``.
+
+Hashing follows the same convention as ``app.services.pebble_access``: a
+plain SHA-256 digest of a high-entropy, server-generated token. An HMAC with
+a server-side secret buys nothing extra at this entropy (128+ bits pulled
+from ``secrets.token_urlsafe``) — brute force is infeasible either way — so a
+keyed hash would only add a secret to manage without a security benefit.
+"""
+
+from __future__ import annotations
+
+import collections
+import hashlib
+import secrets
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.models import IntegrationClient
+from app.services.errors import ConflictError, NotFoundError, ValidationFailedError
+from app.utils import make_id
+
+TOKEN_PREFIX = "cfic_"
+ALLOWED_ROLES = ("admin", "volunteer")
+"""The only role tiers an integration client may resolve to. Deliberately
+excludes 'public' — a public-only credential has no reason to be issued, since
+every public MCP tool already works with no authentication at all."""
+
+DEFAULT_RATE_LIMIT_PER_MINUTE = 120
+_LAST_USED_UPDATE_INTERVAL = timedelta(minutes=5)
+
+# In-process sliding-window request timestamps, keyed by client id. Mirrors
+# app.ratelimit's per-IP limiter: process-local, so a multi-worker deployment
+# multiplies the effective limit by worker count. Acceptable for an
+# operator-issued automation credential; replace with a shared store if
+# strict enforcement across workers becomes necessary.
+_request_log: dict[str, collections.deque[datetime]] = {}
+
+
+def _hash_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+def _generate_raw_key() -> str:
+    return f"{TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
+
+
+def integration_client_to_dict(client: IntegrationClient) -> dict:
+    """Serialise a client — deliberately never includes key_hash or the raw key."""
+    return {
+        "id": client.id,
+        "name": client.name,
+        "allowed_role": client.allowed_role,
+        "created_by_actor": client.created_by_actor,
+        "rate_limit_per_minute": client.rate_limit_per_minute,
+        "is_active": client.is_active,
+        "created_at": client.created_at,
+        "last_used_at": client.last_used_at,
+        "revoked_at": client.revoked_at,
+    }
+
+
+async def create_integration_client(
+    db: AsyncSession,
+    *,
+    actor: str,
+    creator_role: str,
+    name: str,
+    allowed_role: str,
+    rate_limit_per_minute: int = DEFAULT_RATE_LIMIT_PER_MINUTE,
+    request_id: str | None = None,
+) -> tuple[dict, str]:
+    """Create a new integration client.
+
+    Returns ``(dict, raw_key)`` — the raw key is shown exactly once here and is
+    never recoverable afterward; only its hash is persisted.
+    """
+    if allowed_role not in ALLOWED_ROLES:
+        raise ValidationFailedError(f"allowed_role must be one of {ALLOWED_ROLES}.")
+    # An integration credential must never be able to mint a more privileged
+    # credential than its own creator's tier: 'admin' outranks 'volunteer'.
+    # In practice this endpoint is admin-only end to end, but this guard keeps
+    # that invariant true even if a future caller path changes.
+    if allowed_role == "admin" and creator_role != "admin":
+        raise ValidationFailedError("Only an admin caller may create an admin-tier integration client.")
+    if not name.strip():
+        raise ValidationFailedError("name must not be blank.")
+    if rate_limit_per_minute <= 0:
+        raise ValidationFailedError("rate_limit_per_minute must be greater than 0.")
+
+    raw_key = _generate_raw_key()
+    client = IntegrationClient(
+        id=make_id("ic"),
+        name=name.strip(),
+        key_hash=_hash_key(raw_key),
+        allowed_role=allowed_role,
+        created_by_actor=actor,
+        rate_limit_per_minute=rate_limit_per_minute,
+    )
+    db.add(client)
+    await db.flush()
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="integration_client_created",
+        resource_type="integration_client",
+        resource_id=client.id,
+        request_id=request_id,
+        details={"name": client.name, "allowed_role": client.allowed_role},
+    )
+    await db.commit()
+    await db.refresh(client)
+    return integration_client_to_dict(client), raw_key
+
+
+async def list_integration_clients(db: AsyncSession) -> list[dict]:
+    result = await db.execute(select(IntegrationClient).order_by(IntegrationClient.created_at))
+    return [integration_client_to_dict(c) for c in result.scalars().all()]
+
+
+async def get_integration_client(db: AsyncSession, client_id: str) -> IntegrationClient:
+    client = await db.get(IntegrationClient, client_id)
+    if client is None:
+        raise NotFoundError(f"Integration client '{client_id}' not found.")
+    return client
+
+
+async def revoke_integration_client(
+    db: AsyncSession, *, actor: str, client_id: str, request_id: str | None = None
+) -> dict:
+    client = await get_integration_client(db, client_id)
+    if not client.is_active:
+        raise ConflictError(f"Integration client '{client_id}' is already revoked.")
+    client.is_active = False
+    client.revoked_at = datetime.now(UTC)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="integration_client_revoked",
+        resource_type="integration_client",
+        resource_id=client_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    await db.refresh(client)
+    return integration_client_to_dict(client)
+
+
+async def rotate_integration_client(
+    db: AsyncSession, *, actor: str, client_id: str, request_id: str | None = None
+) -> tuple[dict, str]:
+    """Replace a client's credential with a freshly generated one.
+
+    Returns ``(dict, raw_key)`` — same one-time-reveal contract as creation.
+    """
+    client = await get_integration_client(db, client_id)
+    if not client.is_active:
+        raise ConflictError(f"Integration client '{client_id}' is revoked; create a new one instead.")
+    raw_key = _generate_raw_key()
+    client.key_hash = _hash_key(raw_key)
+    client.last_used_at = None
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="integration_client_rotated",
+        resource_type="integration_client",
+        resource_id=client_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    await db.refresh(client)
+    return integration_client_to_dict(client), raw_key
+
+
+async def get_client_by_token_hash(db: AsyncSession, token_hash: str) -> IntegrationClient | None:
+    result = await db.execute(select(IntegrationClient).where(IntegrationClient.key_hash == token_hash))
+    return result.scalar_one_or_none()
+
+
+def check_rate_limit(client_id: str, limit_per_minute: int) -> bool:
+    """In-process sliding-window rate limit for one client. Returns True if within limit."""
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(minutes=1)
+    bucket = _request_log.setdefault(client_id, collections.deque())
+    while bucket and bucket[0] < cutoff:
+        bucket.popleft()
+    if len(bucket) >= limit_per_minute:
+        return False
+    bucket.append(now)
+    return True
+
+
+async def authenticate_integration_client(db: AsyncSession, raw_token: str) -> IntegrationClient | None:
+    """Validate a raw bearer token against the integration_clients table.
+
+    Returns the active, rate-limit-passing client, or ``None`` on any failure
+    (unknown token, inactive/revoked client, rate limit exceeded) — deliberately
+    a single opaque failure mode so a caller can't distinguish "wrong token"
+    from "right token, but revoked" or "right token, but rate limited".
+    Updates ``last_used_at`` (throttled, like app.services.pebble_access, to
+    avoid a write on every single call) on success.
+    """
+    if not raw_token.startswith(TOKEN_PREFIX):
+        return None
+    client = await get_client_by_token_hash(db, _hash_key(raw_token))
+    if client is None or not client.is_active:
+        return None
+    if not check_rate_limit(client.id, client.rate_limit_per_minute):
+        return None
+
+    now = datetime.now(UTC)
+    last_used_at = client.last_used_at
+    if last_used_at is not None and last_used_at.tzinfo is None:
+        last_used_at = last_used_at.replace(tzinfo=UTC)
+    if last_used_at is None or now - last_used_at >= _LAST_USED_UPDATE_INTERVAL:
+        client.last_used_at = now
+        await db.commit()
+    return client

--- a/backend/app/services/layouts_service.py
+++ b/backend/app/services/layouts_service.py
@@ -1,0 +1,361 @@
+"""Shared application-service operations for floor-plan layouts.
+
+Used by both ``app.routers.layouts`` (REST) and ``app.mcp.admin.layouts``
+(MCP) so validation, row locking, cascade guards, and audit-detail
+construction live in exactly one place instead of being duplicated between
+the two surfaces (see issue #807). Callers pass an already-open
+``AsyncSession`` and a validated Pydantic schema instance; each adapter is
+responsible for opening/closing the session and translating a
+``ServiceError`` into its own error convention (see ``app/services/errors.py``).
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date as dt_date
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.audit import write_audit_entry
+from app.models import Area, Edition, Exhibitor, Layout, Room, Table, TableType
+from app.schemas import LayoutCopyCreate, LayoutCreate
+from app.services.errors import ConflictError, NotFoundError, ValidationFailedError
+from app.utils import layout_to_dict, make_id
+
+# Mirror the rendering constants from frontend/src/utils/layoutUtils.ts so that
+# the backend containment check matches the frontend's hit-testing exactly.
+_PX_PER_M: int = 28
+_MIN_CANVAS_WIDTH_PX: int = 280
+_MIN_CANVAS_HEIGHT_PX: int = 180
+_MIN_AREA_WIDTH_PX: int = 40
+_MIN_AREA_HEIGHT_PX: int = 24
+_MIN_TABLE_SIZE_PX: int = 32
+
+
+def _js_round(x: float) -> int:
+    """Round a non-negative float the same way JS Math.round does.
+
+    Python's built-in round() uses banker's rounding (round half to even),
+    whereas JS Math.round always rounds 0.5 up (towards +∞).  For the
+    positive pixel values we deal with here the difference is:
+      Python: round(0.5) == 0   JS: Math.round(0.5) == 1
+    Using math.floor(x + 0.5) reproduces the JS behaviour for x >= 0.
+    """
+    return math.floor(x + 0.5)
+
+
+def table_in_any_area(
+    table: Table,
+    areas: list[Area],
+    table_types: dict[str, TableType],
+    room: Room,
+) -> bool:
+    """Return True if the table's centre falls inside any of the given areas.
+
+    All geometry is computed in pixel space using the same rounding and minimum
+    rendered dimensions as the frontend (layoutUtils.ts / getAreaSizePx /
+    getTableSizePx), so the result matches what the user sees in the editor.
+    """
+    # Effective canvas dimensions (pixels) — match getCanvasSizePx
+    canvas_w = max(_MIN_CANVAS_WIDTH_PX, room.width_m * _PX_PER_M)
+    canvas_h = max(_MIN_CANVAS_HEIGHT_PX, room.length_m * _PX_PER_M)
+
+    # Effective table size (pixels) — match getTableSizePx
+    table_type = table_types.get(table.table_type_id)
+    table_w_px = max(_MIN_TABLE_SIZE_PX, _js_round((table_type.width_m if table_type else 1.0) * _PX_PER_M))
+    table_h_px = max(_MIN_TABLE_SIZE_PX, _js_round((table_type.length_m if table_type else 1.0) * _PX_PER_M))
+
+    # Table centre in canvas pixels
+    table_cx = (table.x / 100.0) * canvas_w + table_w_px / 2.0
+    table_cy = (table.y / 100.0) * canvas_h + table_h_px / 2.0
+
+    for area in areas:
+        # Effective area size (pixels) — match getAreaSizePx
+        area_w_px = max(_MIN_AREA_WIDTH_PX, _js_round(area.width_m * _PX_PER_M))
+        area_h_px = max(_MIN_AREA_HEIGHT_PX, _js_round(area.length_m * _PX_PER_M))
+
+        # Area centre in canvas pixels
+        area_left = (area.x / 100.0) * canvas_w
+        area_top = (area.y / 100.0) * canvas_h
+        area_cx = area_left + area_w_px / 2.0
+        area_cy = area_top + area_h_px / 2.0
+
+        # Rotate table centre into area-local space (negate rotation to invert)
+        radians = -((area.rotation or 0) * math.pi / 180.0)
+        cos_v = math.cos(radians)
+        sin_v = math.sin(radians)
+
+        dx = table_cx - area_cx
+        dy = table_cy - area_cy
+        lx = cos_v * dx - sin_v * dy
+        ly = sin_v * dx + cos_v * dy
+
+        if abs(lx) <= area_w_px / 2.0 and abs(ly) <= area_h_px / 2.0:
+            return True
+    return False
+
+
+async def resolve_layout_day(db: AsyncSession, body: LayoutCreate | LayoutCopyCreate) -> tuple[int, dt_date | None]:
+    if body.date is None:
+        return body.day_id or 1, None
+    if not body.edition_id:
+        raise ValidationFailedError("edition_id is required when date is provided.")
+
+    result = await db.execute(
+        select(Edition).options(selectinload(Edition.events)).where(Edition.id == body.edition_id)
+    )
+    edition = result.scalar_one_or_none()
+    if edition is None:
+        raise NotFoundError("Edition not found.")
+
+    unique_dates = sorted({event.date for event in edition.events})
+    if body.date not in unique_dates:
+        raise ValidationFailedError("Layout date must match one of the edition event dates.")
+    return unique_dates.index(body.date) + 1, body.date
+
+
+async def layout_payloads(db: AsyncSession, layouts: list[Layout]) -> list[dict]:
+    edition_ids = {layout.edition_id for layout in layouts if layout.edition_id}
+    edition_dates_by_id: dict[str, list] = {}
+    if edition_ids:
+        result = await db.execute(
+            select(Edition).options(selectinload(Edition.events)).where(Edition.id.in_(edition_ids))
+        )
+        for edition in result.scalars().all():
+            edition_dates_by_id[edition.id] = sorted({event.date for event in edition.events})
+
+    payloads: list[dict] = []
+    for layout in layouts:
+        date = None
+        if layout.edition_id and layout.edition_id in edition_dates_by_id:
+            dates = edition_dates_by_id[layout.edition_id]
+            if 1 <= layout.day_id <= len(dates):
+                date = dates[layout.day_id - 1]
+        payloads.append(layout_to_dict(layout, date=date))
+    return payloads
+
+
+async def _reject_if_duplicate(db: AsyncSession, *, room_id: str, day_id: int, edition_id: str | None) -> None:
+    existing_stmt = select(Layout).where(Layout.room_id == room_id, Layout.day_id == day_id)
+    existing_stmt = (
+        existing_stmt.where(Layout.edition_id.is_(None))
+        if edition_id is None
+        else existing_stmt.where(Layout.edition_id == edition_id)
+    )
+    existing = (await db.execute(existing_stmt.limit(1))).scalar_one_or_none()
+    if existing is not None:
+        raise ConflictError("A layout already exists for this room and day.")
+
+
+async def create_layout(
+    db: AsyncSession,
+    *,
+    actor: str,
+    body: LayoutCreate,
+    request_id: str | None = None,
+) -> dict:
+    resolved_day_id, resolved_date = await resolve_layout_day(db, body)
+
+    # Lock the room row so a concurrent room deletion (which refuses to proceed
+    # while layouts reference the room) can't race this insert: whichever
+    # transaction locks the room first is the one the other serializes behind.
+    # Also doubles as the room-existence check — an unchecked bogus room_id
+    # would otherwise surface as a raw FK IntegrityError instead of a clean,
+    # uniform NotFoundError.
+    locked_room = (await db.execute(select(Room.id).where(Room.id == body.room_id).with_for_update())).scalar_one_or_none()
+    if locked_room is None:
+        raise NotFoundError(f"Room '{body.room_id}' not found.")
+
+    await _reject_if_duplicate(db, room_id=body.room_id, day_id=resolved_day_id, edition_id=body.edition_id)
+
+    lay = Layout(
+        id=make_id("lay"),
+        edition_id=body.edition_id,
+        room_id=body.room_id,
+        day_id=resolved_day_id,
+        label=body.label.strip(),
+    )
+    db.add(lay)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="layout_created",
+        resource_type="layout",
+        resource_id=lay.id,
+        request_id=request_id,
+        details={"room_id": lay.room_id, "day_id": lay.day_id},
+    )
+    await db.commit()
+    await db.refresh(lay)
+    return layout_to_dict(lay, date=resolved_date)
+
+
+async def copy_layout(
+    db: AsyncSession,
+    *,
+    actor: str,
+    source_layout_id: str,
+    body: LayoutCopyCreate,
+    request_id: str | None = None,
+) -> dict:
+    source = await db.get(Layout, source_layout_id)
+    if source is None:
+        raise NotFoundError(f"Layout '{source_layout_id}' not found.")
+
+    resolved_day_id, resolved_date = await resolve_layout_day(db, body)
+
+    # See create_layout: lock the target room (also doubling as the existence
+    # check) so it can't be deleted out from under this insert.
+    locked_target_room = (
+        await db.execute(select(Room.id).where(Room.id == body.room_id).with_for_update())
+    ).scalar_one_or_none()
+    if locked_target_room is None:
+        raise NotFoundError(f"Room '{body.room_id}' not found.")
+
+    await _reject_if_duplicate(db, room_id=body.room_id, day_id=resolved_day_id, edition_id=body.edition_id)
+
+    room_stmt = select(Room).where(Room.id == source.room_id)
+    source_room = (await db.execute(room_stmt)).scalar_one_or_none()
+    if source_room is None:
+        raise NotFoundError("Source room not found.")
+
+    source_tables = (await db.execute(select(Table).where(Table.layout_id == source_layout_id))).scalars().all()
+    source_areas = (await db.execute(select(Area).where(Area.layout_id == source_layout_id))).scalars().all()
+
+    table_type_ids = {t.table_type_id for t in source_tables}
+    table_types: dict[str, TableType] = {}
+    if table_type_ids:
+        result = await db.execute(select(TableType).where(TableType.id.in_(table_type_ids)))
+        table_types = {tt.id: tt for tt in result.scalars().all()}
+
+    cloned = Layout(
+        id=make_id("lay"),
+        edition_id=body.edition_id,
+        room_id=body.room_id,
+        day_id=resolved_day_id,
+        label=body.label.strip(),
+    )
+    db.add(cloned)
+    await db.flush()
+
+    # Tables inside areas travel with copy_areas; tables outside areas travel with copy_tables.
+    all_areas = list(source_areas)
+    tables_inside: list[Table] = []
+    if body.copy_areas and all_areas:
+        tables_inside = [table for table in source_tables if table_in_any_area(table, all_areas, table_types, source_room)]
+
+    tables_outside: list[Table] = []
+    if body.copy_tables:
+        if body.copy_areas and all_areas:
+            tables_outside = [
+                table for table in source_tables if not table_in_any_area(table, all_areas, table_types, source_room)
+            ]
+        else:
+            tables_outside = list(source_tables)
+
+    tables_to_copy = tables_inside + tables_outside
+
+    for table in tables_to_copy:
+        db.add(
+            Table(
+                id=make_id("tbl"),
+                name=table.name,
+                capacity=table.capacity,
+                x=table.x,
+                y=table.y,
+                table_type_id=table.table_type_id,
+                rotation=table.rotation,
+                layout_id=cloned.id,
+                reservation_ids=[],
+            )
+        )
+
+    if body.copy_areas:
+        # An area whose exhibitor was deactivated after the source area was created
+        # (or last updated) must not be silently carried into the copy — create_area
+        # and update_area both refuse to assign an inactive exhibitor, so the copy
+        # path can't create areas those tools would reject.
+        exhibitor_ids = {area.exhibitor_id for area in source_areas if area.exhibitor_id is not None}
+        if exhibitor_ids:
+            active_result = await db.execute(
+                select(Exhibitor.id).where(Exhibitor.id.in_(exhibitor_ids), Exhibitor.active.is_(True))
+            )
+            active_ids = set(active_result.scalars().all())
+            inactive_ids = sorted(exhibitor_ids - active_ids)
+            if inactive_ids:
+                raise ValidationFailedError(
+                    "Cannot copy: the following areas reference an inactive or "
+                    f"deleted exhibitor: {inactive_ids}. Update those areas first."
+                )
+        for area in source_areas:
+            db.add(
+                Area(
+                    id=make_id("area"),
+                    layout_id=cloned.id,
+                    label=area.label,
+                    icon=area.icon,
+                    exhibitor_id=area.exhibitor_id,
+                    width_m=area.width_m,
+                    length_m=area.length_m,
+                    x=area.x,
+                    y=area.y,
+                    rotation=area.rotation,
+                )
+            )
+
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="layout_copied",
+        resource_type="layout",
+        resource_id=cloned.id,
+        request_id=request_id,
+        details={"source_layout_id": source_layout_id, "room_id": cloned.room_id, "day_id": cloned.day_id},
+    )
+    await db.commit()
+    await db.refresh(cloned)
+    return layout_to_dict(cloned, date=resolved_date)
+
+
+async def list_layouts(db: AsyncSession, *, limit: int | None = None, offset: int = 0) -> list[dict]:
+    stmt = select(Layout).order_by(Layout.created_at).offset(offset)
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    result = await db.execute(stmt)
+    layouts = list(result.scalars().all())
+    return await layout_payloads(db, layouts)
+
+
+async def get_layout(db: AsyncSession, layout_id: str) -> dict:
+    lay = await db.get(Layout, layout_id)
+    if lay is None:
+        raise NotFoundError(f"Layout '{layout_id}' not found.")
+    payloads = await layout_payloads(db, [lay])
+    return payloads[0]
+
+
+async def delete_layout(db: AsyncSession, *, actor: str, layout_id: str, request_id: str | None = None) -> dict:
+    lay = await db.get(Layout, layout_id)
+    if lay is None:
+        raise NotFoundError(f"Layout '{layout_id}' not found.")
+    # Lock the layout row so a concurrent table creation/copy (which validates the
+    # layout exists before inserting) can't race this delete: whichever
+    # transaction locks the layout first is the one the other serializes behind.
+    await db.execute(select(Layout.id).where(Layout.id == layout_id).with_for_update())
+    tables_in_use = await db.execute(select(Table).where(Table.layout_id == layout_id).limit(1))
+    if tables_in_use.scalars().first() is not None:
+        raise ConflictError("Cannot delete: tables are still assigned to this layout.")
+    await db.delete(lay)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="layout_deleted",
+        resource_type="layout",
+        resource_id=layout_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": layout_id}

--- a/backend/app/services/layouts_service.py
+++ b/backend/app/services/layouts_service.py
@@ -226,6 +226,22 @@ async def copy_layout(
     source_tables = (await db.execute(select(Table).where(Table.layout_id == source_layout_id))).scalars().all()
     source_areas = (await db.execute(select(Area).where(Area.layout_id == source_layout_id))).scalars().all()
 
+    # Validate inactive exhibitors before creating any pending inserts — fail fast
+    # before db.add(cloned) / db.flush() or table copies.
+    if body.copy_areas:
+        exhibitor_ids = {area.exhibitor_id for area in source_areas if area.exhibitor_id is not None}
+        if exhibitor_ids:
+            active_result = await db.execute(
+                select(Exhibitor.id).where(Exhibitor.id.in_(exhibitor_ids), Exhibitor.active.is_(True))
+            )
+            active_ids = set(active_result.scalars().all())
+            inactive_ids = sorted(exhibitor_ids - active_ids)
+            if inactive_ids:
+                raise ValidationFailedError(
+                    "Cannot copy: the following areas reference an inactive or "
+                    f"deleted exhibitor: {inactive_ids}. Update those areas first."
+                )
+
     table_type_ids = {t.table_type_id for t in source_tables}
     table_types: dict[str, TableType] = {}
     if table_type_ids:
@@ -277,22 +293,6 @@ async def copy_layout(
         )
 
     if body.copy_areas:
-        # An area whose exhibitor was deactivated after the source area was created
-        # (or last updated) must not be silently carried into the copy — create_area
-        # and update_area both refuse to assign an inactive exhibitor, so the copy
-        # path can't create areas those tools would reject.
-        exhibitor_ids = {area.exhibitor_id for area in source_areas if area.exhibitor_id is not None}
-        if exhibitor_ids:
-            active_result = await db.execute(
-                select(Exhibitor.id).where(Exhibitor.id.in_(exhibitor_ids), Exhibitor.active.is_(True))
-            )
-            active_ids = set(active_result.scalars().all())
-            inactive_ids = sorted(exhibitor_ids - active_ids)
-            if inactive_ids:
-                raise ValidationFailedError(
-                    "Cannot copy: the following areas reference an inactive or "
-                    f"deleted exhibitor: {inactive_ids}. Update those areas first."
-                )
         for area in source_areas:
             db.add(
                 Area(

--- a/backend/app/services/layouts_service.py
+++ b/backend/app/services/layouts_service.py
@@ -164,7 +164,9 @@ async def create_layout(
     # Also doubles as the room-existence check — an unchecked bogus room_id
     # would otherwise surface as a raw FK IntegrityError instead of a clean,
     # uniform NotFoundError.
-    locked_room = (await db.execute(select(Room.id).where(Room.id == body.room_id).with_for_update())).scalar_one_or_none()
+    locked_room = (
+        await db.execute(select(Room.id).where(Room.id == body.room_id).with_for_update())
+    ).scalar_one_or_none()
     if locked_room is None:
         raise NotFoundError(f"Room '{body.room_id}' not found.")
 
@@ -244,7 +246,9 @@ async def copy_layout(
     all_areas = list(source_areas)
     tables_inside: list[Table] = []
     if body.copy_areas and all_areas:
-        tables_inside = [table for table in source_tables if table_in_any_area(table, all_areas, table_types, source_room)]
+        tables_inside = [
+            table for table in source_tables if table_in_any_area(table, all_areas, table_types, source_room)
+        ]
 
     tables_outside: list[Table] = []
     if body.copy_tables:

--- a/backend/app/services/rooms_service.py
+++ b/backend/app/services/rooms_service.py
@@ -1,0 +1,106 @@
+"""Shared application-service operations for rooms.
+
+Used by both ``app.routers.rooms`` (REST) and ``app.mcp.admin.rooms`` (MCP).
+See ``app/services/layouts_service.py`` for the pattern this follows and
+``app/services/errors.py`` for the exception convention each adapter
+translates at its own boundary.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.models import Layout, Room, Venue
+from app.schemas import RoomCreate, RoomUpdate
+from app.services.errors import ConflictError, NotFoundError
+from app.utils import make_id, room_to_dict
+
+
+async def create_room(db: AsyncSession, *, actor: str, body: RoomCreate, request_id: str | None = None) -> dict:
+    venue = await db.execute(select(Venue).where(Venue.id == body.venue_id))
+    if venue.scalar_one_or_none() is None:
+        raise NotFoundError(f"Venue '{body.venue_id}' not found.")
+
+    r = Room(
+        id=make_id("room"),
+        venue_id=body.venue_id,
+        name=body.name,
+        width_m=body.width_m,
+        length_m=body.length_m,
+        color=body.color,
+        active=body.active,
+    )
+    db.add(r)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="room_created",
+        resource_type="room",
+        resource_id=r.id,
+        request_id=request_id,
+        details={"name": r.name, "venue_id": r.venue_id},
+    )
+    await db.commit()
+    await db.refresh(r)
+    return room_to_dict(r)
+
+
+async def list_rooms(db: AsyncSession) -> list[dict]:
+    result = await db.execute(select(Room).order_by(Room.created_at))
+    return [room_to_dict(r) for r in result.scalars().all()]
+
+
+async def get_room(db: AsyncSession, room_id: str) -> dict:
+    r = await db.get(Room, room_id)
+    if r is None:
+        raise NotFoundError(f"Room '{room_id}' not found.")
+    return room_to_dict(r)
+
+
+async def update_room(
+    db: AsyncSession, *, actor: str, room_id: str, body: RoomUpdate, request_id: str | None = None
+) -> dict:
+    r = await db.get(Room, room_id)
+    if r is None:
+        raise NotFoundError(f"Room '{room_id}' not found.")
+    for field in body.model_fields_set:
+        setattr(r, field, getattr(body, field))
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="room_updated",
+        resource_type="room",
+        resource_id=r.id,
+        request_id=request_id,
+        details={"fields_changed": sorted(body.model_fields_set)},
+    )
+    await db.commit()
+    await db.refresh(r)
+    return room_to_dict(r)
+
+
+async def delete_room(db: AsyncSession, *, actor: str, room_id: str, request_id: str | None = None) -> dict:
+    r = await db.get(Room, room_id)
+    if r is None:
+        raise NotFoundError(f"Room '{room_id}' not found.")
+    # Lock the room row so a concurrent layout creation (see layouts_service.create_layout
+    # and copy_layout) can't insert a new layout for this room between our check
+    # and the delete below, which would otherwise cascade-delete it silently.
+    await db.execute(select(Room.id).where(Room.id == room_id).with_for_update())
+    layouts_in_use = await db.execute(select(Layout).where(Layout.room_id == room_id).limit(1))
+    if layouts_in_use.scalars().first() is not None:
+        raise ConflictError("Cannot delete: layouts are still using this room.")
+    await db.delete(r)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="room_deleted",
+        resource_type="room",
+        resource_id=room_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": room_id}

--- a/backend/app/services/table_types_service.py
+++ b/backend/app/services/table_types_service.py
@@ -51,7 +51,7 @@ async def create_table_type(
 
 
 async def list_table_types(db: AsyncSession, *, limit: int | None = None, offset: int = 0) -> list[dict]:
-    stmt = select(TableType).order_by(TableType.created_at).offset(offset)
+    stmt = select(TableType).order_by(TableType.created_at, TableType.id).offset(offset)
     if limit is not None:
         stmt = stmt.limit(limit)
     result = await db.execute(stmt)
@@ -79,13 +79,10 @@ async def update_table_type(
         tt.width_m = body.width_m
     if body.length_m is not None:
         tt.length_m = body.length_m
-    # TableTypeUpdate has no model_validator (unlike TableTypeCreate), so the
-    # normalisation is re-derived by hand after applying fields.
     if body.shape is not None or body.width_m is not None or body.length_m is not None:
-        if tt.shape == "round":
-            tt.length_m = tt.width_m
-        elif tt.length_m < tt.width_m:
-            tt.length_m, tt.width_m = tt.width_m, tt.length_m
+        from app.utils import normalise_table_type_dimensions
+
+        tt.width_m, tt.length_m = normalise_table_type_dimensions(tt.shape, tt.width_m, tt.length_m)
     if body.height_type is not None:
         tt.height_type = body.height_type
     if body.max_capacity is not None:

--- a/backend/app/services/table_types_service.py
+++ b/backend/app/services/table_types_service.py
@@ -1,0 +1,131 @@
+"""Shared application-service operations for table types.
+
+Used by both ``app.routers.table_types`` (REST) and
+``app.mcp.admin.table_types`` (MCP). See ``app/services/layouts_service.py``
+for the pattern this follows and ``app/services/errors.py`` for the
+exception convention each adapter translates at its own boundary.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.models import Table, TableType
+from app.schemas import TableTypeCreate, TableTypeUpdate
+from app.services.errors import ConflictError, NotFoundError
+from app.utils import make_id, table_type_to_dict
+
+
+async def create_table_type(
+    db: AsyncSession, *, actor: str, body: TableTypeCreate, request_id: str | None = None
+) -> dict:
+    # TableTypeCreate.normalise_dimensions (a model_validator) forces
+    # length_m == width_m for round tables and swaps them if length_m <
+    # width_m for rectangular ones — it already ran on `body` at the REST/MCP
+    # boundary, so this row copies its normalised values as-is.
+    tt = TableType(
+        id=make_id("ttype"),
+        name=body.name,
+        shape=body.shape,
+        width_m=body.width_m,
+        length_m=body.length_m,
+        height_type=body.height_type,
+        max_capacity=body.max_capacity,
+        active=body.active,
+    )
+    db.add(tt)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="table_type_created",
+        resource_type="table_type",
+        resource_id=tt.id,
+        request_id=request_id,
+        details={"name": tt.name, "shape": tt.shape},
+    )
+    await db.commit()
+    await db.refresh(tt)
+    return table_type_to_dict(tt)
+
+
+async def list_table_types(db: AsyncSession, *, limit: int | None = None, offset: int = 0) -> list[dict]:
+    stmt = select(TableType).order_by(TableType.created_at).offset(offset)
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    result = await db.execute(stmt)
+    return [table_type_to_dict(tt) for tt in result.scalars().all()]
+
+
+async def get_table_type(db: AsyncSession, type_id: str) -> dict:
+    tt = await db.get(TableType, type_id)
+    if tt is None:
+        raise NotFoundError(f"Table type '{type_id}' not found.")
+    return table_type_to_dict(tt)
+
+
+async def update_table_type(
+    db: AsyncSession, *, actor: str, type_id: str, body: TableTypeUpdate, request_id: str | None = None
+) -> dict:
+    tt = await db.get(TableType, type_id)
+    if tt is None:
+        raise NotFoundError(f"Table type '{type_id}' not found.")
+    if body.name is not None:
+        tt.name = body.name
+    if body.shape is not None:
+        tt.shape = body.shape
+    if body.width_m is not None:
+        tt.width_m = body.width_m
+    if body.length_m is not None:
+        tt.length_m = body.length_m
+    # TableTypeUpdate has no model_validator (unlike TableTypeCreate), so the
+    # normalisation is re-derived by hand after applying fields.
+    if body.shape is not None or body.width_m is not None or body.length_m is not None:
+        if tt.shape == "round":
+            tt.length_m = tt.width_m
+        elif tt.length_m < tt.width_m:
+            tt.length_m, tt.width_m = tt.width_m, tt.length_m
+    if body.height_type is not None:
+        tt.height_type = body.height_type
+    if body.max_capacity is not None:
+        tt.max_capacity = body.max_capacity
+    if body.active is not None:
+        tt.active = body.active
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="table_type_updated",
+        resource_type="table_type",
+        resource_id=tt.id,
+        request_id=request_id,
+        details={"fields_changed": sorted(body.model_fields_set)},
+    )
+    await db.commit()
+    await db.refresh(tt)
+    return table_type_to_dict(tt)
+
+
+async def delete_table_type(db: AsyncSession, *, actor: str, type_id: str, request_id: str | None = None) -> dict:
+    tt = await db.get(TableType, type_id)
+    if tt is None:
+        raise NotFoundError(f"Table type '{type_id}' not found.")
+    # Lock the table type row so a concurrent table creation (which validates the
+    # type exists before inserting) can't race this delete: whichever transaction
+    # locks the type first is the one the other serializes behind.
+    await db.execute(select(TableType.id).where(TableType.id == type_id).with_for_update())
+    in_use = await db.execute(select(Table).where(Table.table_type_id == type_id).limit(1))
+    if in_use.scalars().first() is not None:
+        raise ConflictError("Cannot delete: tables are still using this type.")
+    await db.delete(tt)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="table_type_deleted",
+        resource_type="table_type",
+        resource_id=type_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": type_id}

--- a/backend/app/services/table_types_service.py
+++ b/backend/app/services/table_types_service.py
@@ -71,24 +71,37 @@ async def update_table_type(
     tt = await db.get(TableType, type_id)
     if tt is None:
         raise NotFoundError(f"Table type '{type_id}' not found.")
+    fields_changed: list[str] = []
+    pre_width, pre_length = tt.width_m, tt.length_m
     if body.name is not None:
         tt.name = body.name
+        fields_changed.append("name")
     if body.shape is not None:
         tt.shape = body.shape
+        fields_changed.append("shape")
     if body.width_m is not None:
         tt.width_m = body.width_m
+        fields_changed.append("width_m")
     if body.length_m is not None:
         tt.length_m = body.length_m
+        fields_changed.append("length_m")
     if body.shape is not None or body.width_m is not None or body.length_m is not None:
         from app.utils import normalise_table_type_dimensions
 
         tt.width_m, tt.length_m = normalise_table_type_dimensions(tt.shape, tt.width_m, tt.length_m)
+        if tt.width_m != pre_width and "width_m" not in fields_changed:
+            fields_changed.append("width_m")
+        if tt.length_m != pre_length and "length_m" not in fields_changed:
+            fields_changed.append("length_m")
     if body.height_type is not None:
         tt.height_type = body.height_type
+        fields_changed.append("height_type")
     if body.max_capacity is not None:
         tt.max_capacity = body.max_capacity
+        fields_changed.append("max_capacity")
     if body.active is not None:
         tt.active = body.active
+        fields_changed.append("active")
     await write_audit_entry(
         db,
         actor=actor,
@@ -96,7 +109,7 @@ async def update_table_type(
         resource_type="table_type",
         resource_id=tt.id,
         request_id=request_id,
-        details={"fields_changed": sorted(body.model_fields_set)},
+        details={"fields_changed": sorted(fields_changed)},
     )
     await db.commit()
     await db.refresh(tt)

--- a/backend/app/services/tables_service.py
+++ b/backend/app/services/tables_service.py
@@ -1,0 +1,176 @@
+"""Shared application-service operations for floor-plan tables.
+
+Used by both ``app.routers.tables`` (REST) and ``app.mcp.admin.tables`` (MCP).
+See ``app/services/layouts_service.py`` for the pattern this follows and
+``app/services/errors.py`` for the exception convention each adapter
+translates at its own boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.live import live_bus
+from app.live import mapping as live_mapping
+from app.models import Layout, Registration, Table, TableType
+from app.schemas import TableCreate, TableUpdate
+from app.services.errors import NotFoundError
+from app.utils import make_id, table_to_dict
+
+logger = logging.getLogger(__name__)
+
+
+async def _get_layout_edition_id(db: AsyncSession, layout_id: str) -> str | None:
+    result = await db.execute(select(Layout.edition_id).where(Layout.id == layout_id))
+    return result.scalar_one_or_none()
+
+
+async def _publish_seating_changed(*, action: str, table_id: str, edition_id: str | None) -> None:
+    try:
+        await live_bus.publish(live_mapping.seating_changed(action=action, table_id=table_id, edition_id=edition_id))
+    except Exception:
+        logger.warning("live_bus.publish failed for table %s", table_id, exc_info=True)
+
+
+async def create_table(db: AsyncSession, *, actor: str, body: TableCreate, request_id: str | None = None) -> dict:
+    tt = await db.execute(select(TableType).where(TableType.id == body.table_type_id))
+    if tt.scalar_one_or_none() is None:
+        raise NotFoundError(f"TableType '{body.table_type_id}' not found.")
+    lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
+    if lay.scalar_one_or_none() is None:
+        raise NotFoundError(f"Layout '{body.layout_id}' not found.")
+
+    t = Table(
+        id=make_id("tbl"),
+        name=body.name,
+        capacity=body.capacity,
+        x=body.x,
+        y=body.y,
+        table_type_id=body.table_type_id,
+        rotation=body.rotation,
+        layout_id=body.layout_id,
+    )
+    t.reservation_ids = []
+    db.add(t)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="table_created",
+        resource_type="table",
+        resource_id=t.id,
+        request_id=request_id,
+        details={"layout_id": t.layout_id, "name": t.name},
+    )
+    await db.commit()
+    await db.refresh(t)
+    edition_id = await _get_layout_edition_id(db, t.layout_id)
+    await _publish_seating_changed(action="created", table_id=t.id, edition_id=edition_id)
+    # New tables have no reservations yet
+    return table_to_dict(t, [])
+
+
+async def list_tables(db: AsyncSession) -> list[dict]:
+    result = await db.execute(select(Table).order_by(Table.created_at))
+    tables = result.scalars().all()
+
+    # Compute registration_ids from the Registration.table_id FK (source of truth),
+    # scoped to the tables actually being returned.
+    table_res_map: dict[str, list[str]] = {}
+    table_ids = [t.id for t in tables]
+    if table_ids:
+        res_result = await db.execute(
+            select(Registration.id, Registration.table_id).where(Registration.table_id.in_(table_ids))
+        )
+        for res_id, tbl_id in res_result.all():
+            table_res_map.setdefault(tbl_id, []).append(res_id)
+
+    return [table_to_dict(t, table_res_map.get(t.id, [])) for t in tables]
+
+
+async def get_table(db: AsyncSession, table_id: str) -> dict:
+    t = await db.get(Table, table_id)
+    if t is None:
+        raise NotFoundError(f"Table '{table_id}' not found.")
+    res_result = await db.execute(select(Registration.id).where(Registration.table_id == table_id))
+    registration_ids = [row[0] for row in res_result.all()]
+    return table_to_dict(t, registration_ids)
+
+
+async def update_table(
+    db: AsyncSession,
+    *,
+    actor: str,
+    table_id: str,
+    body: TableUpdate,
+    request_id: str | None = None,
+) -> dict:
+    t = await db.get(Table, table_id)
+    if t is None:
+        raise NotFoundError(f"Table '{table_id}' not found.")
+
+    # All fields in TableUpdate are Optional[…], so an absent key and an
+    # explicit null both arrive here as None and are simply skipped.  Only
+    # fields with a real value are applied to the row.
+    if body.name is not None:
+        t.name = body.name
+    if body.capacity is not None:
+        t.capacity = body.capacity
+    if body.x is not None:
+        t.x = body.x
+    if body.y is not None:
+        t.y = body.y
+    if body.table_type_id is not None:
+        tt = await db.execute(select(TableType).where(TableType.id == body.table_type_id))
+        if tt.scalar_one_or_none() is None:
+            raise NotFoundError(f"TableType '{body.table_type_id}' not found.")
+        t.table_type_id = body.table_type_id
+    # Zero-valid fields: must use model_fields_set so that an explicit zero
+    # degrees (rotation=0) is honoured even though the value is falsy.
+    if "rotation" in body.model_fields_set and body.rotation is not None:
+        t.rotation = body.rotation
+    if "layout_id" in body.model_fields_set and body.layout_id is not None:
+        lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
+        if lay.scalar_one_or_none() is None:
+            raise NotFoundError(f"Layout '{body.layout_id}' not found.")
+        t.layout_id = body.layout_id
+
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="table_updated",
+        resource_type="table",
+        resource_id=table_id,
+        request_id=request_id,
+        details={"fields_changed": sorted(body.model_fields_set)},
+    )
+    await db.commit()
+    await db.refresh(t)
+    edition_id = await _get_layout_edition_id(db, t.layout_id)
+    await _publish_seating_changed(action="updated", table_id=table_id, edition_id=edition_id)
+    res_result = await db.execute(select(Registration.id).where(Registration.table_id == table_id))
+    registration_ids = [row[0] for row in res_result.all()]
+    return table_to_dict(t, registration_ids)
+
+
+async def delete_table(db: AsyncSession, *, actor: str, table_id: str, request_id: str | None = None) -> dict:
+    t = await db.get(Table, table_id)
+    if t is None:
+        raise NotFoundError(f"Table '{table_id}' not found.")
+    edition_id = await _get_layout_edition_id(db, t.layout_id)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="table_deleted",
+        resource_type="table",
+        resource_id=table_id,
+        request_id=request_id,
+        details={"layout_id": t.layout_id, "name": t.name},
+    )
+    await db.delete(t)
+    await db.commit()
+    await _publish_seating_changed(action="deleted", table_id=table_id, edition_id=edition_id)
+    return {"deleted": True, "id": table_id}

--- a/backend/app/services/tables_service.py
+++ b/backend/app/services/tables_service.py
@@ -18,7 +18,7 @@ from app.live import live_bus
 from app.live import mapping as live_mapping
 from app.models import Layout, Registration, Table, TableType
 from app.schemas import TableCreate, TableUpdate
-from app.services.errors import NotFoundError
+from app.services.errors import ConflictError, NotFoundError
 from app.utils import make_id, table_to_dict
 
 logger = logging.getLogger(__name__)
@@ -37,7 +37,9 @@ async def _publish_seating_changed(*, action: str, table_id: str, edition_id: st
 
 
 async def create_table(db: AsyncSession, *, actor: str, body: TableCreate, request_id: str | None = None) -> dict:
-    tt = await db.execute(select(TableType).where(TableType.id == body.table_type_id))
+    # Lock the referenced TableType row so a concurrent delete_table_type (which
+    # acquires with_for_update on the same row) serializes correctly.
+    tt = await db.execute(select(TableType).where(TableType.id == body.table_type_id).with_for_update())
     if tt.scalar_one_or_none() is None:
         raise NotFoundError(f"TableType '{body.table_type_id}' not found.")
     lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
@@ -115,28 +117,34 @@ async def update_table(
     # All fields in TableUpdate are Optional[…], so an absent key and an
     # explicit null both arrive here as None and are simply skipped.  Only
     # fields with a real value are applied to the row.
+    fields_changed: list[str] = []
     if body.name is not None:
         t.name = body.name
+        fields_changed.append("name")
     if body.capacity is not None:
         t.capacity = body.capacity
+        fields_changed.append("capacity")
     if body.x is not None:
         t.x = body.x
+        fields_changed.append("x")
     if body.y is not None:
         t.y = body.y
+        fields_changed.append("y")
     if body.table_type_id is not None:
         tt = await db.execute(select(TableType).where(TableType.id == body.table_type_id))
         if tt.scalar_one_or_none() is None:
             raise NotFoundError(f"TableType '{body.table_type_id}' not found.")
         t.table_type_id = body.table_type_id
-    # Zero-valid fields: must use model_fields_set so that an explicit zero
-    # degrees (rotation=0) is honoured even though the value is falsy.
-    if "rotation" in body.model_fields_set and body.rotation is not None:
+        fields_changed.append("table_type_id")
+    if body.rotation is not None:
         t.rotation = body.rotation
-    if "layout_id" in body.model_fields_set and body.layout_id is not None:
+        fields_changed.append("rotation")
+    if body.layout_id is not None:
         lay = await db.execute(select(Layout).where(Layout.id == body.layout_id))
         if lay.scalar_one_or_none() is None:
             raise NotFoundError(f"Layout '{body.layout_id}' not found.")
         t.layout_id = body.layout_id
+        fields_changed.append("layout_id")
 
     await write_audit_entry(
         db,
@@ -145,7 +153,7 @@ async def update_table(
         resource_type="table",
         resource_id=table_id,
         request_id=request_id,
-        details={"fields_changed": sorted(body.model_fields_set)},
+        details={"fields_changed": sorted(fields_changed)},
     )
     await db.commit()
     await db.refresh(t)
@@ -160,6 +168,9 @@ async def delete_table(db: AsyncSession, *, actor: str, table_id: str, request_i
     t = await db.get(Table, table_id)
     if t is None:
         raise NotFoundError(f"Table '{table_id}' not found.")
+    regs = await db.execute(select(Registration.id).where(Registration.table_id == table_id).limit(1))
+    if regs.scalars().first() is not None:
+        raise ConflictError("Cannot delete: registrations are still assigned to this table.")
     edition_id = await _get_layout_edition_id(db, t.layout_id)
     await write_audit_entry(
         db,

--- a/backend/app/services/venues_service.py
+++ b/backend/app/services/venues_service.py
@@ -1,0 +1,110 @@
+"""Shared application-service operations for venues.
+
+Used by both ``app.routers.venues`` (REST) and ``app.mcp.admin.venues`` (MCP).
+See ``app/services/layouts_service.py`` for the pattern this follows and
+``app/services/errors.py`` for the exception convention each adapter
+translates at its own boundary.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.models import Edition, Room, Venue
+from app.schemas import VenueCreate, VenueUpdate
+from app.services.errors import ConflictError, NotFoundError
+from app.utils import make_id, venue_to_dict
+
+
+async def create_venue(db: AsyncSession, *, actor: str, body: VenueCreate, request_id: str | None = None) -> dict:
+    v = Venue(
+        id=make_id("venue"),
+        name=body.name,
+        address=body.address,
+        city=body.city,
+        postal_code=body.postal_code,
+        country=body.country,
+        lat=body.lat,
+        lng=body.lng,
+        active=body.active,
+    )
+    db.add(v)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="venue_created",
+        resource_type="venue",
+        resource_id=v.id,
+        request_id=request_id,
+        details={"name": v.name},
+    )
+    await db.commit()
+    await db.refresh(v)
+    return venue_to_dict(v)
+
+
+async def list_venues(db: AsyncSession, *, limit: int | None = None, offset: int = 0) -> list[dict]:
+    stmt = select(Venue).order_by(Venue.created_at).offset(offset)
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    result = await db.execute(stmt)
+    return [venue_to_dict(v) for v in result.scalars().all()]
+
+
+async def get_venue(db: AsyncSession, venue_id: str) -> dict:
+    v = await db.get(Venue, venue_id)
+    if v is None:
+        raise NotFoundError(f"Venue '{venue_id}' not found.")
+    return venue_to_dict(v)
+
+
+async def update_venue(
+    db: AsyncSession, *, actor: str, venue_id: str, body: VenueUpdate, request_id: str | None = None
+) -> dict:
+    v = await db.get(Venue, venue_id)
+    if v is None:
+        raise NotFoundError(f"Venue '{venue_id}' not found.")
+    for field in body.model_fields_set:
+        setattr(v, field, getattr(body, field))
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="venue_updated",
+        resource_type="venue",
+        resource_id=v.id,
+        request_id=request_id,
+        details={"fields_changed": sorted(body.model_fields_set)},
+    )
+    await db.commit()
+    await db.refresh(v)
+    return venue_to_dict(v)
+
+
+async def delete_venue(db: AsyncSession, *, actor: str, venue_id: str, request_id: str | None = None) -> dict:
+    v = await db.get(Venue, venue_id)
+    if v is None:
+        raise NotFoundError(f"Venue '{venue_id}' not found.")
+    # Lock the venue row so a concurrent edition/room creation (which validates
+    # the venue exists before inserting) can't race this delete: whichever
+    # transaction locks the venue first is the one the other serializes behind.
+    await db.execute(select(Venue.id).where(Venue.id == venue_id).with_for_update())
+    in_use = await db.execute(select(Edition).where(Edition.venue_id == venue_id).limit(1))
+    if in_use.scalars().first() is not None:
+        raise ConflictError("Cannot delete: editions are still using this venue.")
+    rooms_in_use = await db.execute(select(Room).where(Room.venue_id == venue_id).limit(1))
+    if rooms_in_use.scalars().first() is not None:
+        raise ConflictError("Cannot delete: rooms are still using this venue.")
+    await db.delete(v)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="venue_deleted",
+        resource_type="venue",
+        resource_id=venue_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": venue_id}

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -4,6 +4,23 @@ from __future__ import annotations
 
 import secrets
 import time
+
+
+def normalise_table_type_dimensions(shape: str, width_m: float, length_m: float) -> tuple[float, float]:
+    """Return canonical (width_m, length_m) for a table type.
+
+    - round tables force length_m == width_m
+    - rectangular tables ensure length_m >= width_m by swapping if needed
+    Shared between TableTypeCreate validator and table_types_service update path
+    so the two entry points cannot diverge.
+    """
+    if shape == "round":
+        return width_m, width_m
+    if length_m < width_m:
+        return length_m, width_m
+    return width_m, length_m
+
+
 from collections.abc import Sequence
 from datetime import date
 from typing import Any, TypeVar

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -4,23 +4,6 @@ from __future__ import annotations
 
 import secrets
 import time
-
-
-def normalise_table_type_dimensions(shape: str, width_m: float, length_m: float) -> tuple[float, float]:
-    """Return canonical (width_m, length_m) for a table type.
-
-    - round tables force length_m == width_m
-    - rectangular tables ensure length_m >= width_m by swapping if needed
-    Shared between TableTypeCreate validator and table_types_service update path
-    so the two entry points cannot diverge.
-    """
-    if shape == "round":
-        return width_m, width_m
-    if length_m < width_m:
-        return length_m, width_m
-    return width_m, length_m
-
-
 from collections.abc import Sequence
 from datetime import date
 from typing import Any, TypeVar
@@ -49,6 +32,21 @@ from app.models import (
 )
 
 T = TypeVar("T", bound=Base)
+
+
+def normalise_table_type_dimensions(shape: str, width_m: float, length_m: float) -> tuple[float, float]:
+    """Return canonical (width_m, length_m) for a table type.
+
+    - round tables force length_m == width_m
+    - rectangular tables ensure length_m >= width_m by swapping if needed
+    Shared between TableTypeCreate validator and table_types_service update path
+    so the two entry points cannot diverge.
+    """
+    if shape == "round":
+        return width_m, width_m
+    if length_m < width_m:
+        return length_m, width_m
+    return width_m, length_m
 
 
 async def get_or_404(

--- a/backend/tests/test_audit_provenance.py
+++ b/backend/tests/test_audit_provenance.py
@@ -1,0 +1,11 @@
+from app.audit import audit_provenance
+
+
+def test_audit_provenance_preserves_authentication_identity() -> None:
+    assert audit_provenance("anonymous") == ("none", None, None)
+    assert audit_provenance("keycloak-subject") == ("keycloak", "keycloak-subject", None)
+    assert audit_provenance("integration:ic-123") == (
+        "integration",
+        "integration:ic-123",
+        "ic-123",
+    )

--- a/backend/tests/test_integration_clients.py
+++ b/backend/tests/test_integration_clients.py
@@ -1,0 +1,109 @@
+"""Tests for the managed integration-client REST endpoints (admin only)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.helpers import ADMIN_HEADERS
+
+
+@pytest.mark.anyio
+async def test_create_list_revoke_rotate_integration_client(client):
+    r = await client.post(
+        "/api/integration-clients",
+        json={"name": "Home Assistant", "allowed_role": "volunteer"},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+    created = r.json()
+    assert created["name"] == "Home Assistant"
+    assert created["allowed_role"] == "volunteer"
+    assert created["is_active"] is True
+    assert created["key"].startswith("cfic_")
+    client_id = created["id"]
+
+    r = await client.get("/api/integration-clients", headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    listed = r.json()
+    assert any(c["id"] == client_id for c in listed)
+    # The list/detail shape never includes key material.
+    assert all("key" not in c and "key_hash" not in c for c in listed)
+
+    r = await client.post(f"/api/integration-clients/{client_id}/rotate", headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    rotated = r.json()
+    assert rotated["key"].startswith("cfic_")
+    assert rotated["key"] != created["key"]
+
+    r = await client.post(f"/api/integration-clients/{client_id}/revoke", headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    revoked = r.json()
+    assert revoked["is_active"] is False
+    assert revoked["revoked_at"] is not None
+
+
+@pytest.mark.anyio
+async def test_create_integration_client_requires_admin(unauth_client):
+    r = await unauth_client.post(
+        "/api/integration-clients", json={"name": "X", "allowed_role": "volunteer"}
+    )
+    assert r.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_volunteer_cannot_create_integration_client(volunteer_client):
+    r = await volunteer_client.post(
+        "/api/integration-clients", json={"name": "X", "allowed_role": "volunteer"}
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_create_integration_client_rejects_invalid_role(client):
+    r = await client.post(
+        "/api/integration-clients", json={"name": "X", "allowed_role": "public"}, headers=ADMIN_HEADERS
+    )
+    assert r.status_code == 422  # rejected by the Literal["admin", "volunteer"] schema
+
+
+@pytest.mark.anyio
+async def test_revoke_unknown_client_404(client):
+    r = await client.post("/api/integration-clients/nonexistent/revoke", headers=ADMIN_HEADERS)
+    assert r.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_revoke_already_revoked_409(client):
+    r = await client.post(
+        "/api/integration-clients", json={"name": "X", "allowed_role": "volunteer"}, headers=ADMIN_HEADERS
+    )
+    client_id = r.json()["id"]
+    await client.post(f"/api/integration-clients/{client_id}/revoke", headers=ADMIN_HEADERS)
+
+    r = await client.post(f"/api/integration-clients/{client_id}/revoke", headers=ADMIN_HEADERS)
+    assert r.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_rotate_revoked_client_409(client):
+    r = await client.post(
+        "/api/integration-clients", json={"name": "X", "allowed_role": "volunteer"}, headers=ADMIN_HEADERS
+    )
+    client_id = r.json()["id"]
+    await client.post(f"/api/integration-clients/{client_id}/revoke", headers=ADMIN_HEADERS)
+
+    r = await client.post(f"/api/integration-clients/{client_id}/rotate", headers=ADMIN_HEADERS)
+    assert r.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_create_integration_client_writes_audit_entry(client):
+    r = await client.post(
+        "/api/integration-clients", json={"name": "X", "allowed_role": "volunteer"}, headers=ADMIN_HEADERS
+    )
+    client_id = r.json()["id"]
+
+    r = await client.get("/api/audit", params={"resource_type": "integration_client"}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    entries = r.json()
+    assert any(e["resource_id"] == client_id and e["action"] == "integration_client_created" for e in entries)

--- a/backend/tests/test_integration_clients.py
+++ b/backend/tests/test_integration_clients.py
@@ -44,17 +44,13 @@ async def test_create_list_revoke_rotate_integration_client(client):
 
 @pytest.mark.anyio
 async def test_create_integration_client_requires_admin(unauth_client):
-    r = await unauth_client.post(
-        "/api/integration-clients", json={"name": "X", "allowed_role": "volunteer"}
-    )
+    r = await unauth_client.post("/api/integration-clients", json={"name": "X", "allowed_role": "volunteer"})
     assert r.status_code == 401
 
 
 @pytest.mark.anyio
 async def test_volunteer_cannot_create_integration_client(volunteer_client):
-    r = await volunteer_client.post(
-        "/api/integration-clients", json={"name": "X", "allowed_role": "volunteer"}
-    )
+    r = await volunteer_client.post("/api/integration-clients", json={"name": "X", "allowed_role": "volunteer"})
     assert r.status_code == 403
 
 

--- a/backend/tests/test_integration_clients_service.py
+++ b/backend/tests/test_integration_clients_service.py
@@ -1,0 +1,280 @@
+"""Unit/integration tests for managed integration-client credentials (issue #807).
+
+Covers hashing, lookup, rate limiting, role-escalation prevention, and
+revocation/rotation — mirroring the spirit of daynest's
+backend/tests/test_integration_clients.py.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services import integration_clients_service as ics
+from app.services.errors import ConflictError, ValidationFailedError
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+def test_hash_key_is_deterministic_sha256():
+    raw = "cfic_sometoken"
+    assert ics._hash_key(raw) == ics._hash_key(raw)
+    assert len(ics._hash_key(raw)) == 64  # hex-encoded SHA-256 digest
+
+
+def test_generated_raw_key_has_prefix_and_high_entropy():
+    keys = {ics._generate_raw_key() for _ in range(20)}
+    assert all(k.startswith(ics.TOKEN_PREFIX) for k in keys)
+    assert len(keys) == 20  # no collisions across 20 draws
+
+
+# ---------------------------------------------------------------------------
+# create_integration_client — validation and role-escalation prevention
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_create_integration_client_returns_dict_and_raw_key(db_session):
+    client_dict, raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="Home Assistant", allowed_role="volunteer"
+    )
+    assert client_dict["name"] == "Home Assistant"
+    assert client_dict["allowed_role"] == "volunteer"
+    assert client_dict["is_active"] is True
+    assert client_dict["created_by_actor"] == "admin-1"
+    assert raw_key.startswith(ics.TOKEN_PREFIX)
+    # The raw key itself is never persisted anywhere retrievable.
+    assert "key" not in client_dict
+    assert "key_hash" not in client_dict
+
+
+@pytest.mark.anyio
+async def test_create_integration_client_rejects_unknown_role(db_session):
+    with pytest.raises(ValidationFailedError, match="allowed_role"):
+        await ics.create_integration_client(
+            db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="public"
+        )
+
+
+@pytest.mark.anyio
+async def test_create_integration_client_rejects_blank_name(db_session):
+    with pytest.raises(ValidationFailedError, match="name"):
+        await ics.create_integration_client(
+            db_session, actor="admin-1", creator_role="admin", name="   ", allowed_role="volunteer"
+        )
+
+
+@pytest.mark.anyio
+async def test_create_integration_client_rejects_non_positive_rate_limit(db_session):
+    with pytest.raises(ValidationFailedError, match="rate_limit_per_minute"):
+        await ics.create_integration_client(
+            db_session,
+            actor="admin-1",
+            creator_role="admin",
+            name="X",
+            allowed_role="volunteer",
+            rate_limit_per_minute=0,
+        )
+
+
+@pytest.mark.anyio
+async def test_create_integration_client_prevents_role_escalation(db_session):
+    """A caller whose own tier is 'volunteer' must never be able to mint an
+    'admin'-tier integration client — the credential can never outrank its
+    creator. (In practice the REST/MCP surfaces are admin-only end to end,
+    but this is the last line of defence at the service layer.)"""
+    with pytest.raises(ValidationFailedError, match="admin"):
+        await ics.create_integration_client(
+            db_session, actor="volunteer-1", creator_role="volunteer", name="X", allowed_role="admin"
+        )
+
+
+@pytest.mark.anyio
+async def test_create_integration_client_allows_admin_creator_to_mint_volunteer_tier(db_session):
+    client_dict, _raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    assert client_dict["allowed_role"] == "volunteer"
+
+
+@pytest.mark.anyio
+async def test_create_integration_client_allows_admin_creator_to_mint_admin_tier(db_session):
+    client_dict, _raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="admin"
+    )
+    assert client_dict["allowed_role"] == "admin"
+
+
+# ---------------------------------------------------------------------------
+# authenticate_integration_client — lookup, revocation, rate limiting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_authenticate_accepts_valid_active_key(db_session):
+    _client_dict, raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    client = await ics.authenticate_integration_client(db_session, raw_key)
+    assert client is not None
+    assert client.allowed_role == "volunteer"
+
+
+@pytest.mark.anyio
+async def test_authenticate_rejects_unknown_token(db_session):
+    assert await ics.authenticate_integration_client(db_session, f"{ics.TOKEN_PREFIX}bogus") is None
+
+
+@pytest.mark.anyio
+async def test_authenticate_rejects_token_without_expected_prefix(db_session):
+    assert await ics.authenticate_integration_client(db_session, "not-a-valid-prefix") is None
+
+
+@pytest.mark.anyio
+async def test_authenticate_rejects_revoked_client(db_session):
+    client_dict, raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    await ics.revoke_integration_client(db_session, actor="admin-1", client_id=client_dict["id"])
+
+    assert await ics.authenticate_integration_client(db_session, raw_key) is None
+
+
+@pytest.mark.anyio
+async def test_authenticate_rejects_key_after_rotation(db_session):
+    client_dict, old_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    _new_dict, new_key = await ics.rotate_integration_client(db_session, actor="admin-1", client_id=client_dict["id"])
+
+    assert await ics.authenticate_integration_client(db_session, old_key) is None
+    assert await ics.authenticate_integration_client(db_session, new_key) is not None
+
+
+@pytest.mark.anyio
+async def test_authenticate_updates_last_used_at(db_session):
+    client_dict, raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    assert client_dict["last_used_at"] is None
+
+    client = await ics.authenticate_integration_client(db_session, raw_key)
+    assert client is not None
+    assert client.last_used_at is not None
+
+
+@pytest.mark.anyio
+async def test_authenticate_throttles_last_used_write_on_rapid_reuse(db_session, monkeypatch):
+    client_dict, raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    first = await ics.authenticate_integration_client(db_session, raw_key)
+    first_seen = first.last_used_at
+
+    # Immediately re-authenticate: within the throttle window, last_used_at must not move.
+    second = await ics.authenticate_integration_client(db_session, raw_key)
+    assert second.last_used_at == first_seen
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+def test_check_rate_limit_allows_up_to_the_configured_limit():
+    client_id = "rl-client-1"
+    ics._request_log.pop(client_id, None)
+    try:
+        for _ in range(5):
+            assert ics.check_rate_limit(client_id, limit_per_minute=5) is True
+        assert ics.check_rate_limit(client_id, limit_per_minute=5) is False
+    finally:
+        ics._request_log.pop(client_id, None)
+
+
+def test_check_rate_limit_recovers_after_window_expires():
+    client_id = "rl-client-2"
+    ics._request_log.pop(client_id, None)
+    try:
+        stale_time = datetime.now(UTC) - timedelta(minutes=2)
+        ics._request_log[client_id] = __import__("collections").deque([stale_time] * 5)
+        # All 5 entries are outside the 1-minute window, so a fresh request is allowed.
+        assert ics.check_rate_limit(client_id, limit_per_minute=5) is True
+    finally:
+        ics._request_log.pop(client_id, None)
+
+
+@pytest.mark.anyio
+async def test_authenticate_rejects_when_rate_limit_exceeded(db_session):
+    client_dict, raw_key = await ics.create_integration_client(
+        db_session,
+        actor="admin-1",
+        creator_role="admin",
+        name="X",
+        allowed_role="volunteer",
+        rate_limit_per_minute=2,
+    )
+    try:
+        assert await ics.authenticate_integration_client(db_session, raw_key) is not None
+        assert await ics.authenticate_integration_client(db_session, raw_key) is not None
+        # Third call within the same minute exceeds the per-client limit.
+        assert await ics.authenticate_integration_client(db_session, raw_key) is None
+    finally:
+        ics._request_log.pop(client_dict["id"], None)
+
+
+# ---------------------------------------------------------------------------
+# revoke / rotate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_revoke_sets_inactive_and_revoked_at(db_session):
+    client_dict, _raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    revoked = await ics.revoke_integration_client(db_session, actor="admin-1", client_id=client_dict["id"])
+    assert revoked["is_active"] is False
+    assert revoked["revoked_at"] is not None
+
+
+@pytest.mark.anyio
+async def test_revoke_already_revoked_raises_conflict(db_session):
+    client_dict, _raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    await ics.revoke_integration_client(db_session, actor="admin-1", client_id=client_dict["id"])
+    with pytest.raises(ConflictError, match="already revoked"):
+        await ics.revoke_integration_client(db_session, actor="admin-1", client_id=client_dict["id"])
+
+
+@pytest.mark.anyio
+async def test_rotate_revoked_client_raises_conflict(db_session):
+    client_dict, _raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    await ics.revoke_integration_client(db_session, actor="admin-1", client_id=client_dict["id"])
+    with pytest.raises(ConflictError, match="revoked"):
+        await ics.rotate_integration_client(db_session, actor="admin-1", client_id=client_dict["id"])
+
+
+@pytest.mark.anyio
+async def test_get_integration_client_not_found(db_session):
+    from app.services.errors import NotFoundError
+
+    with pytest.raises(NotFoundError, match="not found"):
+        await ics.get_integration_client(db_session, "nonexistent")
+
+
+@pytest.mark.anyio
+async def test_list_integration_clients_never_exposes_key_hash(db_session):
+    await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    listed = await ics.list_integration_clients(db_session)
+    assert len(listed) == 1
+    assert "key_hash" not in listed[0]
+    assert "key" not in listed[0]

--- a/backend/tests/test_integration_clients_service.py
+++ b/backend/tests/test_integration_clients_service.py
@@ -222,13 +222,10 @@ async def test_authenticate_rejects_when_rate_limit_exceeded(db_session):
         allowed_role="volunteer",
         rate_limit_per_minute=2,
     )
-    try:
-        assert await ics.authenticate_integration_client(db_session, raw_key) is not None
-        assert await ics.authenticate_integration_client(db_session, raw_key) is not None
-        # Third call within the same minute exceeds the per-client limit.
-        assert await ics.authenticate_integration_client(db_session, raw_key) is None
-    finally:
-        ics._request_log.pop(client_dict["id"], None)
+    assert await ics.authenticate_integration_client(db_session, raw_key) is not None
+    assert await ics.authenticate_integration_client(db_session, raw_key) is not None
+    # Third call within the same minute exceeds the per-client limit.
+    assert await ics.authenticate_integration_client(db_session, raw_key) is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_integration_clients_service.py
+++ b/backend/tests/test_integration_clients_service.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+from app.models import IntegrationClient
 from app.services import integration_clients_service as ics
 from app.services.errors import ConflictError, ValidationFailedError
 
@@ -46,6 +47,7 @@ async def test_create_integration_client_returns_dict_and_raw_key(db_session):
     assert client_dict["is_active"] is True
     assert client_dict["created_by_actor"] == "admin-1"
     assert raw_key.startswith(ics.TOKEN_PREFIX)
+    assert client_dict["key_preview"] == raw_key[-8:]
     # The raw key itself is never persisted anywhere retrievable.
     assert "key" not in client_dict
     assert "key_hash" not in client_dict
@@ -148,10 +150,12 @@ async def test_authenticate_rejects_key_after_rotation(db_session):
     client_dict, old_key = await ics.create_integration_client(
         db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
     )
-    _new_dict, new_key = await ics.rotate_integration_client(db_session, actor="admin-1", client_id=client_dict["id"])
+    new_dict, new_key = await ics.rotate_integration_client(db_session, actor="admin-1", client_id=client_dict["id"])
 
     assert await ics.authenticate_integration_client(db_session, old_key) is None
     assert await ics.authenticate_integration_client(db_session, new_key) is not None
+    assert new_dict["key_preview"] == new_key[-8:]
+    assert new_dict["key_preview"] != client_dict["key_preview"]
 
 
 @pytest.mark.anyio
@@ -186,27 +190,26 @@ async def test_authenticate_throttles_last_used_write_on_rapid_reuse(db_session,
 # ---------------------------------------------------------------------------
 
 
-def test_check_rate_limit_allows_up_to_the_configured_limit():
-    client_id = "rl-client-1"
-    ics._request_log.pop(client_id, None)
-    try:
-        for _ in range(5):
-            assert ics.check_rate_limit(client_id, limit_per_minute=5) is True
-        assert ics.check_rate_limit(client_id, limit_per_minute=5) is False
-    finally:
-        ics._request_log.pop(client_id, None)
+@pytest.mark.anyio
+async def test_check_rate_limit_allows_up_to_the_configured_limit(db_session):
+    client_dict, _ = await ics.create_integration_client(
+        db_session, actor="admin", creator_role="admin", name="rl-1", allowed_role="volunteer", rate_limit_per_minute=5
+    )
+    for _ in range(5):
+        assert await ics.check_rate_limit(db_session, client_dict["id"]) is True
+    assert await ics.check_rate_limit(db_session, client_dict["id"]) is False
 
 
-def test_check_rate_limit_recovers_after_window_expires():
-    client_id = "rl-client-2"
-    ics._request_log.pop(client_id, None)
-    try:
-        stale_time = datetime.now(UTC) - timedelta(minutes=2)
-        ics._request_log[client_id] = __import__("collections").deque([stale_time] * 5)
-        # All 5 entries are outside the 1-minute window, so a fresh request is allowed.
-        assert ics.check_rate_limit(client_id, limit_per_minute=5) is True
-    finally:
-        ics._request_log.pop(client_id, None)
+@pytest.mark.anyio
+async def test_check_rate_limit_recovers_after_window_expires(db_session):
+    client_dict, _ = await ics.create_integration_client(
+        db_session, actor="admin", creator_role="admin", name="rl-2", allowed_role="volunteer", rate_limit_per_minute=1
+    )
+    client = await db_session.get(IntegrationClient, client_dict["id"])
+    client.rate_limit_window_started_at = datetime.now(UTC) - timedelta(minutes=2)
+    client.rate_limit_window_count = 1
+    await db_session.commit()
+    assert await ics.check_rate_limit(db_session, client_dict["id"]) is True
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_integration_clients_service.py
+++ b/backend/tests/test_integration_clients_service.py
@@ -172,10 +172,12 @@ async def test_authenticate_throttles_last_used_write_on_rapid_reuse(db_session,
         db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
     )
     first = await ics.authenticate_integration_client(db_session, raw_key)
+    assert first is not None
     first_seen = first.last_used_at
 
     # Immediately re-authenticate: within the throttle window, last_used_at must not move.
     second = await ics.authenticate_integration_client(db_session, raw_key)
+    assert second is not None
     assert second.last_used_at == first_seen
 
 

--- a/backend/tests/test_mcp_admin_integration_clients.py
+++ b/backend/tests/test_mcp_admin_integration_clients.py
@@ -1,0 +1,44 @@
+"""Tests for the admin (write) integration-client MCP tools."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp.admin import integration_clients as mcp_integration_clients
+from tests.helpers import mcp_session_factory
+
+
+@pytest.mark.anyio
+async def test_create_list_revoke_rotate(db_session):
+    factory = mcp_session_factory(db_session)
+
+    created = await mcp_integration_clients.create_integration_client(
+        factory, "admin-1", name="Home Assistant", allowed_role="volunteer"
+    )
+    assert created["allowed_role"] == "volunteer"
+    assert created["key"].startswith("cfic_")
+    client_id = created["id"]
+
+    listed = await mcp_integration_clients.list_integration_clients(factory)
+    assert any(c["id"] == client_id for c in listed["integration_clients"])
+    assert "key" not in listed["integration_clients"][0]
+
+    rotated = await mcp_integration_clients.rotate_integration_client(factory, "admin-1", client_id)
+    assert rotated["key"] != created["key"]
+
+    revoked = await mcp_integration_clients.revoke_integration_client(factory, "admin-1", client_id)
+    assert revoked["is_active"] is False
+
+
+@pytest.mark.anyio
+async def test_create_rejects_invalid_role(db_session):
+    factory = mcp_session_factory(db_session)
+    with pytest.raises(ValueError, match="allowed_role"):
+        await mcp_integration_clients.create_integration_client(factory, "admin-1", name="X", allowed_role="public")
+
+
+@pytest.mark.anyio
+async def test_revoke_unknown_client(db_session):
+    factory = mcp_session_factory(db_session)
+    with pytest.raises(ValueError, match="not found"):
+        await mcp_integration_clients.revoke_integration_client(factory, "admin-1", "nonexistent")

--- a/backend/tests/test_mcp_capabilities.py
+++ b/backend/tests/test_mcp_capabilities.py
@@ -1,0 +1,107 @@
+"""Tests for the MCP capabilities manifest (issue #807).
+
+Guards against drift between the advertised tool/role manifest and the
+actual live tool registration in ``create_mcp_server()`` — the acceptance
+criterion is "Capability output is generated from or verified against actual
+MCP registration."
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.mcp_server import (
+    PUBLIC_TOOL_NAMES,
+    ROLE_ADMIN,
+    ROLE_PUBLIC,
+    ROLE_VOLUNTEER,
+    VOLUNTEER_TOOL_NAMES,
+    create_mcp_server,
+    get_mcp_capabilities,
+)
+
+
+@pytest.mark.anyio
+async def test_capabilities_manifest_covers_every_registered_tool_exactly_once():
+    mcp = create_mcp_server(session_factory=MagicMock())
+    registered = {tool.name for tool in await mcp.list_tools()}
+
+    manifest = await get_mcp_capabilities(mcp)
+    manifest_names = {entry["name"] for entry in manifest["tools"]}
+
+    # Generated directly off mcp.list_tools(), so this can't drift by
+    # construction — asserted anyway as a regression guard on that invariant.
+    assert manifest_names == registered
+
+
+def test_public_and_volunteer_tool_allowlists_are_disjoint():
+    assert PUBLIC_TOOL_NAMES.isdisjoint(VOLUNTEER_TOOL_NAMES)
+
+
+@pytest.mark.anyio
+async def test_public_and_volunteer_allowlists_only_reference_real_tools():
+    """Catches a typo'd or removed tool name lingering in the allowlists —
+    every name in PUBLIC_TOOL_NAMES/VOLUNTEER_TOOL_NAMES must correspond to an
+    actually-registered tool, otherwise the manifest would silently omit it."""
+    mcp = create_mcp_server(session_factory=MagicMock())
+    registered = {tool.name for tool in await mcp.list_tools()}
+
+    assert registered >= PUBLIC_TOOL_NAMES
+    assert registered >= VOLUNTEER_TOOL_NAMES
+
+
+@pytest.mark.anyio
+async def test_capabilities_manifest_required_roles_are_valid_and_sorted():
+    mcp = create_mcp_server(session_factory=MagicMock())
+    manifest = await get_mcp_capabilities(mcp)
+
+    names = [entry["name"] for entry in manifest["tools"]]
+    assert names == sorted(names)
+    assert all(entry["required_role"] in (ROLE_PUBLIC, ROLE_VOLUNTEER, ROLE_ADMIN) for entry in manifest["tools"])
+
+
+@pytest.mark.anyio
+async def test_capabilities_manifest_spot_checks_known_tiers():
+    mcp = create_mcp_server(session_factory=MagicMock())
+    manifest = await get_mcp_capabilities(mcp)
+    role_by_name = {entry["name"]: entry["required_role"] for entry in manifest["tools"]}
+
+    assert role_by_name["whoami"] == ROLE_PUBLIC
+    assert role_by_name["get_active_edition"] == ROLE_PUBLIC
+    assert role_by_name["find_guest"] == ROLE_VOLUNTEER
+    assert role_by_name["get_check_in_summary"] == ROLE_VOLUNTEER
+    assert role_by_name["create_venue"] == ROLE_ADMIN
+    assert role_by_name["create_integration_client"] == ROLE_ADMIN
+
+
+# ---------------------------------------------------------------------------
+# /api/mcp/capabilities REST endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_mcp_capabilities_endpoint_reports_disabled_when_mcp_not_mounted(client):
+    # The test app's settings.mcp_base_url is unset, so app.main._mcp is None.
+    r = await client.get("/api/mcp/capabilities")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["enabled"] is False
+    assert body["tools"] == []
+    assert body["mount_path"] == "/mcp"
+
+
+@pytest.mark.anyio
+async def test_mcp_capabilities_endpoint_reports_enabled_tool_list(client, monkeypatch):
+    import app.main as main_module
+
+    fake_mcp = create_mcp_server(session_factory=MagicMock())
+    monkeypatch.setattr(main_module, "_mcp", fake_mcp)
+
+    r = await client.get("/api/mcp/capabilities")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["enabled"] is True
+    assert any(t["name"] == "whoami" for t in body["tools"])
+    assert any(t["name"] == "create_venue" and t["required_role"] == "admin" for t in body["tools"])

--- a/backend/tests/test_mcp_capabilities.py
+++ b/backend/tests/test_mcp_capabilities.py
@@ -13,15 +13,18 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from app.mcp_server import (
+from app.mcp.capabilities import (
     PUBLIC_TOOL_NAMES,
     ROLE_ADMIN,
     ROLE_PUBLIC,
     ROLE_VOLUNTEER,
+    TOOL_EFFECT_READ,
+    TOOL_EFFECT_WRITE,
     VOLUNTEER_TOOL_NAMES,
-    create_mcp_server,
     get_mcp_capabilities,
+    tool_effect,
 )
+from app.mcp_server import create_mcp_server
 
 
 @pytest.mark.anyio
@@ -62,6 +65,7 @@ async def test_capabilities_manifest_required_roles_are_valid_and_sorted():
     names = [entry["name"] for entry in tools]
     assert names == sorted(names)
     assert all(entry["required_role"] in (ROLE_PUBLIC, ROLE_VOLUNTEER, ROLE_ADMIN) for entry in tools)
+    assert all(entry["effect"] in (TOOL_EFFECT_READ, TOOL_EFFECT_WRITE) for entry in tools)
 
 
 @pytest.mark.anyio
@@ -76,6 +80,20 @@ async def test_capabilities_manifest_spot_checks_known_tiers():
     assert role_by_name["get_check_in_summary"] == ROLE_VOLUNTEER
     assert role_by_name["create_venue"] == ROLE_ADMIN
     assert role_by_name["create_integration_client"] == ROLE_ADMIN
+
+
+@pytest.mark.anyio
+async def test_capabilities_manifest_classifies_side_effects_conservatively():
+    mcp = create_mcp_server(session_factory=MagicMock())
+    manifest = cast(dict[str, Any], await get_mcp_capabilities(mcp))
+    effect_by_name = {entry["name"]: entry["effect"] for entry in cast(list[dict[str, Any]], manifest["tools"])}
+
+    assert effect_by_name["whoami"] == TOOL_EFFECT_READ
+    assert effect_by_name["get_active_edition"] == TOOL_EFFECT_READ
+    assert effect_by_name["list_audit_entries"] == TOOL_EFFECT_READ
+    assert effect_by_name["create_venue"] == TOOL_EFFECT_WRITE
+    assert effect_by_name["rotate_integration_client"] == TOOL_EFFECT_WRITE
+    assert tool_effect("future_tool_without_policy") == TOOL_EFFECT_WRITE
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_capabilities.py
+++ b/backend/tests/test_mcp_capabilities.py
@@ -8,6 +8,7 @@ MCP registration."
 
 from __future__ import annotations
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,8 +29,8 @@ async def test_capabilities_manifest_covers_every_registered_tool_exactly_once()
     mcp = create_mcp_server(session_factory=MagicMock())
     registered = {tool.name for tool in await mcp.list_tools()}
 
-    manifest = await get_mcp_capabilities(mcp)
-    manifest_names = {entry["name"] for entry in manifest["tools"]}
+    manifest = cast(dict[str, Any], await get_mcp_capabilities(mcp))
+    manifest_names = {entry["name"] for entry in cast(list[dict[str, Any]], manifest["tools"])}
 
     # Generated directly off mcp.list_tools(), so this can't drift by
     # construction — asserted anyway as a regression guard on that invariant.
@@ -55,18 +56,19 @@ async def test_public_and_volunteer_allowlists_only_reference_real_tools():
 @pytest.mark.anyio
 async def test_capabilities_manifest_required_roles_are_valid_and_sorted():
     mcp = create_mcp_server(session_factory=MagicMock())
-    manifest = await get_mcp_capabilities(mcp)
+    manifest = cast(dict[str, Any], await get_mcp_capabilities(mcp))
 
-    names = [entry["name"] for entry in manifest["tools"]]
+    tools = cast(list[dict[str, Any]], manifest["tools"])
+    names = [entry["name"] for entry in tools]
     assert names == sorted(names)
-    assert all(entry["required_role"] in (ROLE_PUBLIC, ROLE_VOLUNTEER, ROLE_ADMIN) for entry in manifest["tools"])
+    assert all(entry["required_role"] in (ROLE_PUBLIC, ROLE_VOLUNTEER, ROLE_ADMIN) for entry in tools)
 
 
 @pytest.mark.anyio
 async def test_capabilities_manifest_spot_checks_known_tiers():
     mcp = create_mcp_server(session_factory=MagicMock())
-    manifest = await get_mcp_capabilities(mcp)
-    role_by_name = {entry["name"]: entry["required_role"] for entry in manifest["tools"]}
+    manifest = cast(dict[str, Any], await get_mcp_capabilities(mcp))
+    role_by_name = {entry["name"]: entry["required_role"] for entry in cast(list[dict[str, Any]], manifest["tools"])}
 
     assert role_by_name["whoami"] == ROLE_PUBLIC
     assert role_by_name["get_active_edition"] == ROLE_PUBLIC

--- a/backend/tests/test_mcp_integration_auth.py
+++ b/backend/tests/test_mcp_integration_auth.py
@@ -1,0 +1,72 @@
+"""Tests for IntegrationKeyTokenVerifier — the FastMCP TokenVerifier that
+authenticates managed integration-client credentials (issue #807)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp.integration_auth import IntegrationKeyTokenVerifier
+from app.services import integration_clients_service as ics
+from tests.helpers import mcp_session_factory
+
+
+@pytest.mark.anyio
+async def test_verify_token_returns_access_token_with_synthesised_claims(db_session):
+    _client_dict, raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="Home Assistant", allowed_role="volunteer"
+    )
+    verifier = IntegrationKeyTokenVerifier(mcp_session_factory(db_session))
+
+    access_token = await verifier.verify_token(raw_key)
+
+    assert access_token is not None
+    assert access_token.claims["realm_access"]["roles"] == ["volunteer"]
+    assert access_token.claims["sub"].startswith("integration:")
+    assert access_token.claims["auth_source"] == "integration"
+    assert access_token.client_id == access_token.claims["sub"]
+    assert access_token.scopes == []
+
+
+@pytest.mark.anyio
+async def test_verify_token_rejects_unknown_token(db_session):
+    verifier = IntegrationKeyTokenVerifier(mcp_session_factory(db_session))
+    assert await verifier.verify_token(f"{ics.TOKEN_PREFIX}bogus") is None
+
+
+@pytest.mark.anyio
+async def test_verify_token_rejects_revoked_client(db_session):
+    client_dict, raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    await ics.revoke_integration_client(db_session, actor="admin-1", client_id=client_dict["id"])
+    verifier = IntegrationKeyTokenVerifier(mcp_session_factory(db_session))
+
+    assert await verifier.verify_token(raw_key) is None
+
+
+@pytest.mark.anyio
+async def test_verify_token_admin_tier_client_resolves_admin_role(db_session):
+    _client_dict, raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="admin"
+    )
+    verifier = IntegrationKeyTokenVerifier(mcp_session_factory(db_session))
+
+    access_token = await verifier.verify_token(raw_key)
+
+    assert access_token is not None
+    assert access_token.claims["realm_access"]["roles"] == ["admin"]
+
+
+@pytest.mark.anyio
+async def test_verify_token_never_leaks_key_hash_in_claims(db_session):
+    _client_dict, raw_key = await ics.create_integration_client(
+        db_session, actor="admin-1", creator_role="admin", name="X", allowed_role="volunteer"
+    )
+    verifier = IntegrationKeyTokenVerifier(mcp_session_factory(db_session))
+
+    access_token = await verifier.verify_token(raw_key)
+
+    assert access_token is not None
+    serialized = str(access_token.claims)
+    assert raw_key not in serialized
+    assert "key_hash" not in serialized

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import app.mcp_server as mcp_module
+from app.mcp import auth as mcp_auth_module
 from app.mcp.utils import get_active_edition_obj, person_dict
 from app.mcp_server import (
     ROLE_ADMIN,
@@ -252,9 +253,9 @@ def _make_db_execute(rows_by_call: list[Any]):
 def test_build_keycloak_auth_accepts_client_credentials_without_user_scopes(monkeypatch):
     from fastmcp.server.auth import MultiAuth
 
-    monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "https://auth.example/realms/champagnefestival")
-    monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "https://api.example/mcp")
-    monkeypatch.setattr(mcp_module.settings, "oidc_audience", "champagnefestival")
+    monkeypatch.setattr(mcp_auth_module.settings, "oidc_issuer_url", "https://auth.example/realms/champagnefestival")
+    monkeypatch.setattr(mcp_auth_module.settings, "mcp_base_url", "https://api.example/mcp")
+    monkeypatch.setattr(mcp_auth_module.settings, "oidc_audience", "champagnefestival")
 
     with patch("fastmcp.server.auth.providers.keycloak.KeycloakAuthProvider") as provider:
         auth = build_keycloak_auth(session_factory=MagicMock())
@@ -276,8 +277,8 @@ def test_build_keycloak_auth_accepts_client_credentials_without_user_scopes(monk
 def test_build_keycloak_auth_includes_integration_key_verifier(monkeypatch):
     from app.mcp.integration_auth import IntegrationKeyTokenVerifier
 
-    monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "https://auth.example/realms/champagnefestival")
-    monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "https://api.example/mcp")
+    monkeypatch.setattr(mcp_auth_module.settings, "oidc_issuer_url", "https://auth.example/realms/champagnefestival")
+    monkeypatch.setattr(mcp_auth_module.settings, "mcp_base_url", "https://api.example/mcp")
 
     with patch("fastmcp.server.auth.providers.keycloak.KeycloakAuthProvider"):
         auth = build_keycloak_auth(session_factory=MagicMock())
@@ -287,16 +288,16 @@ def test_build_keycloak_auth_includes_integration_key_verifier(monkeypatch):
 
 
 def test_build_keycloak_auth_rejects_http_mcp_without_oidc(monkeypatch):
-    monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "")
-    monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "https://api.example/mcp")
+    monkeypatch.setattr(mcp_auth_module.settings, "oidc_issuer_url", "")
+    monkeypatch.setattr(mcp_auth_module.settings, "mcp_base_url", "https://api.example/mcp")
 
     with pytest.raises(RuntimeError, match="OIDC_ISSUER_URL is required"):
         build_keycloak_auth()
 
 
 def test_build_keycloak_auth_propagates_provider_failure(monkeypatch):
-    monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "https://auth.example/realms/champagnefestival")
-    monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "https://api.example/mcp")
+    monkeypatch.setattr(mcp_auth_module.settings, "oidc_issuer_url", "https://auth.example/realms/champagnefestival")
+    monkeypatch.setattr(mcp_auth_module.settings, "mcp_base_url", "https://api.example/mcp")
 
     with (
         patch(
@@ -309,8 +310,8 @@ def test_build_keycloak_auth_propagates_provider_failure(monkeypatch):
 
 
 def test_build_keycloak_auth_is_unused_without_http_mcp(monkeypatch):
-    monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "")
-    monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "")
+    monkeypatch.setattr(mcp_auth_module.settings, "oidc_issuer_url", "")
+    monkeypatch.setattr(mcp_auth_module.settings, "mcp_base_url", "")
 
     assert build_keycloak_auth() is None
 

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -485,7 +485,8 @@ class TestWhoami:
     async def test_whoami_never_exposes_token_material(self):
         backend = ChampagneFestivalMcpBackend(MagicMock())
         token = SimpleNamespace(
-            claims={"sub": "user-1", "realm_access": {"roles": ["admin"]}}, token="super-secret-raw-jwt"  # noqa: S106
+            claims={"sub": "user-1", "realm_access": {"roles": ["admin"]}},
+            token="super-secret-raw-jwt",  # noqa: S106
         )
         with patch.object(mcp_module, "get_access_token", return_value=token):
             result = await backend.whoami()

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -250,20 +250,40 @@ def _make_db_execute(rows_by_call: list[Any]):
 
 
 def test_build_keycloak_auth_accepts_client_credentials_without_user_scopes(monkeypatch):
+    from fastmcp.server.auth import MultiAuth
+
     monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "https://auth.example/realms/champagnefestival")
     monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "https://api.example/mcp")
     monkeypatch.setattr(mcp_module.settings, "oidc_audience", "champagnefestival")
 
     with patch("fastmcp.server.auth.providers.keycloak.KeycloakAuthProvider") as provider:
-        auth = build_keycloak_auth()
+        auth = build_keycloak_auth(session_factory=MagicMock())
 
-    assert auth is provider.return_value
+    # build_keycloak_auth() now composes Keycloak with the database-backed
+    # integration-client verifier via MultiAuth (see #807) — Keycloak client
+    # credentials keep working unchanged, they're just no longer the only
+    # accepted credential type.
+    assert isinstance(auth, MultiAuth)
+    assert auth.server is provider.return_value
     provider.assert_called_once_with(
         realm_url="https://auth.example/realms/champagnefestival",
         base_url="https://api.example/mcp",
         audience="champagnefestival",
         required_scopes=[],
     )
+
+
+def test_build_keycloak_auth_includes_integration_key_verifier(monkeypatch):
+    from app.mcp.integration_auth import IntegrationKeyTokenVerifier
+
+    monkeypatch.setattr(mcp_module.settings, "oidc_issuer_url", "https://auth.example/realms/champagnefestival")
+    monkeypatch.setattr(mcp_module.settings, "mcp_base_url", "https://api.example/mcp")
+
+    with patch("fastmcp.server.auth.providers.keycloak.KeycloakAuthProvider"):
+        auth = build_keycloak_auth(session_factory=MagicMock())
+
+    assert len(auth.verifiers) == 1
+    assert isinstance(auth.verifiers[0], IntegrationKeyTokenVerifier)
 
 
 def test_build_keycloak_auth_rejects_http_mcp_without_oidc(monkeypatch):
@@ -402,6 +422,76 @@ class TestResolveRole:
         with patch.object(mcp_module, "get_access_token", return_value=token):
             assert backend._actor() == "anonymous"
 
+    def test_auth_source_none_without_token(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        with patch.object(mcp_module, "get_access_token", return_value=None):
+            assert backend._auth_source() == "none"
+
+    def test_auth_source_keycloak_for_ordinary_jwt(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        token = SimpleNamespace(claims={"sub": "user-1", "realm_access": {"roles": ["admin"]}})
+        with patch.object(mcp_module, "get_access_token", return_value=token):
+            assert backend._auth_source() == "keycloak"
+
+    def test_auth_source_integration_when_claim_present(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        token = SimpleNamespace(
+            claims={
+                "sub": "integration:ic-1",
+                "realm_access": {"roles": ["volunteer"]},
+                "auth_source": "integration",
+            }
+        )
+        with patch.object(mcp_module, "get_access_token", return_value=token):
+            assert backend._auth_source() == "integration"
+
+
+# ---------------------------------------------------------------------------
+# whoami — identity/capability discovery (#807)
+# ---------------------------------------------------------------------------
+
+
+class TestWhoami:
+    @pytest.mark.anyio
+    async def test_whoami_unauthenticated(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        with patch.object(mcp_module, "get_access_token", return_value=None):
+            result = await backend.whoami()
+        assert result == {"auth_source": "none", "subject": None, "role": ROLE_PUBLIC}
+
+    @pytest.mark.anyio
+    async def test_whoami_keycloak_admin(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        token = SimpleNamespace(claims={"sub": "user-1", "realm_access": {"roles": ["admin"]}})
+        with patch.object(mcp_module, "get_access_token", return_value=token):
+            result = await backend.whoami()
+        assert result == {"auth_source": "keycloak", "subject": "user-1", "role": ROLE_ADMIN}
+
+    @pytest.mark.anyio
+    async def test_whoami_integration_volunteer(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        token = SimpleNamespace(
+            claims={
+                "sub": "integration:ic-1",
+                "realm_access": {"roles": ["volunteer"]},
+                "auth_source": "integration",
+            }
+        )
+        with patch.object(mcp_module, "get_access_token", return_value=token):
+            result = await backend.whoami()
+        assert result == {"auth_source": "integration", "subject": "integration:ic-1", "role": ROLE_VOLUNTEER}
+
+    @pytest.mark.anyio
+    async def test_whoami_never_exposes_token_material(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        token = SimpleNamespace(
+            claims={"sub": "user-1", "realm_access": {"roles": ["admin"]}}, token="super-secret-raw-jwt"  # noqa: S106
+        )
+        with patch.object(mcp_module, "get_access_token", return_value=token):
+            result = await backend.whoami()
+        assert "super-secret-raw-jwt" not in str(result)
+        assert "token" not in result
+
 
 # ---------------------------------------------------------------------------
 # Admin write tool wiring (role gate + delegation to app.mcp.admin.*)
@@ -505,6 +595,41 @@ class TestAdminToolWiring:
         assert result == {"maintenance_mode": True}
         mocked.assert_awaited_once_with(backend.session_factory, "admin-1", maintenance_mode=True)
 
+    @pytest.mark.anyio
+    async def test_create_integration_client_requires_admin(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        token = _make_access_token(["volunteer"])
+        with patch.object(mcp_module, "get_access_token", return_value=token), pytest.raises(PermissionError):
+            await backend.create_integration_client(name="X", allowed_role="volunteer")
+
+    @pytest.mark.anyio
+    async def test_create_integration_client_delegates_with_actor(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        token = SimpleNamespace(claims={"sub": "admin-1", "realm_access": {"roles": ["admin"]}})
+        with (
+            patch.object(mcp_module, "get_access_token", return_value=token),
+            patch.object(
+                mcp_module.mcp_admin_integration_clients,
+                "create_integration_client",
+                new=AsyncMock(return_value={"id": "ic-1", "key": "cfic_x"}),
+            ) as mocked,
+        ):
+            result = await backend.create_integration_client(name="Home Assistant", allowed_role="volunteer")
+        assert result == {"id": "ic-1", "key": "cfic_x"}
+        mocked.assert_awaited_once_with(
+            backend.session_factory,
+            "admin-1",
+            name="Home Assistant",
+            allowed_role="volunteer",
+            rate_limit_per_minute=mcp_module.DEFAULT_RATE_LIMIT_PER_MINUTE,
+        )
+
+    @pytest.mark.anyio
+    async def test_revoke_integration_client_requires_admin(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        with patch.object(mcp_module, "get_access_token", return_value=None), pytest.raises(PermissionError):
+            await backend.revoke_integration_client("ic-1")
+
 
 # ---------------------------------------------------------------------------
 # Server creation / tool registration
@@ -533,6 +658,7 @@ class TestCreateMcpServer:
         tools = await mcp.list_tools()
         tool_names = {tool.name for tool in tools}
         expected = {
+            "whoami",
             "get_active_edition",
             "list_editions",
             "get_event_schedule",
@@ -615,6 +741,10 @@ class TestCreateMcpServer:
             "delete_registration",
             "list_audit_entries",
             "list_audit_resource_types",
+            "create_integration_client",
+            "list_integration_clients",
+            "revoke_integration_client",
+            "rotate_integration_client",
         }
         assert expected == tool_names
 

--- a/backend/tests/test_venues.py
+++ b/backend/tests/test_venues.py
@@ -36,6 +36,18 @@ async def test_venue_crud(client):
 
 
 @pytest.mark.anyio
+async def test_venue_create_respects_explicit_inactive(client):
+    """Regression test for a REST/MCP drift bug fixed by the shared
+    venues_service extraction (#807): the REST router used to construct the
+    Venue row without passing `active=`, silently ignoring `active: false` in
+    the request body and always creating an active venue. The MCP tool always
+    respected it. Both now go through the same service and behave identically."""
+    r = await client.post("/api/venues", json={**VENUE_PAYLOAD, "active": False}, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    assert r.json()["active"] is False
+
+
+@pytest.mark.anyio
 async def test_venue_requires_admin(unauth_client):
     r = await unauth_client.post("/api/venues", json=VENUE_PAYLOAD)
     assert r.status_code == 401

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -35,9 +35,12 @@ cd backend
 uv run python -m app.mcp_server
 ```
 
-This starts the MCP server in stdio mode without authentication enforcement. All unauthenticated tool calls resolve to the `public` role (edition/event/venue overview only).
+This starts the MCP server in stdio mode without authentication enforcement. All unauthenticated tool calls resolve to the `public` role (edition/event/venue overview only). Call the `whoami` tool at any time to check which role a session is currently resolving to.
 
-To run as a specific role (e.g., `volunteer`) in local development, you can set `MCP_INTEGRATION_TOKEN` to a signed JWT containing the appropriate `realm_access.roles` and configure `OIDC_ISSUER_URL` and a `JWTVerifier`.
+To run as a specific role (e.g., `volunteer`) in local development against a real backend, the two supported credential types are:
+
+- **A Keycloak-issued JWT** — obtain a token from your local/dev Keycloak realm (or use `DEV_AUTH_BYPASS_TOKEN`, see the backend README) with the appropriate `realm_access.roles` claim, and pass it as the bearer token when connecting over the HTTP transport (see [HTTP transport](#http-transport-with-keycloak--managed-integration-client-auth) below). Stdio mode has no bearer token to attach, so this only applies to the HTTP transport.
+- **A managed integration-client key** — create one via the admin API/MCP tools (`create_integration_client`, admin-only) and use the raw key it returns as the bearer token over the HTTP transport. See [Managed integration clients](#managed-integration-clients) below.
 
 ---
 
@@ -45,6 +48,7 @@ To run as a specific role (e.g., `volunteer`) in local development, you can set 
 
 | Tool | Auth required | Description |
 |------|---------------|-------------|
+| `whoami` | public | Resolved identity for the current session: auth source (`keycloak`/`integration`/`none`), subject, and effective role. Never returns token material. |
 | `get_active_edition` | public | Current/next upcoming active festival edition |
 | `list_editions` | public | Past and upcoming festival editions for historical discovery |
 | `get_event_schedule` | public | Event schedule for an edition |
@@ -86,6 +90,7 @@ complete regardless of which surface made the change. All are `admin`-only excep
 | Volunteers | `create_volunteer`, `get_volunteer`, `list_volunteers`, `update_volunteer`, `delete_volunteer` |
 | Registrations | `create_registration`, `update_registration`, `delete_registration` |
 | Audit trail | `list_audit_entries`, `list_audit_resource_types` |
+| Integration clients | `create_integration_client`, `list_integration_clients`, `revoke_integration_client`, `rotate_integration_client` |
 
 Partial updates follow one convention throughout: an omitted keyword argument (`None`)
 leaves that field unchanged. Nullable fields with no natural "clear" value (an id, not
@@ -147,7 +152,7 @@ env = { DATABASE_URL = "postgresql+asyncpg://postgres:postgres@localhost:5432/ch
 
 ---
 
-## HTTP (SSE) transport with Keycloak auth
+## HTTP transport with Keycloak + managed integration-client auth
 
 For production use or when running as a network-accessible service, set the following environment variables:
 
@@ -157,14 +162,82 @@ For production use or when running as a network-accessible service, set the foll
 | `MCP_BASE_URL` | Public URL of this MCP server, e.g. `https://mcp.champagnefestival.be` |
 | `DATABASE_URL` | PostgreSQL connection string |
 
-Then run with:
+There is no separate `app.mcp_http` module — the MCP server is mounted directly inside the
+main FastAPI app (`app.main:app`) at the `/mcp` path (see `backend/app/main.py`). Run it with
+the same command you'd use for the REST API:
 
 ```bash
 cd backend
-uv run uvicorn app.mcp_http:app --host 0.0.0.0 --port 8001
+uv run uvicorn app.main:app --host 0.0.0.0 --port 8001
 ```
 
-The HTTP transport will use `KeycloakAuthProvider` when both `OIDC_ISSUER_URL` and `MCP_BASE_URL` are configured.
+The MCP server is only mounted when `MCP_BASE_URL` is set; `OIDC_ISSUER_URL` is required
+whenever `MCP_BASE_URL` is (the app refuses to start otherwise). When both are configured,
+`build_keycloak_auth()` (`backend/app/mcp_server.py`) builds a FastMCP `MultiAuth` that
+accepts either credential type on the same endpoint:
+
+- a Keycloak-issued JWT (`KeycloakAuthProvider`), or
+- a managed integration-client key (`IntegrationKeyTokenVerifier`, see below).
+
+Both resolve through the same role-tier logic (`ChampagneFestivalMcpBackend._resolve_role()`),
+so every tool's authorization behaves identically regardless of which credential type made
+the call.
+
+### Managed integration clients
+
+For long-running automation (e.g. a Home Assistant integration or a scheduled script) that
+shouldn't depend on a Keycloak service account, an admin can issue a database-backed
+integration-client credential instead. Each credential:
+
+- is scoped to exactly one role tier (`admin` or `volunteer`), fixed at creation and never
+  more privileged than the creating admin's own tier;
+- is shown as a raw key exactly once, at creation or rotation time — only its SHA-256 hash
+  is stored afterward;
+- is rate-limited per minute (configurable per client, default 120/minute);
+- can be listed, revoked, or rotated at any time;
+- is recorded as the audit-trail actor (`integration:<client_id>`) for every mutation it makes.
+
+Create one via the REST API (admin bearer token required):
+
+```bash
+curl -X POST https://champagnefestival.example/api/integration-clients \
+  -H "Authorization: Bearer <admin-jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Home Assistant", "allowed_role": "volunteer", "rate_limit_per_minute": 60}'
+```
+
+The response includes the one-time `key` — save it immediately, it cannot be retrieved
+again. Use it as the bearer token when connecting to `/mcp`:
+
+```bash
+curl https://champagnefestival.example/mcp \
+  -H "Authorization: Bearer cfic_<the-returned-key>" \
+  ...
+```
+
+Or the equivalent MCP tools (`create_integration_client`, `list_integration_clients`,
+`revoke_integration_client`, `rotate_integration_client`) from an already-authenticated
+admin session. Call `whoami` from the new session to confirm `auth_source: "integration"`
+and the expected `role`.
+
+### Capabilities manifest
+
+`GET /api/mcp/capabilities` returns whether the MCP server is mounted and, when it is, the
+live registered tool list with each tool's required role tier — generated directly from the
+running server's tool registration (`app.mcp_server.get_mcp_capabilities`), so it cannot
+drift from what's actually callable:
+
+```json
+{
+  "enabled": true,
+  "mount_path": "/mcp",
+  "version": "2026.8.1",
+  "tools": [
+    {"name": "whoami", "required_role": "public"},
+    {"name": "create_venue", "required_role": "admin"}
+  ]
+}
+```
 
 ---
 

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -223,7 +223,8 @@ and the expected `role`.
 ### Capabilities manifest
 
 `GET /api/mcp/capabilities` returns whether the MCP server is mounted and, when it is, the
-live registered tool list with each tool's required role tier — generated directly from the
+live registered tool list with each tool's required role tier and side-effect classification
+(`read` or `write`) — generated directly from the
 running server's tool registration (`app.mcp_server.get_mcp_capabilities`), so it cannot
 drift from what's actually callable (example below is abbreviated — the live response includes all registered tools):
 
@@ -233,8 +234,8 @@ drift from what's actually callable (example below is abbreviated — the live r
   "mount_path": "/mcp",
   "version": "2026.8.1",
   "tools": [
-    {"name": "whoami", "required_role": "public"},
-    {"name": "create_venue", "required_role": "admin"}
+    {"name": "whoami", "effect": "read", "required_role": "public"},
+    {"name": "create_venue", "effect": "write", "required_role": "admin"}
     // ... additional tools omitted for brevity
   ]
 }

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -39,7 +39,7 @@ This starts the MCP server in stdio mode without authentication enforcement. All
 
 To run as a specific role (e.g., `volunteer`) in local development against a real backend, the two supported credential types are:
 
-- **A Keycloak-issued JWT** — obtain a token from your local/dev Keycloak realm (or use `DEV_AUTH_BYPASS_TOKEN`, see the backend README) with the appropriate `realm_access.roles` claim, and pass it as the bearer token when connecting over the HTTP transport (see [HTTP transport](#http-transport-with-keycloak--managed-integration-client-auth) below). Stdio mode has no bearer token to attach, so this only applies to the HTTP transport.
+- **A Keycloak-issued JWT** — obtain a token from your local/dev Keycloak realm (or use `DEV_AUTH_BYPASS_TOKEN` when `ENVIRONMENT=development`, see the backend README) with the appropriate `realm_access.roles` claim, and pass it as the bearer token when connecting over the HTTP transport (see [HTTP transport](#http-transport-with-keycloak--managed-integration-client-auth) below). Stdio mode has no bearer token to attach, so this only applies to the HTTP transport. `DEV_AUTH_BYPASS_TOKEN` is accepted only when `ENVIRONMENT=development`; startup refuses any configuration using this token in all other environments (see `app.config.Settings.validate_production_no_dev_bypass`).
 - **A managed integration-client key** — create one via the admin API/MCP tools (`create_integration_client`, admin-only) and use the raw key it returns as the bearer token over the HTTP transport. See [Managed integration clients](#managed-integration-clients) below.
 
 ---
@@ -181,7 +181,7 @@ accepts either credential type on the same endpoint:
 
 Both resolve through the same role-tier logic (`ChampagneFestivalMcpBackend._resolve_role()`),
 so every tool's authorization behaves identically regardless of which credential type made
-the call.
+the call. Bearer JWT roles are read from the `realm_access.roles` claim in the Keycloak-issued token, while managed integration-key roles are supplied as fixed synthesized claims (`{"realm_access": {"roles": [allowed_role]}}` and `auth_source: "integration"`) by `IntegrationKeyTokenVerifier`.
 
 ### Managed integration clients
 
@@ -225,7 +225,7 @@ and the expected `role`.
 `GET /api/mcp/capabilities` returns whether the MCP server is mounted and, when it is, the
 live registered tool list with each tool's required role tier — generated directly from the
 running server's tool registration (`app.mcp_server.get_mcp_capabilities`), so it cannot
-drift from what's actually callable:
+drift from what's actually callable (example below is abbreviated — the live response includes all registered tools):
 
 ```json
 {
@@ -235,6 +235,7 @@ drift from what's actually callable:
   "tools": [
     {"name": "whoami", "required_role": "public"},
     {"name": "create_venue", "required_role": "admin"}
+    // ... additional tools omitted for brevity
   ]
 }
 ```


### PR DESCRIPTION
Introduce managed integration-client credentials and extract shared application services.

- New database-backed IntegrationClient model and Alembic revision (006) to store hashed keys.
- Add full integration-client service: create/list/revoke/rotate, auth verifier (IntegrationKeyTokenVerifier), rate-limiting, and tests.
- Extract shared domain logic into app/services/*_service.py (areas, layouts, rooms, table_types, tables, venues) and new app/services/errors.py with adapter translations.
- Update REST routers and MCP admin tools to delegate to services and translate ServiceError.
- Add MCP capabilities endpoint, whoami tool, and compose Keycloak + integration-key auth via MultiAuth.
- Update docs and many tests to cover new behavior and guard against REST/MCP drift.