### PR TITLE
Remove redundant fastmcp-slim constraint blocking Dependabot

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -61,5 +61,3 @@ known-first-party = ["app"]
 [tool.ty.rules]
 unresolved-attribute = "warn"
 
-[tool.uv]
-constraint-dependencies = ["fastmcp-slim==4.0.0b1"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -8,9 +8,6 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
-[manifest]
-constraints = [{ name = "fastmcp-slim", specifier = "==4.0.0b1" }]
-
 [[package]]
 name = "aiofile"
 version = "3.11.1"


### PR DESCRIPTION
[tool.uv] constraint-dependencies pinned fastmcp-slim==4.0.0b1 explicitly, added alongside the fastmcp v4 upgrade (#828). It's redundant: fastmcp's own metadata already requires fastmcp-slim[client,server]==<matching version> exactly, so uv resolves to the same version with or without it (verified: uv lock/sync/pytest all pass identically without the pin).

The pin is also what broke Dependabot: fastmcp 4.0.0b2 is now available and requires fastmcp-slim==4.0.0b2, but Dependabot only bumps the `dependencies` list entry it's targeting, not this separate [tool.uv] constraint — leaving fastmcp-slim pinned to 4.0.0b1 and the resolution unsatisfiable. That failure aborts Dependabot's Python resolution entirely rather than surfacing as an actionable update, so it silently stopped proposing any Python dependency updates at all.