### PR TITLE
Restore missing indexes/constraints and gate CI on alembic check

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -72,5 +72,8 @@ jobs:
       - name: Migrate (alembic upgrade head)
         run: uv run alembic upgrade head
 
+      - name: Verify migrations are in sync with models
+        run: uv run alembic check
+
       - name: Test
         run: uv run pytest

--- a/backend/alembic/versions/008_drop_redundant_unique_constraints.py
+++ b/backend/alembic/versions/008_drop_redundant_unique_constraints.py
@@ -1,0 +1,38 @@
+"""Drop redundant unique constraints superseded by named unique indexes.
+
+users.oidc_subject and pebble_access_tokens.token_hash have carried a
+plain (unnamed) unique constraint since 001_initial/002, which Postgres
+auto-named users_oidc_subject_key / pebble_access_tokens_token_hash_key.
+The models were also missing the named unique indexes (ix_users_oidc_subject,
+ix_pebble_access_tokens_token_hash) those same migrations create — models.py
+drifted to not declare either index at all. Restoring the missing index
+declarations (rather than re-adding a second, differently-named constraint)
+leaves both columns doubly unique-enforced: the old anonymous constraint and
+the named index. Drop the now-redundant constraint; the named unique index
+alone continues to enforce uniqueness with no behavior change.
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-08-12
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "008"
+down_revision: str | None = "007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("users_oidc_subject_key", "users", type_="unique")
+    op.drop_constraint("pebble_access_tokens_token_hash_key", "pebble_access_tokens", type_="unique")
+
+
+def downgrade() -> None:
+    op.create_unique_constraint("users_oidc_subject_key", "users", ["oidc_subject"])
+    op.create_unique_constraint("pebble_access_tokens_token_hash_key", "pebble_access_tokens", ["token_hash"])

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     Numeric,
     String,
@@ -32,7 +33,7 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    oidc_subject: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    oidc_subject: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
     """OIDC ``sub`` claim — stable identifier from the identity provider."""
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
@@ -58,7 +59,7 @@ class PebbleAccessToken(Base):
         unique=True,
         nullable=False,
     )
-    token_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
@@ -69,21 +70,27 @@ class Registration(Base):
     __tablename__ = "registrations"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    event_id: Mapped[str] = mapped_column(String(64), ForeignKey("events.id", ondelete="RESTRICT"), nullable=False)
+    event_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("events.id", ondelete="RESTRICT"), index=True, nullable=False
+    )
     guest_count: Mapped[int] = mapped_column(Integer)
     order_items: Mapped[list[dict]] = mapped_column(JSON, default=list)
     notes: Mapped[str] = mapped_column(Text, default="")
     accessibility_note: Mapped[str] = mapped_column(Text, default="")
     """Optional accessibility requirements for the guest (wheelchair, low table, etc.)."""
 
-    person_id: Mapped[str] = mapped_column(String(64), ForeignKey("people.id", ondelete="RESTRICT"), nullable=False)
-    table_id: Mapped[str | None] = mapped_column(
-        String(64), ForeignKey("tables.id", ondelete="SET NULL"), nullable=True
+    person_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("people.id", ondelete="RESTRICT"), index=True, nullable=False
     )
-    user_id: Mapped[str | None] = mapped_column(String(64), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    table_id: Mapped[str | None] = mapped_column(
+        String(64), ForeignKey("tables.id", ondelete="SET NULL"), index=True, nullable=True
+    )
+    user_id: Mapped[str | None] = mapped_column(
+        String(64), ForeignKey("users.id", ondelete="SET NULL"), index=True, nullable=True
+    )
     """FK to the portal User who owns this booking (filled when a visitor claims it)."""
 
-    status: Mapped[str] = mapped_column(String(20), default="pending")
+    status: Mapped[str] = mapped_column(String(20), default="pending", index=True)
     """pending | confirmed | cancelled"""
 
     payment_status: Mapped[str] = mapped_column(String(20), default="unpaid")
@@ -335,10 +342,12 @@ class Event(Base):
     __tablename__ = "events"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    edition_id: Mapped[str] = mapped_column(String(100), ForeignKey("editions.id", ondelete="CASCADE"), nullable=False)
+    edition_id: Mapped[str] = mapped_column(
+        String(100), ForeignKey("editions.id", ondelete="CASCADE"), index=True, nullable=False
+    )
     title: Mapped[str] = mapped_column(String(200))
     description: Mapped[str] = mapped_column(Text, default="")
-    date: Mapped[date] = mapped_column(Date)  # ty: ignore[invalid-type-form]
+    date: Mapped[date] = mapped_column(Date, index=True)  # ty: ignore[invalid-type-form]
     start_time: Mapped[str] = mapped_column(String(10))
     end_time: Mapped[str | None] = mapped_column(String(10), nullable=True)
     category: Mapped[str] = mapped_column(String(50))
@@ -350,7 +359,7 @@ class Event(Base):
     registration_required: Mapped[bool] = mapped_column(Boolean, default=False)
     registrations_open_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     max_capacity: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    active: Mapped[bool] = mapped_column(Boolean, default=True)
+    active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow, onupdate=_utcnow)
 
@@ -373,7 +382,9 @@ class Product(Base):
     __tablename__ = "products"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    event_id: Mapped[str] = mapped_column(String(64), ForeignKey("events.id", ondelete="CASCADE"), nullable=False)
+    event_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("events.id", ondelete="CASCADE"), index=True, nullable=False
+    )
     name: Mapped[str] = mapped_column(String(200))
     price: Mapped[Decimal] = mapped_column(Numeric(10, 2))
     category: Mapped[str] = mapped_column(String(20))
@@ -404,6 +415,30 @@ class Person(Base):
     """Unified person entity used for members, volunteers, and visitors."""
 
     __tablename__ = "people"
+    __table_args__ = (
+        # Trigram (pg_trgm) GIN indexes backing fuzzy operational search, in
+        # addition to the plain btree index=True below on search_email — the
+        # migration creates both, since exact-match lookup and fuzzy search
+        # need different index shapes on the same column.
+        Index(
+            "ix_people_search_name_trgm",
+            "search_name",
+            postgresql_using="gin",
+            postgresql_ops={"search_name": "gin_trgm_ops"},
+        ),
+        Index(
+            "ix_people_search_name_alt_trgm",
+            "search_name_alt",
+            postgresql_using="gin",
+            postgresql_ops={"search_name_alt": "gin_trgm_ops"},
+        ),
+        Index(
+            "ix_people_search_email_trgm",
+            "search_email",
+            postgresql_using="gin",
+            postgresql_ops={"search_email": "gin_trgm_ops"},
+        ),
+    )
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     name: Mapped[str] = mapped_column(String(200))
@@ -412,7 +447,7 @@ class Person(Base):
     """Trigger-maintained unaccented lower-case name for operational lookup."""
     search_name_alt: Mapped[str] = mapped_column(String(200), default="")
     """Trigger-maintained German-transliteration variant for operational lookup."""
-    search_email: Mapped[str] = mapped_column(String(200), default="")
+    search_email: Mapped[str] = mapped_column(String(200), default="", index=True)
     """Trigger-maintained lower-case email for authorized operational lookup."""
     phone: Mapped[str] = mapped_column(String(50), default="")
     address: Mapped[str] = mapped_column(String(300), default="")


### PR DESCRIPTION
## Summary

`models.py` had drifted from what the migrations actually create:

- **15 missing indexes**: `events.active/date/edition_id`, `registrations.event_id/person_id/table_id/user_id/status`, `products.event_id`, `people.search_email` plus its 3 trigram (GIN) indexes, `pebble_access_tokens.token_hash`, `users.oidc_subject`.
- **2 redundant unique constraints**, once the missing indexes above were restored: `pebble_access_tokens.token_hash` and `users.oidc_subject` each already had a plain unique constraint from `001_initial`/`002`, and restoring their named unique indexes (matching what those same migrations create) makes the old anonymous constraints redundant.

Restoring the missing index declarations is additive — no new migration needed, they already exist in the database. The two redundant constraints do need a migration (`008`) to drop; the named unique indexes already enforce the same uniqueness, so this changes nothing about what's allowed, only removes duplicate bookkeeping.

Also adds `alembic check` to backend CI, so drift like this gets caught going forward instead of accumulating silently — matching the same job `daynest` already runs (and `worktime` now also runs, in a companion PR).

## Test plan

- [x] `alembic check` — "No new upgrade operations detected" against a freshly migrated database
- [x] `uv run pytest` — 744 passed
- [x] `uv run ruff check .` / `ruff format --check .` — clean
- [x] `uv run ty check .` — clean
- [x] Re-verified against `fastmcp==4.0.0b2` (the version Dependabot already bumped to on `main` after #853/#854)

🤖 Generated with [Claude Code](https://claude.com/claude-code)