### PR TITLE
Fix delete_event info leak; mask unhandled MCP tool errors by default

### DIFF
--- a/backend/app/mcp/admin/areas.py
+++ b/backend/app/mcp/admin/areas.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.mcp.utils import validate_with_schema
+from app.mcp.utils import MCPToolError, validate_with_schema
 from app.schemas import AreaCreate, AreaUpdate
 from app.services import areas_service
 from app.services.errors import ServiceError
@@ -44,7 +44,7 @@ async def create_area(
         try:
             return await areas_service.create_area(db, actor=actor, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def list_areas(session_factory: Any, layout_id: str | None = None) -> dict:
@@ -57,7 +57,7 @@ async def get_area(session_factory: Any, area_id: str) -> dict:
         try:
             return await areas_service.get_area(db, area_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def update_area(
@@ -94,7 +94,7 @@ async def update_area(
     # (clear_exhibitor_id=True) the way REST distinguishes an absent JSON key
     # from an explicit ``null`` via ``model_fields_set``.
     if exhibitor_id is not None and clear_exhibitor_id:
-        raise ValueError("Pass either exhibitor_id or clear_exhibitor_id, not both.")
+        raise MCPToolError("Pass either exhibitor_id or clear_exhibitor_id, not both.")
     if exhibitor_id is not None:
         provided["exhibitor_id"] = exhibitor_id
     elif clear_exhibitor_id:
@@ -105,7 +105,7 @@ async def update_area(
         try:
             return await areas_service.update_area(db, actor=actor, area_id=area_id, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def delete_area(session_factory: Any, actor: str, area_id: str) -> dict:
@@ -113,4 +113,4 @@ async def delete_area(session_factory: Any, actor: str, area_id: str) -> dict:
         try:
             return await areas_service.delete_area(db, actor=actor, area_id=area_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc

--- a/backend/app/mcp/admin/audit.py
+++ b/backend/app/mcp/admin/audit.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from sqlalchemy import select
 
+from app.mcp.utils import MCPToolError
 from app.models import AuditEntry
 
 DEFAULT_AUDIT_LIMIT = 100
@@ -56,7 +57,7 @@ async def list_audit_entries(
     many matching rows.
     """
     if offset < 0:
-        raise ValueError("offset must not be negative.")
+        raise MCPToolError("offset must not be negative.")
     effective_limit = DEFAULT_AUDIT_LIMIT if limit is None else max(1, min(limit, MAX_AUDIT_LIMIT))
     async with session_factory() as db:
         stmt = select(AuditEntry)
@@ -81,7 +82,7 @@ async def list_audit_entries(
         if before_id is not None:
             cursor = await db.get(AuditEntry, before_id)
             if cursor is None:
-                raise ValueError("audit cursor does not exist")
+                raise MCPToolError("audit cursor does not exist")
             stmt = stmt.where(
                 (AuditEntry.timestamp < cursor.timestamp)
                 | ((AuditEntry.timestamp == cursor.timestamp) & (AuditEntry.id < cursor.id))

--- a/backend/app/mcp/admin/editions.py
+++ b/backend/app/mcp/admin/editions.py
@@ -20,7 +20,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 
 from app.audit import write_audit_entry
-from app.mcp.utils import as_value_error, validate_with_schema
+from app.mcp.utils import MCPToolError, as_value_error, validate_with_schema
 from app.models import Edition
 from app.routers.editions import (
     _edition_payload,
@@ -62,7 +62,7 @@ async def create_edition(
     async with session_factory() as db:
         existing = (await db.execute(select(Edition).where(Edition.id == body.id))).scalar_one_or_none()
         if existing is not None:
-            raise ValueError(f"Edition '{body.id}' already exists.")
+            raise MCPToolError(f"Edition '{body.id}' already exists.")
 
         try:
             await _load_venue(db, body.venue_id)
@@ -151,7 +151,7 @@ async def update_edition(
     }
     if clear_co_organizer:
         if co_organizer_exhibitor_id is not None:
-            raise ValueError("Pass either co_organizer_exhibitor_id or clear_co_organizer, not both.")
+            raise MCPToolError("Pass either co_organizer_exhibitor_id or clear_co_organizer, not both.")
         provided["co_organizer_exhibitor_id"] = None
     body = validate_with_schema(EditionUpdate, **provided)
 

--- a/backend/app/mcp/admin/events.py
+++ b/backend/app/mcp/admin/events.py
@@ -28,6 +28,7 @@ from app.models import Event
 from app.routers.events import (
     _ensure_edition_exists,
     _get_event_or_404,
+    _reject_if_registrations_exist,
     _validate_registration_settings,
     _validate_standalone_event_date,
 )
@@ -244,6 +245,7 @@ async def delete_event(session_factory: Any, actor: str, event_id: str) -> dict:
     async with session_factory() as db:
         try:
             event = await _get_event_or_404(db, event_id)
+            await _reject_if_registrations_exist(db, event_id)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
         await db.delete(event)

--- a/backend/app/mcp/admin/exhibitors.py
+++ b/backend/app/mcp/admin/exhibitors.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.audit import write_audit_entry
-from app.mcp.utils import get_or_error, validate_with_schema
+from app.mcp.utils import MCPToolError, get_or_error, validate_with_schema
 from app.models import Edition, Exhibitor, Person
 from app.routers.exhibitors import _editions_linking
 from app.schemas import ExhibitorCreate, ExhibitorUpdate
@@ -55,7 +55,7 @@ async def create_exhibitor(
     async with session_factory() as db:
         contact = await _load_contact(db, body.contact_person_id)
         if body.contact_person_id and contact is None:
-            raise ValueError("Person not found.")
+            raise MCPToolError("Person not found.")
         e = Exhibitor(
             name=body.name,
             image=body.image,
@@ -147,7 +147,7 @@ async def update_exhibitor(
                 await db.execute(select(Exhibitor.id).where(Exhibitor.id == exhibitor_id).with_for_update())
                 linked = await _editions_linking(db, exhibitor_id)
                 if linked:
-                    raise ValueError(
+                    raise MCPToolError(
                         "Cannot change this exhibitor to a vendor while editions still link to it: "
                         f"{', '.join(linked)}. Remove it from those editions first."
                     )
@@ -161,7 +161,7 @@ async def update_exhibitor(
             if body.contact_person_id is not None:
                 contact_check = await _load_contact(db, body.contact_person_id)
                 if contact_check is None:
-                    raise ValueError("Person not found.")
+                    raise MCPToolError("Person not found.")
             e.contact_person_id = body.contact_person_id
 
         await write_audit_entry(

--- a/backend/app/mcp/admin/integration_clients.py
+++ b/backend/app/mcp/admin/integration_clients.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.mcp.utils import MCPToolError
 from app.services import integration_clients_service as ics
 from app.services.errors import ServiceError
 
@@ -32,7 +33,7 @@ async def create_integration_client(
                 rate_limit_per_minute=rate_limit_per_minute,
             )
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
         return {**client_dict, "key": raw_key}
 
 
@@ -46,7 +47,7 @@ async def revoke_integration_client(session_factory: Any, actor: str, client_id:
         try:
             return await ics.revoke_integration_client(db, actor=actor, client_id=client_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def rotate_integration_client(session_factory: Any, actor: str, client_id: str) -> dict:
@@ -54,5 +55,5 @@ async def rotate_integration_client(session_factory: Any, actor: str, client_id:
         try:
             client_dict, raw_key = await ics.rotate_integration_client(db, actor=actor, client_id=client_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
         return {**client_dict, "key": raw_key}

--- a/backend/app/mcp/admin/layouts.py
+++ b/backend/app/mcp/admin/layouts.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import date as dt_date
 from typing import Any
 
-from app.mcp.utils import validate_with_schema
+from app.mcp.utils import MCPToolError, validate_with_schema
 from app.schemas import LayoutCopyCreate, LayoutCreate
 from app.services import layouts_service
 from app.services.errors import ServiceError
@@ -39,7 +39,7 @@ async def create_layout(
         try:
             return await layouts_service.create_layout(db, actor=actor, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def copy_layout(
@@ -69,7 +69,7 @@ async def copy_layout(
         try:
             return await layouts_service.copy_layout(db, actor=actor, source_layout_id=source_layout_id, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def list_layouts(session_factory: Any) -> dict:
@@ -82,7 +82,7 @@ async def get_layout(session_factory: Any, layout_id: str) -> dict:
         try:
             return await layouts_service.get_layout(db, layout_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def delete_layout(session_factory: Any, actor: str, layout_id: str) -> dict:
@@ -90,4 +90,4 @@ async def delete_layout(session_factory: Any, actor: str, layout_id: str) -> dic
         try:
             return await layouts_service.delete_layout(db, actor=actor, layout_id=layout_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc

--- a/backend/app/mcp/admin/members.py
+++ b/backend/app/mcp/admin/members.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import selectinload
 from app.audit import write_audit_entry
 from app.live import live_bus
 from app.live import mapping as live_mapping
-from app.mcp.utils import as_value_error, validate_with_schema
+from app.mcp.utils import MCPToolError, as_value_error, validate_with_schema
 from app.models import Person, Registration
 from app.routers.members import _ensure_member_role, _get_member_or_404
 from app.routers.members import _ensure_unique_fields as _member_ensure_unique_fields
@@ -101,7 +101,7 @@ async def create_member(
             await db.commit()
         except IntegrityError as exc:
             await db.rollback()
-            raise ValueError(
+            raise MCPToolError(
                 "Person with this national register number or eID document number already exists."
             ) from exc
         await db.refresh(person)
@@ -239,7 +239,7 @@ async def update_member(
             await db.commit()
         except IntegrityError as exc:
             await db.rollback()
-            raise ValueError(
+            raise MCPToolError(
                 "Person with this national register number or eID document number already exists."
             ) from exc
         await db.refresh(person)

--- a/backend/app/mcp/admin/people.py
+++ b/backend/app/mcp/admin/people.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import selectinload
 from app.audit import write_audit_entry
 from app.live import live_bus
 from app.live import mapping as live_mapping
-from app.mcp.utils import as_value_error, get_or_error, validate_with_schema
+from app.mcp.utils import MCPToolError, as_value_error, get_or_error, validate_with_schema
 from app.models import Exhibitor, Person, Registration, VolunteerPeriod
 from app.routers.people import (
     _ensure_unique_identity_fields,
@@ -262,7 +262,7 @@ async def merge_people(session_factory: Any, actor: str, person_id: str, duplica
     error). The duplicate person record is deleted.
     """
     if person_id == duplicate_id:
-        raise ValueError("Cannot merge a person with themselves.")
+        raise MCPToolError("Cannot merge a person with themselves.")
 
     async with session_factory() as db:
         canonical = await get_or_error(db, Person, person_id, f"Person '{person_id}' not found.")
@@ -277,7 +277,7 @@ async def merge_people(session_factory: Any, actor: str, person_id: str, duplica
             dup_val = _normalise_optional_identity(getattr(duplicate, field))
             if canon_val and dup_val and canon_val != dup_val:
                 label = field_labels[field]
-                raise ValueError(f"Both persons have a different {label}; resolve manually before merging.")
+                raise MCPToolError(f"Both persons have a different {label}; resolve manually before merging.")
 
         # Normalise canonical's own existing identity fields in-place so the
         # surviving record is always in canonical form, consistent with

--- a/backend/app/mcp/admin/rooms.py
+++ b/backend/app/mcp/admin/rooms.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.mcp.utils import validate_with_schema
+from app.mcp.utils import MCPToolError, validate_with_schema
 from app.schemas import RoomCreate, RoomUpdate
 from app.services import rooms_service
 from app.services.errors import ServiceError
@@ -38,7 +38,7 @@ async def create_room(
         try:
             return await rooms_service.create_room(db, actor=actor, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def list_rooms(session_factory: Any) -> dict:
@@ -51,7 +51,7 @@ async def get_room(session_factory: Any, room_id: str) -> dict:
         try:
             return await rooms_service.get_room(db, room_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def update_room(
@@ -81,7 +81,7 @@ async def update_room(
         try:
             return await rooms_service.update_room(db, actor=actor, room_id=room_id, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def delete_room(session_factory: Any, actor: str, room_id: str) -> dict:
@@ -89,4 +89,4 @@ async def delete_room(session_factory: Any, actor: str, room_id: str) -> dict:
         try:
             return await rooms_service.delete_room(db, actor=actor, room_id=room_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc

--- a/backend/app/mcp/admin/table_types.py
+++ b/backend/app/mcp/admin/table_types.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.mcp.utils import validate_with_schema
+from app.mcp.utils import MCPToolError, validate_with_schema
 from app.schemas import TableTypeCreate, TableTypeUpdate
 from app.services import table_types_service
 from app.services.errors import ServiceError
@@ -40,7 +40,7 @@ async def create_table_type(
         try:
             return await table_types_service.create_table_type(db, actor=actor, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def list_table_types(session_factory: Any) -> dict:
@@ -53,7 +53,7 @@ async def get_table_type(session_factory: Any, type_id: str) -> dict:
         try:
             return await table_types_service.get_table_type(db, type_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def update_table_type(
@@ -87,7 +87,7 @@ async def update_table_type(
         try:
             return await table_types_service.update_table_type(db, actor=actor, type_id=type_id, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def delete_table_type(session_factory: Any, actor: str, type_id: str) -> dict:
@@ -95,4 +95,4 @@ async def delete_table_type(session_factory: Any, actor: str, type_id: str) -> d
         try:
             return await table_types_service.delete_table_type(db, actor=actor, type_id=type_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc

--- a/backend/app/mcp/admin/tables.py
+++ b/backend/app/mcp/admin/tables.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.mcp.utils import validate_with_schema
+from app.mcp.utils import MCPToolError, validate_with_schema
 from app.schemas import TableCreate, TableUpdate
 from app.services import tables_service
 from app.services.errors import ServiceError
@@ -40,7 +40,7 @@ async def create_table(
         try:
             return await tables_service.create_table(db, actor=actor, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def list_tables(session_factory: Any) -> dict:
@@ -53,7 +53,7 @@ async def get_table(session_factory: Any, table_id: str) -> dict:
         try:
             return await tables_service.get_table(db, table_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def update_table(
@@ -87,7 +87,7 @@ async def update_table(
         try:
             return await tables_service.update_table(db, actor=actor, table_id=table_id, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def delete_table(session_factory: Any, actor: str, table_id: str) -> dict:
@@ -95,4 +95,4 @@ async def delete_table(session_factory: Any, actor: str, table_id: str) -> dict:
         try:
             return await tables_service.delete_table(db, actor=actor, table_id=table_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc

--- a/backend/app/mcp/admin/venues.py
+++ b/backend/app/mcp/admin/venues.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.mcp.utils import validate_with_schema
+from app.mcp.utils import MCPToolError, validate_with_schema
 from app.schemas import VenueCreate, VenueUpdate
 from app.services import venues_service
 from app.services.errors import ServiceError
@@ -42,7 +42,7 @@ async def create_venue(
         try:
             return await venues_service.create_venue(db, actor=actor, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def list_venues(session_factory: Any) -> dict:
@@ -55,7 +55,7 @@ async def get_venue(session_factory: Any, venue_id: str) -> dict:
         try:
             return await venues_service.get_venue(db, venue_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def update_venue(
@@ -91,7 +91,7 @@ async def update_venue(
         try:
             return await venues_service.update_venue(db, actor=actor, venue_id=venue_id, body=body)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc
 
 
 async def delete_venue(session_factory: Any, actor: str, venue_id: str) -> dict:
@@ -99,4 +99,4 @@ async def delete_venue(session_factory: Any, actor: str, venue_id: str) -> dict:
         try:
             return await venues_service.delete_venue(db, actor=actor, venue_id=venue_id)
         except ServiceError as exc:
-            raise ValueError(str(exc)) from exc
+            raise MCPToolError(str(exc)) from exc

--- a/backend/app/mcp/admin/volunteers.py
+++ b/backend/app/mcp/admin/volunteers.py
@@ -16,7 +16,7 @@ from sqlalchemy import delete, or_, select
 from sqlalchemy.exc import IntegrityError
 
 from app.audit import write_audit_entry
-from app.mcp.utils import as_value_error, validate_with_schema
+from app.mcp.utils import MCPToolError, as_value_error, validate_with_schema
 from app.models import Person, VolunteerPeriod
 from app.routers.volunteers import _ensure_unique_fields as _volunteer_ensure_unique_fields
 from app.routers.volunteers import (
@@ -86,7 +86,7 @@ async def create_volunteer(
             await db.commit()
         except IntegrityError as exc:
             await db.rollback()
-            raise ValueError(
+            raise MCPToolError(
                 "Person with this national register number or eID document number already exists."
             ) from exc
         await db.refresh(person)
@@ -205,7 +205,7 @@ async def update_volunteer(
             await db.commit()
         except IntegrityError as exc:
             await db.rollback()
-            raise ValueError(
+            raise MCPToolError(
                 "Person with this national register number or eID document number already exists."
             ) from exc
         await db.refresh(volunteer)

--- a/backend/app/mcp/orders.py
+++ b/backend/app/mcp/orders.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from sqlalchemy import select
 
-from app.mcp.utils import ROLE_ADMIN, order_item_dict
+from app.mcp.utils import ROLE_ADMIN, MCPToolError, order_item_dict
 from app.models import Person, Registration, Table
 from app.services.operational_search import DEFAULT_RESULT_LIMIT, rank_table_reference
 
@@ -18,7 +18,7 @@ async def get_table_order_summary(
     table_reference: str | None = None,
 ) -> dict:
     if not table_id and not table_reference:
-        raise ValueError("Provide 'table_id' or 'table_reference'.")
+        raise MCPToolError("Provide 'table_id' or 'table_reference'.")
 
     async with session_factory() as db:
         if not table_id and table_reference:
@@ -43,7 +43,7 @@ async def get_table_order_summary(
                 }
             table_id = candidates[0].id
         if table_id is None:
-            raise ValueError("table_id could not be resolved.")
+            raise MCPToolError("table_id could not be resolved.")
 
         table_result = await db.execute(select(Table).where(Table.id == table_id))
         table: Table | None = table_result.scalar_one_or_none()

--- a/backend/app/mcp/seating.py
+++ b/backend/app/mcp/seating.py
@@ -7,6 +7,7 @@ from typing import Any
 from sqlalchemy import select
 
 from app.mcp.utils import (
+    MCPToolError,
     get_active_edition_obj,
     order_item_dict,
     person_dict,
@@ -31,7 +32,7 @@ async def find_guest(
     name = name.strip() if name else None
     email = email.strip() if email else None
     if not name and not email:
-        raise ValueError("Provide at least one of 'name' or 'email' to search.")
+        raise MCPToolError("Provide at least one of 'name' or 'email' to search.")
 
     async with session_factory() as db:
         stmt = (
@@ -198,7 +199,7 @@ async def get_table_seating(
 async def resolve_table_reference(session_factory: Any, reference: str) -> dict:
     reference = reference.strip()
     if not reference:
-        raise ValueError("Provide a table reference to resolve.")
+        raise MCPToolError("Provide a table reference to resolve.")
 
     async with session_factory() as db:
         tables_result = await db.execute(select(Table).order_by(Table.name))

--- a/backend/app/mcp/utils.py
+++ b/backend/app/mcp/utils.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, date, datetime
 from typing import Any, TypeVar
 
 from fastapi import HTTPException
+from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,16 +23,39 @@ T = TypeVar("T")
 SchemaT = TypeVar("SchemaT", bound=BaseModel)
 
 
+class MCPToolError(ValueError, ToolError):
+    """A domain error raised by an admin MCP tool.
+
+    Subclasses both ``ValueError`` (so every existing ``raise ValueError(...)``
+    call site, and every test asserting ``pytest.raises(ValueError, ...)``,
+    keeps working unchanged) and FastMCP's own ``ToolError``. The second parent
+    matters for how FastMCP's tool-call dispatcher treats the exception: a
+    plain ``ValueError`` falls through to the generic ``except Exception``
+    branch, which wraps *any* exception's ``str()`` into the response —
+    including, for an exception nobody anticipated (e.g. a raw driver
+    ``IntegrityError``), internal SQL/row details. A ``ToolError`` instead hits
+    FastMCP's ``except FastMCPError`` branch, which re-raises it unchanged: our
+    already-sanitized message reaches the caller verbatim, and — paired with
+    ``mask_error_details=True`` on the server — any exception we did *not*
+    explicitly raise this way gets masked to a generic message instead of
+    leaking its details.
+    """
+
+    def __init__(self, message: str) -> None:
+        ValueError.__init__(self, message)
+        self.log_level = logging.ERROR
+
+
 async def get_or_error(db: AsyncSession, model: type[T], object_id: Any, message: str) -> T:
-    """Return the row with primary key ``object_id``, or raise ``ValueError``.
+    """Return the row with primary key ``object_id``, or raise ``MCPToolError``.
 
     MCP-context equivalent of ``app.utils.get_or_404`` — tools have no HTTP
-    response to attach a status code to, so a plain ``ValueError`` (whose
-    message reaches the calling agent) stands in for the 404.
+    response to attach a status code to, so ``MCPToolError`` (whose message
+    reaches the calling agent verbatim) stands in for the 404.
     """
     obj = await db.get(model, object_id)
     if obj is None:
-        raise ValueError(message)
+        raise MCPToolError(message)
     return obj
 
 
@@ -41,28 +66,28 @@ def validate_with_schema(schema_cls: type[SchemaT], **kwargs: Any) -> SchemaT:
     the only place field constraints (ranges, patterns, ``model_validator``s such as
     table-type dimension normalisation) actually run — reusing the exact REST schema
     keeps validation identical across both surfaces instead of drifting out of sync.
-    Raises ``ValueError`` with a readable message on failure, matching the rest of the
+    Raises ``MCPToolError`` with a readable message on failure, matching the rest of the
     admin MCP tools' error convention.
     """
     try:
         return schema_cls(**kwargs)
     except ValidationError as exc:
         messages = [f"{'.'.join(str(p) for p in err['loc'])}: {err['msg']}" for err in exc.errors()]
-        raise ValueError("; ".join(messages)) from exc
+        raise MCPToolError("; ".join(messages)) from exc
 
 
-def as_value_error(exc: HTTPException | ServiceError) -> ValueError:
-    """Convert a reused router helper's error into a ``ValueError``.
+def as_value_error(exc: HTTPException | ServiceError) -> MCPToolError:
+    """Convert a reused router helper's error into an ``MCPToolError``.
 
     Several REST routers factor validation (existence checks, business rules) into
     private helpers that raise ``HTTPException`` for FastAPI's benefit; shared
     ``app.services.*_service`` operations raise ``ServiceError`` instead so both
     the REST and MCP adapters can translate the same exception. Admin MCP tools
     reuse those helpers/services rather than duplicating the logic, then convert
-    here so every error an MCP caller sees is a plain ``ValueError``.
+    here so every error an MCP caller sees is an ``MCPToolError``.
     """
     detail = exc.detail if isinstance(exc, HTTPException) else exc.message
-    return ValueError(detail)
+    return MCPToolError(detail)
 
 
 async def get_active_edition_obj(db: Any, edition_type: str | None = "festival") -> Edition | None:

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -1601,6 +1601,12 @@ def create_mcp_server(
         ),
         auth=auth,
         version=APP_VERSION,
+        # Every admin tool's business errors are raised as `MCPToolError`
+        # (app.mcp.utils), which FastMCP re-raises verbatim regardless of this
+        # setting. Masking here is the safety net for exceptions nobody wrapped
+        # that way — e.g. a raw driver `IntegrityError` — which would otherwise
+        # have their full str() (SQL, row contents) embedded in the tool result.
+        mask_error_details=True,
         transforms=[
             BM25SearchTransform(
                 max_results=10,

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -238,8 +238,7 @@ async def _reject_if_registrations_exist(db: AsyncSession, event_id: str) -> Non
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
-                f"Cannot delete event: {count} registration(s) are still linked to it. "
-                "Delete or reassign them first."
+                f"Cannot delete event: {count} registration(s) are still linked to it. Delete or reassign them first."
             ),
         )
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -207,6 +207,7 @@ async def delete_event(
     actor: str = Depends(get_actor_id),
 ) -> None:
     event = await _get_event_or_404(db, event_id)
+    await _reject_if_registrations_exist(db, event_id)
     await db.delete(event)
     await write_audit_entry(
         db,
@@ -218,6 +219,29 @@ async def delete_event(
         details={},
     )
     await db.commit()
+
+
+async def _reject_if_registrations_exist(db: AsyncSession, event_id: str) -> None:
+    """Block event deletion while registrations still reference it.
+
+    ``registrations.event_id`` is non-nullable and the ORM relationship has no
+    delete cascade configured (registrations carry payment/attendance/order
+    history, so silently orphaning or cascading them is unsafe). Without this
+    check, ``db.delete(event)`` reaches the database, which raises a raw
+    ``NotNullViolationError`` that would otherwise surface driver/SQL details
+    and registration row contents to the caller.
+    """
+    count = (
+        await db.execute(select(func.count()).select_from(Registration).where(Registration.event_id == event_id))
+    ).scalar_one()
+    if count:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Cannot delete event: {count} registration(s) are still linked to it. "
+                "Delete or reassign them first."
+            ),
+        )
 
 
 async def _get_event_or_404(db: AsyncSession, event_id: str) -> Event:

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -27,6 +27,32 @@ async def _register(client, event, *, guest_count, person_name):
 
 
 @pytest.mark.anyio
+async def test_delete_event_rejects_when_registrations_exist(client):
+    """A blocking registration must produce a clean 409, not a raw DB error.
+
+    Regression test: without a pre-check, the delete reached the database and raised a
+    raw ``NotNullViolationError`` (the ORM has no cascade for `event.registrations`, so it
+    tried to null out the non-nullable `registrations.event_id`), which surfaced driver
+    internals, SQL, and the full registration row (including its check-in token) to the caller.
+    """
+    event = await _create_event(client)
+    await _register(client, event, guest_count=1, person_name="Alice")
+
+    response = await client.delete(f"/api/events/{event['id']}", headers=ADMIN_HEADERS)
+
+    assert response.status_code == 409
+    body = response.json()
+    assert "1 registration" in body["detail"]
+    assert "IntegrityError" not in response.text
+    assert "NotNullViolation" not in response.text
+    assert "check_in_token" not in response.text
+
+    # the event must survive the rejected delete
+    get_response = await client.get(f"/api/events/{event['id']}", headers=ADMIN_HEADERS)
+    assert get_response.status_code == 200
+
+
+@pytest.mark.anyio
 async def test_checkin_stats_counts_guests_not_bookings(client):
     """total/checked_in are guest headcounts (sum of guest_count), matching the
     admin's own capacity panel — not a count of bookings."""

--- a/backend/tests/test_mcp_admin_events.py
+++ b/backend/tests/test_mcp_admin_events.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import pytest
 
 from app.mcp.admin import events as mcp_events
-from app.models import Edition, Venue
+from app.mcp.admin import people as mcp_people
+from app.mcp.utils import MCPToolError
+from app.models import Edition, Registration, Venue
 from tests.helpers import mcp_session_factory
 
 
@@ -106,6 +108,56 @@ async def test_delete_event(db_session):
 
     with pytest.raises(ValueError, match="not found"):
         await mcp_events.get_event(factory, created["id"])
+
+
+async def test_delete_event_rejects_when_registrations_exist(db_session):
+    """A blocking registration must produce a clean conflict message, not a raw DB error.
+
+    Regression test: without a pre-check, ``db.delete(event)`` reached the database and
+    raised a raw ``NotNullViolationError`` (the ORM has no cascade for `event.registrations`,
+    so it tried to null out the non-nullable `registrations.event_id`), which surfaced driver
+    internals, SQL, and the full registration row (including its check-in token) to the caller.
+    """
+    factory = mcp_session_factory(db_session)
+    edition_id = await _create_edition(db_session)
+    created = await mcp_events.create_event(
+        factory,
+        "admin-1",
+        edition_id=edition_id,
+        title="Friday Tasting",
+        date="2099-03-21",
+        start_time="18:00",
+        category="festival",
+    )
+    person = await mcp_people.create_person(factory, "admin-1", name="Alice")
+    db_session.add(
+        Registration(
+            id="reg-1",
+            event_id=created["id"],
+            person_id=person["id"],
+            guest_count=1,
+            check_in_token="super-secret-token",
+        )
+    )
+    await db_session.commit()
+
+    with pytest.raises(ValueError) as exc_info:
+        await mcp_events.delete_event(factory, "admin-1", created["id"])
+
+    # Must be the FastMCP-aware error type, not a plain ValueError — that's what
+    # lets the sanitized message reach the caller unmodified instead of being
+    # wrapped/masked by FastMCP's generic exception handling (see MCPToolError).
+    assert isinstance(exc_info.value, MCPToolError)
+    message = str(exc_info.value)
+    assert "1 registration" in message
+    assert "super-secret-token" not in message
+    assert "IntegrityError" not in message
+    assert "NotNullViolation" not in message
+
+    # the event and its registration must both survive the rejected delete
+    assert await db_session.get(Registration, "reg-1") is not None
+    fetched = await mcp_events.get_event(factory, created["id"])
+    assert fetched["id"] == created["id"]
 
 
 async def test_standalone_edition_rejects_a_second_date(db_session):

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -20,6 +20,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 import app.mcp_server as mcp_module
 from app.mcp import auth as mcp_auth_module
@@ -686,6 +687,73 @@ class TestCreateMcpServer:
         names = [item["name"] for item in result.structured_content["result"]]
         assert "get_event_schedule" in names
         assert "find_guest" not in names
+
+
+# ---------------------------------------------------------------------------
+# MCPToolError / mask_error_details — the mechanism admin MCP tools rely on
+# to keep unsanitized exception details from ever reaching a client.
+#
+# A full round trip through this project's ``create_mcp_server()`` would need
+# a real FastMCP-native auth context (its per-tool ``require_roles`` check
+# reads the access token via FastMCP's own request-context machinery, not the
+# ``mcp_module.get_access_token`` this file already patches for backend-level
+# tests) — not reproducible in-process without a live Keycloak token. These
+# tests instead exercise the mechanism directly against a minimal FastMCP
+# server with the same ``mask_error_details=True`` setting, which is exactly
+# where the "does our error class pass through unmodified, does everything
+# else get masked" behaviour actually lives.
+# ---------------------------------------------------------------------------
+
+
+class TestMCPToolErrorMasking:
+    @pytest.mark.anyio
+    async def test_mcp_tool_error_message_passes_through_unmodified(self):
+        from fastmcp import FastMCP
+
+        from app.mcp.utils import MCPToolError
+
+        mcp = FastMCP(name="test", mask_error_details=True)
+
+        @mcp.tool
+        def delete_something() -> str:
+            raise MCPToolError("Cannot delete event: 1 registration(s) are still linked to it.")
+
+        with pytest.raises(ToolError) as exc_info:
+            await mcp.call_tool("delete_something", {})
+
+        message = str(exc_info.value)
+        assert message == "Cannot delete event: 1 registration(s) are still linked to it."
+        # Would appear if MCPToolError fell into the generic `except Exception`
+        # branch (the one every plain `ValueError` hits) instead of FastMCP's
+        # `except FastMCPError` re-raise.
+        assert "Error calling tool" not in message
+
+    @pytest.mark.anyio
+    async def test_unwrapped_exception_is_masked_not_leaked(self):
+        """A bug nobody wrapped in ``MCPToolError`` must not leak ``str(exc)``.
+
+        This is the failure mode the original ``delete_event`` bug actually
+        was: an uncaught, unanticipated exception (there, a raw SQLAlchemy
+        ``IntegrityError`` with SQL and row contents). Without
+        ``mask_error_details=True``, FastMCP's default behaviour embeds the
+        full exception text in the tool result; this proves the server-wide
+        safety net now catches that case generally, not just the one call
+        site that got a manual pre-check.
+        """
+        from fastmcp import FastMCP
+
+        mcp = FastMCP(name="test", mask_error_details=True)
+
+        @mcp.tool
+        def delete_something() -> str:
+            raise RuntimeError("duplicate key value violates unique constraint, token='super-secret-token'")
+
+        with pytest.raises(ToolError) as exc_info:
+            await mcp.call_tool("delete_something", {})
+
+        message = str(exc_info.value)
+        assert "super-secret-token" not in message
+        assert "duplicate key value" not in message
 
 
 # ---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s


### PR DESCRIPTION
## Summary

- Deleting an event with attached registrations tried to null out `registrations.event_id` (non-nullable), and the resulting raw `IntegrityError` propagated to the MCP/REST caller with SQL, row contents, and a token-like value attached. Both `delete_event` paths now pre-check for blocking registrations and return a sanitized `409 Conflict` / MCP error with just a count.
- Added `MCPToolError` (a `ValueError` + FastMCP `ToolError` hybrid) and routed every admin MCP tool's error through it instead of a plain `ValueError`, so intentional domain errors (conflicts, validation failures, not-founds) pass through FastMCP's dispatcher unmodified.
- Set `mask_error_details=True` on the MCP server: any exception *not* explicitly raised as `MCPToolError` is now masked to a generic message instead of FastMCP's default of leaking `str(exc)`. This closes the leak class for the whole admin MCP surface, not just the one call site that prompted this fix.
- Side fix: `docker-compose.yml`'s postgres volume was mounted at the pre-18 path; `postgres:18-alpine` expects the mount one level up, so the local db container wouldn't start at all. Fixed the mount path.

## Test plan

- [x] `uv run pytest` — 744 passed
- [x] `uv run ruff check app` — clean
- [x] `uv run ty check app` — clean
- [x] New regression tests: REST 409 + no-leak assertion (`test_events.py`), MCP `ValueError`/`MCPToolError` type + no-leak assertion (`test_mcp_admin_events.py`), and a mechanism-level test proving `MCPToolError` passes through FastMCP's dispatcher unmodified while an unwrapped exception gets masked (`test_mcp_server.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)