### PR TITLE
Define floor-plan coordinate units and add scoped layout/table reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ See `RELEASE-RUNBOOK.md` for release ownership, post-deploy verification, migrat
 - `frontend/messages/` for translation content
 - `frontend/src/components/ResponsiveImage.tsx` for shared image behavior
 - `frontend/src/utils/adminApi.ts` and `frontend/src/utils/adminRegistrationApi.ts` for admin API integration
+- `docs/floor-plan-coordinates.md` for the `Table`/`Area` `x`/`y`/`rotation` coordinate contract
 
 ## CI & workflows
 

--- a/backend/alembic/versions/012_enforce_unique_faq_sort_order.py
+++ b/backend/alembic/versions/012_enforce_unique_faq_sort_order.py
@@ -1,0 +1,54 @@
+"""Enforce unique, deterministic FAQ sort_order.
+
+`faq_items.sort_order` had no uniqueness or secondary tie-break, so two items
+could share a position and the resulting display order depended on
+database/query tie-breaking rather than an explicit rule (#836). Before adding
+the constraint, existing rows are renumbered densely (0..N-1) in their current
+effective order — `sort_order` first, `id` second as the same stable tie-break
+the application now uses — so any pre-existing duplicates or gaps are repaired
+rather than rejected by the new constraint.
+
+The constraint is DEFERRABLE INITIALLY DEFERRED: it's only checked at commit,
+so a reorder that touches several rows in one transaction can pass through a
+transient duplicate state without failing mid-transaction.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-08-13
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "012"
+down_revision: str | None = "011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE faq_items
+        SET sort_order = ranked.new_order
+        FROM (
+            SELECT id, ROW_NUMBER() OVER (ORDER BY sort_order, id) - 1 AS new_order
+            FROM faq_items
+        ) AS ranked
+        WHERE faq_items.id = ranked.id AND faq_items.sort_order != ranked.new_order
+        """
+    )
+    op.create_unique_constraint(
+        "uq_faq_items_sort_order",
+        "faq_items",
+        ["sort_order"],
+        deferrable=True,
+        initially="DEFERRED",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_faq_items_sort_order", "faq_items", type_="unique")

--- a/backend/app/mcp/admin/faq.py
+++ b/backend/app/mcp/admin/faq.py
@@ -1,19 +1,17 @@
 """Admin (write) MCP tool implementations for FAQ item management.
 
-Mirrors ``app.routers.faq``.
+Mirrors ``app.routers.faq``. Business logic lives in
+``app.services.faq_service`` and is shared with the REST router.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import select
-
-from app.audit import write_audit_entry
-from app.mcp.utils import get_or_error, validate_with_schema
-from app.models import FaqItem
-from app.schemas import FaqItemCreate, FaqItemUpdate
-from app.utils import faq_item_to_dict, make_id
+from app.mcp.utils import MCPToolError, validate_with_schema
+from app.schemas import FaqItemCreate, FaqItemReorder, FaqItemUpdate
+from app.services import faq_service
+from app.services.errors import ServiceError
 
 
 async def create_faq_item(
@@ -26,7 +24,6 @@ async def create_faq_item(
     answer_en: str | None = None,
     question_fr: str | None = None,
     answer_fr: str | None = None,
-    sort_order: int = 0,
     active: bool = True,
 ) -> dict:
     body = validate_with_schema(
@@ -37,40 +34,19 @@ async def create_faq_item(
         answer_en=answer_en or None,
         question_fr=question_fr or None,
         answer_fr=answer_fr or None,
-        sort_order=sort_order,
         active=active,
     )
     async with session_factory() as db:
-        f = FaqItem(
-            id=make_id("faq"),
-            question_nl=body.question_nl,
-            answer_nl=body.answer_nl,
-            question_en=body.question_en,
-            answer_en=body.answer_en,
-            question_fr=body.question_fr,
-            answer_fr=body.answer_fr,
-            sort_order=body.sort_order,
-            active=body.active,
-        )
-        db.add(f)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="faq_item_created",
-            resource_type="faq_item",
-            resource_id=f.id,
-            details={"question_nl": f.question_nl},
-        )
-        await db.commit()
-        await db.refresh(f)
-        return faq_item_to_dict(f)
+        try:
+            return await faq_service.create_faq_item(db, actor=actor, body=body)
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
 
 
 async def list_faq_items(session_factory: Any) -> dict:
     """Every FAQ item and every locale, active or not, in display order (admin shape)."""
     async with session_factory() as db:
-        result = await db.execute(select(FaqItem).order_by(FaqItem.sort_order))
-        return {"faq_items": [faq_item_to_dict(f) for f in result.scalars().all()]}
+        return {"faq_items": await faq_service.list_faq_items(db)}
 
 
 async def update_faq_item(
@@ -84,7 +60,6 @@ async def update_faq_item(
     answer_en: str | None = None,
     question_fr: str | None = None,
     answer_fr: str | None = None,
-    sort_order: int | None = None,
     active: bool | None = None,
 ) -> dict:
     """Update an FAQ item.
@@ -102,47 +77,35 @@ async def update_faq_item(
             "answer_en": answer_en,
             "question_fr": question_fr,
             "answer_fr": answer_fr,
-            "sort_order": sort_order,
             "active": active,
         }.items()
         if v is not None
     }
     body = validate_with_schema(FaqItemUpdate, **provided)
     async with session_factory() as db:
-        f = await get_or_error(db, FaqItem, faq_item_id, f"FAQ item '{faq_item_id}' not found.")
-        # Apply from the validated `body`, not the raw arguments — any coercion or
-        # normalisation FaqItemUpdate performs must land on the row, matching
-        # create_faq_item and the REST router's own update_faq_item.
-        optional_locales = {"question_en", "answer_en", "question_fr", "answer_fr"}
-        for field in body.model_fields_set:
-            value = getattr(body, field)
-            if field in optional_locales:
-                value = value or None
-            setattr(f, field, value)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="faq_item_updated",
-            resource_type="faq_item",
-            resource_id=f.id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        await db.commit()
-        await db.refresh(f)
-        return faq_item_to_dict(f)
+        try:
+            return await faq_service.update_faq_item(db, actor=actor, faq_item_id=faq_item_id, body=body)
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
 
 
 async def delete_faq_item(session_factory: Any, actor: str, faq_item_id: str) -> dict:
     async with session_factory() as db:
-        f = await get_or_error(db, FaqItem, faq_item_id, f"FAQ item '{faq_item_id}' not found.")
-        await db.delete(f)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="faq_item_deleted",
-            resource_type="faq_item",
-            resource_id=faq_item_id,
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": faq_item_id}
+        try:
+            return await faq_service.delete_faq_item(db, actor=actor, faq_item_id=faq_item_id)
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
+
+
+async def reorder_faq_items(session_factory: Any, actor: str, *, ordered_ids: list[str]) -> dict:
+    """Reassign every FAQ item's display position to match ``ordered_ids``.
+
+    ``ordered_ids`` must name every existing FAQ item exactly once — the same
+    semantics the admin UI's reorder control uses (#836).
+    """
+    body = validate_with_schema(FaqItemReorder, ordered_ids=ordered_ids)
+    async with session_factory() as db:
+        try:
+            return {"faq_items": await faq_service.reorder_faq_items(db, actor=actor, ordered_ids=body.ordered_ids)}
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc

--- a/backend/app/mcp/admin/layouts.py
+++ b/backend/app/mcp/admin/layouts.py
@@ -72,15 +72,19 @@ async def copy_layout(
             raise MCPToolError(str(exc)) from exc
 
 
-async def list_layouts(session_factory: Any) -> dict:
+async def list_layouts(
+    session_factory: Any,
+    edition_id: str | None = None,
+    room_id: str | None = None,
+) -> dict:
     async with session_factory() as db:
-        return {"layouts": await layouts_service.list_layouts(db)}
+        return {"layouts": await layouts_service.list_layouts(db, edition_id=edition_id, room_id=room_id)}
 
 
-async def get_layout(session_factory: Any, layout_id: str) -> dict:
+async def get_layout(session_factory: Any, layout_id: str, include_tables: bool = False) -> dict:
     async with session_factory() as db:
         try:
-            return await layouts_service.get_layout(db, layout_id)
+            return await layouts_service.get_layout(db, layout_id, include_tables=include_tables)
         except ServiceError as exc:
             raise MCPToolError(str(exc)) from exc
 

--- a/backend/app/mcp/admin/registrations.py
+++ b/backend/app/mcp/admin/registrations.py
@@ -88,9 +88,15 @@ async def list_registrations(
             stmt = stmt.where(Registration.checked_in == checked_in)
         if q and (q_stripped := q.strip()):
             stmt = stmt.join(Registration.person).where(person_search_predicate(name=q_stripped, email=q_stripped))
-        stmt = stmt.offset(offset).limit(effective_limit)
+        # Fetch one extra row beyond effective_limit so its presence (not just a
+        # full page) tells us whether a next page actually exists — otherwise a
+        # result set that lands exactly on effective_limit rows would advertise
+        # a next_offset pointing at an empty page.
+        stmt = stmt.offset(offset).limit(effective_limit + 1)
 
         rows = list((await db.execute(stmt)).scalars().all())
+        has_more = len(rows) > effective_limit
+        rows = rows[:effective_limit]
         person_map = await _fetch_person_map(db, rows)
 
         registrations = []
@@ -102,7 +108,7 @@ async def list_registrations(
         return {
             "registrations": registrations,
             "count": len(registrations),
-            "next_offset": offset + len(registrations) if len(registrations) == effective_limit else None,
+            "next_offset": offset + len(registrations) if has_more else None,
         }
 
 

--- a/backend/app/mcp/admin/registrations.py
+++ b/backend/app/mcp/admin/registrations.py
@@ -1,11 +1,11 @@
-"""Admin (write) MCP tool implementations for registration management.
+"""Admin MCP tool implementations for registration management.
 
 Mirrors the admin-only endpoints of ``app.routers.registrations``
-(``admin_create_registration``, ``update_registration``, ``delete_registration``).
-The public self-service endpoints (guest-facing creation with spam/rate-limit
-checks, the email-token "my registrations" lookup flow) have no MCP
-equivalent — those are unauthenticated flows already reachable via the web
-app, not admin management surface.
+(``list_registrations``, ``admin_create_registration``, ``update_registration``,
+``delete_registration``). The public self-service endpoints (guest-facing
+creation with spam/rate-limit checks, the email-token "my registrations"
+lookup flow) have no MCP equivalent — those are unauthenticated flows already
+reachable via the web app, not admin management surface.
 """
 
 from __future__ import annotations
@@ -16,12 +16,14 @@ from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 from app.audit import write_audit_entry
 from app.live import live_bus
 from app.live import mapping as live_mapping
-from app.mcp.utils import as_value_error, validate_with_schema
-from app.models import Registration
+from app.mcp.utils import MCPToolError, as_value_error, registration_base_dict, validate_with_schema
+from app.models import Event, Registration
 from app.routers.registrations import (
     _assert_table_matches_edition,
     _fetch_person_map,
@@ -32,9 +34,76 @@ from app.routers.registrations import (
     _sum_delivered,
 )
 from app.schemas import RegistrationAdminCreate, RegistrationUpdate
+from app.services.operational_search import person_search_predicate
 from app.utils import make_id, registration_to_dict
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_LIST_LIMIT = 50
+MAX_LIST_LIMIT = 200
+
+
+async def list_registrations(
+    session_factory: Any,
+    role: str,
+    *,
+    edition_id: str | None = None,
+    event_id: str | None = None,
+    status: str | None = None,
+    payment_status: str | None = None,
+    checked_in: bool | None = None,
+    q: str | None = None,
+    limit: int | None = None,
+    offset: int = 0,
+) -> dict:
+    """List registrations, newest first, with optional filters (admin equivalent of ``GET /api/registrations``).
+
+    ``q`` matches against the registrant's name/email using the same
+    normalized/fuzzy predicate as ``find_guest``. ``limit`` caps the page size
+    — defaults to ``DEFAULT_LIST_LIMIT`` (50), capped at ``MAX_LIST_LIMIT``
+    (200). ``offset`` skips that many matching rows. Each row is a compact
+    projection (see ``registration_base_dict``); use ``get_guest_registration``
+    for full detail (order items, notes) on a specific registration.
+    """
+    if offset < 0:
+        raise MCPToolError("offset must not be negative.")
+    effective_limit = DEFAULT_LIST_LIMIT if limit is None else max(1, min(limit, MAX_LIST_LIMIT))
+
+    async with session_factory() as db:
+        stmt = (
+            select(Registration)
+            .join(Registration.event)
+            .options(selectinload(Registration.event))
+            .order_by(Registration.created_at.desc(), Registration.id.desc())
+        )
+        if edition_id:
+            stmt = stmt.where(Event.edition_id == edition_id)
+        if event_id:
+            stmt = stmt.where(Registration.event_id == event_id)
+        if status:
+            stmt = stmt.where(Registration.status == status)
+        if payment_status:
+            stmt = stmt.where(Registration.payment_status == payment_status)
+        if checked_in is not None:
+            stmt = stmt.where(Registration.checked_in == checked_in)
+        if q and (q_stripped := q.strip()):
+            stmt = stmt.join(Registration.person).where(person_search_predicate(name=q_stripped, email=q_stripped))
+        stmt = stmt.offset(offset).limit(effective_limit)
+
+        rows = list((await db.execute(stmt)).scalars().all())
+        person_map = await _fetch_person_map(db, rows)
+
+        registrations = []
+        for row in rows:
+            item = registration_base_dict(row, person_map[row.person_id], role=role)
+            item["edition_id"] = row.event.edition_id
+            registrations.append(item)
+
+        return {
+            "registrations": registrations,
+            "count": len(registrations),
+            "next_offset": offset + len(registrations) if len(registrations) == effective_limit else None,
+        }
 
 
 async def create_registration(

--- a/backend/app/mcp/admin/rooms.py
+++ b/backend/app/mcp/admin/rooms.py
@@ -41,9 +41,9 @@ async def create_room(
             raise MCPToolError(str(exc)) from exc
 
 
-async def list_rooms(session_factory: Any) -> dict:
+async def list_rooms(session_factory: Any, venue_id: str | None = None) -> dict:
     async with session_factory() as db:
-        return {"rooms": await rooms_service.list_rooms(db)}
+        return {"rooms": await rooms_service.list_rooms(db, venue_id)}
 
 
 async def get_room(session_factory: Any, room_id: str) -> dict:

--- a/backend/app/mcp/admin/tables.py
+++ b/backend/app/mcp/admin/tables.py
@@ -43,9 +43,9 @@ async def create_table(
             raise MCPToolError(str(exc)) from exc
 
 
-async def list_tables(session_factory: Any) -> dict:
+async def list_tables(session_factory: Any, layout_id: str | None = None) -> dict:
     async with session_factory() as db:
-        return {"tables": await tables_service.list_tables(db)}
+        return {"tables": await tables_service.list_tables(db, layout_id)}
 
 
 async def get_table(session_factory: Any, table_id: str) -> dict:

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -27,12 +27,13 @@ import logging
 from collections.abc import Sequence
 from datetime import date as dt_date
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_access_token
 from fastmcp.server.transforms.search import BM25SearchTransform
 from fastmcp.tools.base import Tool
+from pydantic import Field
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.mcp import check_in as mcp_check_in
@@ -65,7 +66,7 @@ from app.mcp.capabilities import (
     tool_annotations,
     tool_auth,
 )
-from app.schemas import EditionType
+from app.schemas import ROTATION_DESCRIPTION, X_POSITION_DESCRIPTION, Y_POSITION_DESCRIPTION, EditionType
 from app.services.integration_clients_service import DEFAULT_RATE_LIMIT_PER_MINUTE
 from app.version import APP_VERSION
 
@@ -499,10 +500,10 @@ class ChampagneFestivalMcpBackend:
             active=active,
         )
 
-    async def list_rooms(self) -> dict:
-        """List all rooms. Requires the ``admin`` role."""
+    async def list_rooms(self, venue_id: str | None = None) -> dict:
+        """List rooms, optionally filtered by ``venue_id``. Requires the ``admin`` role."""
         self._require_admin()
-        return await mcp_admin_rooms.list_rooms(self.session_factory)
+        return await mcp_admin_rooms.list_rooms(self.session_factory, venue_id)
 
     async def get_room(self, room_id: str) -> dict:
         """Return a single room. Requires the ``admin`` role."""
@@ -631,11 +632,15 @@ class ChampagneFestivalMcpBackend:
         capacity: int,
         table_type_id: str,
         layout_id: str,
-        x: float = 50.0,
-        y: float = 50.0,
-        rotation: int = 0,
+        x: Annotated[float, Field(ge=0, le=100, description=X_POSITION_DESCRIPTION)] = 50.0,
+        y: Annotated[float, Field(ge=0, le=100, description=Y_POSITION_DESCRIPTION)] = 50.0,
+        rotation: Annotated[int, Field(ge=0, le=359, description=ROTATION_DESCRIPTION)] = 0,
     ) -> dict:
-        """Create a table on a layout. Requires the ``admin`` role."""
+        """Create a table on a layout. Requires the ``admin`` role.
+
+        See ``docs/floor-plan-coordinates.md`` for the full ``x``/``y``/``rotation``
+        coordinate contract.
+        """
         self._require_admin()
         return await mcp_admin_tables.create_table(
             self.session_factory,
@@ -649,10 +654,10 @@ class ChampagneFestivalMcpBackend:
             rotation=rotation,
         )
 
-    async def list_tables(self) -> dict:
-        """List all tables. Requires the ``admin`` role."""
+    async def list_tables(self, layout_id: str | None = None) -> dict:
+        """List tables, optionally filtered by ``layout_id``. Requires the ``admin`` role."""
         self._require_admin()
-        return await mcp_admin_tables.list_tables(self.session_factory)
+        return await mcp_admin_tables.list_tables(self.session_factory, layout_id)
 
     async def get_table(self, table_id: str) -> dict:
         """Return a single table, including its current registration ids. Requires the ``admin`` role."""
@@ -664,13 +669,16 @@ class ChampagneFestivalMcpBackend:
         table_id: str,
         name: str | None = None,
         capacity: int | None = None,
-        x: float | None = None,
-        y: float | None = None,
+        x: Annotated[float, Field(ge=0, le=100, description=X_POSITION_DESCRIPTION)] | None = None,
+        y: Annotated[float, Field(ge=0, le=100, description=Y_POSITION_DESCRIPTION)] | None = None,
         table_type_id: str | None = None,
-        rotation: int | None = None,
+        rotation: Annotated[int, Field(ge=0, le=359, description=ROTATION_DESCRIPTION)] | None = None,
         layout_id: str | None = None,
     ) -> dict:
-        """Partially update a table; omitted fields are left unchanged. Requires the ``admin`` role."""
+        """Partially update a table; omitted fields are left unchanged. Requires the ``admin`` role.
+
+        See ``create_table`` for the ``x``/``y``/``rotation`` coordinate contract.
+        """
         self._require_admin()
         return await mcp_admin_tables.update_table(
             self.session_factory,
@@ -741,15 +749,23 @@ class ChampagneFestivalMcpBackend:
             copy_areas=copy_areas,
         )
 
-    async def list_layouts(self) -> dict:
-        """List all layouts. Requires the ``admin`` role."""
-        self._require_admin()
-        return await mcp_admin_layouts.list_layouts(self.session_factory)
+    async def list_layouts(self, edition_id: str | None = None, room_id: str | None = None) -> dict:
+        """List layouts, optionally filtered by ``edition_id`` and/or ``room_id``.
 
-    async def get_layout(self, layout_id: str) -> dict:
-        """Return a single layout. Requires the ``admin`` role."""
+        Requires the ``admin`` role.
+        """
         self._require_admin()
-        return await mcp_admin_layouts.get_layout(self.session_factory, layout_id)
+        return await mcp_admin_layouts.list_layouts(self.session_factory, edition_id=edition_id, room_id=room_id)
+
+    async def get_layout(self, layout_id: str, include_tables: bool = False) -> dict:
+        """Return a single layout. Requires the ``admin`` role.
+
+        Pass ``include_tables=True`` to also return the layout's ``tables`` and
+        ``areas`` in the same response, instead of a separate ``list_tables``/
+        ``list_areas`` call scoped to this ``layout_id``.
+        """
+        self._require_admin()
+        return await mcp_admin_layouts.get_layout(self.session_factory, layout_id, include_tables=include_tables)
 
     async def delete_layout(self, layout_id: str) -> dict:
         """Delete a layout. Fails if tables still reference it. Requires the ``admin`` role."""
@@ -766,11 +782,15 @@ class ChampagneFestivalMcpBackend:
         exhibitor_id: int | None = None,
         width_m: float = 1.5,
         length_m: float = 1.0,
-        x: float = 50.0,
-        y: float = 50.0,
-        rotation: int = 0,
+        x: Annotated[float, Field(ge=0, le=100, description=X_POSITION_DESCRIPTION)] = 50.0,
+        y: Annotated[float, Field(ge=0, le=100, description=Y_POSITION_DESCRIPTION)] = 50.0,
+        rotation: Annotated[int, Field(ge=0, le=359, description=ROTATION_DESCRIPTION)] = 0,
     ) -> dict:
-        """Create a floor-plan area (e.g. an exhibitor booth) on a layout. Requires the ``admin`` role."""
+        """Create a floor-plan area (e.g. an exhibitor booth) on a layout. Requires the ``admin`` role.
+
+        See ``docs/floor-plan-coordinates.md`` for the ``x``/``y``/``rotation``
+        coordinate contract (identical for areas and tables).
+        """
         self._require_admin()
         return await mcp_admin_areas.create_area(
             self.session_factory,
@@ -805,15 +825,16 @@ class ChampagneFestivalMcpBackend:
         clear_exhibitor_id: bool = False,
         width_m: float | None = None,
         length_m: float | None = None,
-        x: float | None = None,
-        y: float | None = None,
-        rotation: int | None = None,
+        x: Annotated[float, Field(ge=0, le=100, description=X_POSITION_DESCRIPTION)] | None = None,
+        y: Annotated[float, Field(ge=0, le=100, description=Y_POSITION_DESCRIPTION)] | None = None,
+        rotation: Annotated[int, Field(ge=0, le=359, description=ROTATION_DESCRIPTION)] | None = None,
     ) -> dict:
         """Partially update an area; omitted fields are left unchanged.
 
         ``exhibitor_id`` has no natural "clear" value (a real id is never blank) —
         pass ``clear_exhibitor_id=True`` to unassign the exhibitor instead of
-        providing an id. Requires the ``admin`` role.
+        providing an id. Requires the ``admin`` role. See
+        ``docs/floor-plan-coordinates.md`` for the ``x``/``y``/``rotation`` contract.
         """
         self._require_admin()
         return await mcp_admin_areas.update_area(

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -1038,10 +1038,12 @@ class ChampagneFestivalMcpBackend:
         answer_en: str | None = None,
         question_fr: str | None = None,
         answer_fr: str | None = None,
-        sort_order: int = 0,
         active: bool = True,
     ) -> dict:
-        """Create an FAQ item. Requires the ``admin`` role."""
+        """Create an FAQ item, appended after the current last one. Requires the ``admin`` role.
+
+        Display position isn't settable here — use ``reorder_faq_items`` to change it.
+        """
         self._require_admin()
         return await mcp_admin_faq.create_faq_item(
             self.session_factory,
@@ -1052,7 +1054,6 @@ class ChampagneFestivalMcpBackend:
             answer_en=answer_en,
             question_fr=question_fr,
             answer_fr=answer_fr,
-            sort_order=sort_order,
             active=active,
         )
 
@@ -1070,14 +1071,14 @@ class ChampagneFestivalMcpBackend:
         answer_en: str | None = None,
         question_fr: str | None = None,
         answer_fr: str | None = None,
-        sort_order: int | None = None,
         active: bool | None = None,
     ) -> dict:
         """Partially update an FAQ item; omitted fields are left unchanged.
 
         For the optional ``en``/``fr`` locale fields, an explicit empty string
         clears that locale's translation (hiding the item on that locale's FAQ)
-        rather than leaving it unchanged. Requires the ``admin`` role.
+        rather than leaving it unchanged. Display position isn't settable here —
+        use ``reorder_faq_items`` to change it. Requires the ``admin`` role.
         """
         self._require_admin()
         return await mcp_admin_faq.update_faq_item(
@@ -1090,7 +1091,6 @@ class ChampagneFestivalMcpBackend:
             answer_en=answer_en,
             question_fr=question_fr,
             answer_fr=answer_fr,
-            sort_order=sort_order,
             active=active,
         )
 
@@ -1098,6 +1098,17 @@ class ChampagneFestivalMcpBackend:
         """Delete an FAQ item. Requires the ``admin`` role."""
         self._require_admin()
         return await mcp_admin_faq.delete_faq_item(self.session_factory, self._actor(), faq_item_id)
+
+    async def reorder_faq_items(self, ordered_ids: list[str]) -> dict:
+        """Reassign every FAQ item's display position to match ``ordered_ids``.
+
+        ``ordered_ids`` must name every existing FAQ item exactly once — the
+        same all-at-once semantics the admin UI's reorder control uses, so a
+        reorder can't be partial, stale, or racing another admin's reorder.
+        Requires the ``admin`` role.
+        """
+        self._require_admin()
+        return await mcp_admin_faq.reorder_faq_items(self.session_factory, self._actor(), ordered_ids=ordered_ids)
 
     # -- Settings ------------------------------------------------------
 
@@ -1433,6 +1444,39 @@ class ChampagneFestivalMcpBackend:
 
     # -- Registrations (admin) ------------------------------------------
 
+    async def list_registrations(
+        self,
+        edition_id: str | None = None,
+        event_id: str | None = None,
+        status: str | None = None,
+        payment_status: str | None = None,
+        checked_in: bool | None = None,
+        q: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict:
+        """List registrations (newest first), with optional filters. Requires the ``admin`` role.
+
+        Enumerates registrations without needing to already know a
+        ``registration_id`` — pair with ``get_guest_registration`` for full
+        detail (order items, notes) on a specific result. ``q`` matches
+        against the registrant's name/email, same as ``find_guest``. ``limit``
+        defaults to 50 and is capped at 200.
+        """
+        role = self._require_admin()
+        return await mcp_admin_registrations.list_registrations(
+            self.session_factory,
+            role,
+            edition_id=edition_id,
+            event_id=event_id,
+            status=status,
+            payment_status=payment_status,
+            checked_in=checked_in,
+            q=q,
+            limit=limit,
+            offset=offset,
+        )
+
     async def create_registration(
         self,
         person_id: str,
@@ -1725,6 +1769,7 @@ def create_mcp_server(
     register_tool(backend.list_faq_items)
     register_tool(backend.update_faq_item)
     register_tool(backend.delete_faq_item)
+    register_tool(backend.reorder_faq_items)
     register_tool(backend.get_settings)
     register_tool(backend.set_maintenance_mode)
     register_tool(backend.create_exhibitor)
@@ -1747,6 +1792,7 @@ def create_mcp_server(
     register_tool(backend.list_volunteers)
     register_tool(backend.update_volunteer)
     register_tool(backend.delete_volunteer)
+    register_tool(backend.list_registrations)
     register_tool(backend.create_registration)
     register_tool(backend.update_registration)
     register_tool(backend.delete_registration)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    UniqueConstraint,
     text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -604,6 +605,12 @@ class FaqItem(Base):
     """
 
     __tablename__ = "faq_items"
+    __table_args__ = (
+        # Deferred so a reorder can touch several rows in one transaction
+        # without a transient duplicate mid-transaction tripping the check —
+        # only the state at commit has to be unique (#836).
+        UniqueConstraint("sort_order", name="uq_faq_items_sort_order", deferrable=True, initially="DEFERRED"),
+    )
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     question_nl: Mapped[str] = mapped_column(String(500))

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -240,8 +240,8 @@ class Layout(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow, onupdate=_utcnow)
 
     room: Mapped[Room] = relationship()
-    tables: Mapped[list[Table]] = relationship(order_by="Table.created_at")
-    areas: Mapped[list[Area]] = relationship(order_by="Area.created_at")
+    tables: Mapped[list[Table]] = relationship(order_by="Table.created_at, Table.id")
+    areas: Mapped[list[Area]] = relationship(order_by="Area.created_at, Area.id")
 
 
 class TableType(Base):
@@ -279,16 +279,25 @@ class Table(Base):
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     name: Mapped[str] = mapped_column(String(200))
     capacity: Mapped[int] = mapped_column(Integer)
-    # Position as percentage of room dimensions (0-100)
+
     x: Mapped[float] = mapped_column(default=50.0)
     y: Mapped[float] = mapped_column(default=50.0)
+    """Position as a percentage [0, 100] of the layout's *rendered canvas*, not the
+    room's raw ``width_m``/``length_m`` — origin top-left, anchored at this table's
+    own top-left corner. See ``docs/floor-plan-coordinates.md`` for the full contract
+    (including why the canvas isn't a 1:1 percentage of physical room size for small
+    rooms) shared with ``Area.x``/``Area.y`` and the frontend editor.
+    """
+
     table_type_id: Mapped[str] = mapped_column(
         String(64), ForeignKey("table_types.id", ondelete="RESTRICT"), nullable=False
     )
     """FK to the TableType template that defines this table's shape and dimensions."""
 
     rotation: Mapped[int] = mapped_column(Integer, default=0)
-    """Rotation angle in whole degrees [0, 359], clockwise."""
+    """Rotation angle in whole degrees [0, 359], clockwise, pivoting around this
+    table's own center. See ``docs/floor-plan-coordinates.md``.
+    """
 
     layout_id: Mapped[str] = mapped_column(String(64), ForeignKey("layouts.id", ondelete="CASCADE"), nullable=False)
     """FK to the Layout this table belongs to."""
@@ -315,7 +324,15 @@ class Area(Base):
 
     x: Mapped[float] = mapped_column(default=50.0)
     y: Mapped[float] = mapped_column(default=50.0)
+    """Position as a percentage [0, 100] of the layout's rendered canvas. Same
+    contract as ``Table.x``/``Table.y`` — see ``docs/floor-plan-coordinates.md``.
+    """
+
     rotation: Mapped[int] = mapped_column(Integer, default=0)
+    """Rotation angle in whole degrees [0, 359], clockwise, pivoting around this
+    area's own center. Same contract as ``Table.rotation``.
+    """
+
     width_m: Mapped[float] = mapped_column(default=1.5)
     length_m: Mapped[float] = mapped_column(default=1.0)
 

--- a/backend/app/routers/faq.py
+++ b/backend/app/routers/faq.py
@@ -1,15 +1,21 @@
-"""FAQ item management endpoints."""
+"""FAQ item management endpoints.
+
+Business logic lives in ``app.services.faq_service`` and is shared with
+``app.mcp.admin.faq`` — this router is a thin adapter that translates
+``ServiceError`` into ``HTTPException`` (see #807, #836).
+"""
 
 from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
 from app.models import FaqItem
-from app.schemas import FaqItemCreate, FaqItemOut, FaqItemPublicOut, FaqItemUpdate, FaqLocale
-from app.utils import faq_item_to_dict, faq_item_to_public_dict, get_or_404, make_id
+from app.schemas import FaqItemCreate, FaqItemOut, FaqItemPublicOut, FaqItemReorder, FaqItemUpdate, FaqLocale
+from app.services import faq_service
+from app.services.errors import ServiceError, to_http_exception
+from app.utils import faq_item_to_public_dict
 
 router = APIRouter(
     prefix="/api/faq",
@@ -42,106 +48,78 @@ async def list_active_faq_items(
 @router.get("", response_model=list[FaqItemOut], dependencies=[Depends(require_admin)])
 async def list_faq_items(db: AsyncSession = Depends(get_db)) -> list[dict]:
     """Admin: every FAQ item and every locale, active or not, in display order."""
-    stmt = select(FaqItem).order_by(FaqItem.sort_order)
-    result = await db.execute(stmt)
-    return [faq_item_to_dict(f) for f in result.scalars().all()]
+    return await faq_service.list_faq_items(db)
 
 
-@router.post("", response_model=FaqItemOut, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=FaqItemOut, status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_admin)])
 async def create_faq_item(
     body: FaqItemCreate,
     request: Request,
-    _: None = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    f = FaqItem(
-        id=make_id("faq"),
-        question_nl=body.question_nl,
-        answer_nl=body.answer_nl,
-        question_en=body.question_en or None,
-        answer_en=body.answer_en or None,
-        question_fr=body.question_fr or None,
-        answer_fr=body.answer_fr or None,
-        sort_order=body.sort_order,
-        active=body.active,
-    )
-    db.add(f)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="faq_item_created",
-        resource_type="faq_item",
-        resource_id=f.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"question_nl": f.question_nl},
-    )
-    await db.commit()
-    await db.refresh(f)
-    return faq_item_to_dict(f)
+    try:
+        return await faq_service.create_faq_item(
+            db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
-@router.put("/{faq_item_id}", response_model=FaqItemOut)
+@router.put("/{faq_item_id}", response_model=FaqItemOut, dependencies=[Depends(require_admin)])
 async def update_faq_item(
     faq_item_id: str,
     body: FaqItemUpdate,
     request: Request,
-    _: None = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    f = await get_or_404(db, FaqItem, faq_item_id, "FAQ item not found.")
-    if body.question_nl is not None:
-        f.question_nl = body.question_nl
-    if body.answer_nl is not None:
-        f.answer_nl = body.answer_nl
-    # Optional locales: presence, not None-ness, distinguishes "omitted" from
-    # "sent as '', clear it" — an empty string normalizes to NULL, hiding the
-    # item on that locale's FAQ.
-    fields_set = body.model_fields_set
-    if "question_en" in fields_set:
-        f.question_en = body.question_en or None
-    if "answer_en" in fields_set:
-        f.answer_en = body.answer_en or None
-    if "question_fr" in fields_set:
-        f.question_fr = body.question_fr or None
-    if "answer_fr" in fields_set:
-        f.answer_fr = body.answer_fr or None
-    if body.sort_order is not None:
-        f.sort_order = body.sort_order
-    if body.active is not None:
-        f.active = body.active
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="faq_item_updated",
-        resource_type="faq_item",
-        resource_id=f.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(fields_set)},
-    )
-    await db.commit()
-    await db.refresh(f)
-    return faq_item_to_dict(f)
+    try:
+        return await faq_service.update_faq_item(
+            db,
+            actor=actor,
+            faq_item_id=faq_item_id,
+            body=body,
+            request_id=getattr(request.state, "request_id", None),
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
-@router.delete("/{faq_item_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.post("/reorder", response_model=list[FaqItemOut], dependencies=[Depends(require_admin)])
+async def reorder_faq_items(
+    body: FaqItemReorder,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> list[dict]:
+    """Reassign every FAQ item's display position to match ``body.ordered_ids``.
+
+    The dedicated, all-at-once operation (rather than one PUT per item) is
+    what keeps a reorder from landing in a partially-applied, ambiguous state
+    (#836).
+    """
+    try:
+        return await faq_service.reorder_faq_items(
+            db,
+            actor=actor,
+            ordered_ids=body.ordered_ids,
+            request_id=getattr(request.state, "request_id", None),
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
+
+
+@router.delete("/{faq_item_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_admin)])
 async def delete_faq_item(
     faq_item_id: str,
     request: Request,
-    _: None = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    f = await get_or_404(db, FaqItem, faq_item_id, "FAQ item not found.")
-    await db.delete(f)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="faq_item_deleted",
-        resource_type="faq_item",
-        resource_id=faq_item_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={},
-    )
-    await db.commit()
+    try:
+        await faq_service.delete_faq_item(
+            db, actor=actor, faq_item_id=faq_item_id, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc

--- a/backend/app/routers/layouts.py
+++ b/backend/app/routers/layouts.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.schemas import LayoutCopyCreate, LayoutCreate, LayoutOut
+from app.schemas import LayoutCopyCreate, LayoutCreate, LayoutOut, LayoutWithTablesOut
 from app.services import layouts_service
 from app.services.errors import ServiceError, to_http_exception
 
@@ -61,14 +61,20 @@ async def list_layouts(
     db: AsyncSession = Depends(get_db),
     limit: int | None = Query(default=None, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
+    edition_id: str | None = Query(default=None, description="Filter by edition ID"),
+    room_id: str | None = Query(default=None, description="Filter by room ID"),
 ) -> list[dict]:
-    return await layouts_service.list_layouts(db, limit=limit, offset=offset)
+    return await layouts_service.list_layouts(db, limit=limit, offset=offset, edition_id=edition_id, room_id=room_id)
 
 
-@router.get("/{layout_id}", response_model=LayoutOut)
-async def get_layout(layout_id: str, db: AsyncSession = Depends(get_db)) -> dict:
+@router.get("/{layout_id}", response_model=LayoutWithTablesOut)
+async def get_layout(
+    layout_id: str,
+    include_tables: bool = Query(default=False, description="Also return the layout's tables and areas"),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
     try:
-        return await layouts_service.get_layout(db, layout_id)
+        return await layouts_service.get_layout(db, layout_id, include_tables=include_tables)
     except ServiceError as exc:
         raise to_http_exception(exc) from exc
 

--- a/backend/app/routers/rooms.py
+++ b/backend/app/routers/rooms.py
@@ -5,7 +5,7 @@ Business logic lives in ``app.services.rooms_service`` and is shared with
 ``ServiceError`` into ``HTTPException`` (see #807).
 """
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_actor_id, require_admin
@@ -37,8 +37,11 @@ async def create_room(
 
 
 @router.get("", response_model=list[RoomOut])
-async def list_rooms(db: AsyncSession = Depends(get_db)) -> list[dict]:
-    return await rooms_service.list_rooms(db)
+async def list_rooms(
+    venue_id: str | None = Query(default=None, description="Filter by venue ID"),
+    db: AsyncSession = Depends(get_db),
+) -> list[dict]:
+    return await rooms_service.list_rooms(db, venue_id)
 
 
 @router.get("/{room_id}", response_model=RoomOut)

--- a/backend/app/routers/tables.py
+++ b/backend/app/routers/tables.py
@@ -5,7 +5,7 @@ Business logic lives in ``app.services.tables_service`` and is shared with
 ``ServiceError`` into ``HTTPException`` (see #807).
 """
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_actor_id, require_admin
@@ -37,8 +37,11 @@ async def create_table(
 
 
 @router.get("", response_model=list[TableOut])
-async def list_tables(db: AsyncSession = Depends(get_db)) -> list[dict]:
-    return await tables_service.list_tables(db)
+async def list_tables(
+    layout_id: str | None = Query(default=None, description="Filter by layout ID"),
+    db: AsyncSession = Depends(get_db),
+) -> list[dict]:
+    return await tables_service.list_tables(db, layout_id)
 
 
 @router.get("/{table_id}", response_model=TableOut)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -680,23 +680,41 @@ class TableTypeOut(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+# x/y/rotation semantics (percentage of the layout's rendered canvas, top-left
+# origin, clockwise degrees) are shared by Table and Area — see
+# docs/floor-plan-coordinates.md for the full contract, including why the
+# canvas isn't a 1:1 percentage of the room's physical width_m/length_m.
+# Public (no leading underscore) so app.mcp_server can reuse the same text for
+# the MCP tool parameter schemas (see create_table/update_table/create_area/
+# update_area there), keeping the wording identical across REST and MCP.
+X_POSITION_DESCRIPTION = (
+    "Horizontal position: percentage [0, 100] of the layout's rendered canvas width, "
+    "from the left edge. See docs/floor-plan-coordinates.md."
+)
+Y_POSITION_DESCRIPTION = (
+    "Vertical position: percentage [0, 100] of the layout's rendered canvas height, "
+    "from the top edge. See docs/floor-plan-coordinates.md."
+)
+ROTATION_DESCRIPTION = "Clockwise rotation in whole degrees [0, 359], pivoting around this element's own center."
+
+
 class TableCreate(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     capacity: int = Field(ge=1, le=50)
-    x: float = Field(ge=0, le=100, default=50.0)
-    y: float = Field(ge=0, le=100, default=50.0)
+    x: float = Field(ge=0, le=100, default=50.0, description=X_POSITION_DESCRIPTION)
+    y: float = Field(ge=0, le=100, default=50.0, description=Y_POSITION_DESCRIPTION)
     table_type_id: str
-    rotation: int = Field(ge=0, le=359, default=0)
+    rotation: int = Field(ge=0, le=359, default=0, description=ROTATION_DESCRIPTION)
     layout_id: str
 
 
 class TableUpdate(BaseModel):
     name: str | None = None
     capacity: int | None = Field(default=None, ge=1, le=50)
-    x: float | None = Field(default=None, ge=0, le=100)
-    y: float | None = Field(default=None, ge=0, le=100)
+    x: float | None = Field(default=None, ge=0, le=100, description=X_POSITION_DESCRIPTION)
+    y: float | None = Field(default=None, ge=0, le=100, description=Y_POSITION_DESCRIPTION)
     table_type_id: str | None = None
-    rotation: int | None = Field(default=None, ge=0, le=359)
+    rotation: int | None = Field(default=None, ge=0, le=359, description=ROTATION_DESCRIPTION)
     layout_id: str | None = None
 
 
@@ -728,9 +746,9 @@ class AreaCreate(BaseModel):
     exhibitor_id: int | None = None
     width_m: float = Field(ge=0.1, le=50.0, default=1.5)
     length_m: float = Field(ge=0.1, le=50.0, default=1.0)
-    x: float = Field(ge=0, le=100, default=50.0)
-    y: float = Field(ge=0, le=100, default=50.0)
-    rotation: int = Field(ge=0, le=359, default=0)
+    x: float = Field(ge=0, le=100, default=50.0, description=X_POSITION_DESCRIPTION)
+    y: float = Field(ge=0, le=100, default=50.0, description=Y_POSITION_DESCRIPTION)
+    rotation: int = Field(ge=0, le=359, default=0, description=ROTATION_DESCRIPTION)
 
 
 class AreaUpdate(BaseModel):
@@ -739,9 +757,9 @@ class AreaUpdate(BaseModel):
     exhibitor_id: int | None = None
     width_m: float | None = Field(default=None, ge=0.1, le=50.0)
     length_m: float | None = Field(default=None, ge=0.1, le=50.0)
-    x: float | None = Field(default=None, ge=0, le=100)
-    y: float | None = Field(default=None, ge=0, le=100)
-    rotation: int | None = Field(default=None, ge=0, le=359)
+    x: float | None = Field(default=None, ge=0, le=100, description=X_POSITION_DESCRIPTION)
+    y: float | None = Field(default=None, ge=0, le=100, description=Y_POSITION_DESCRIPTION)
+    rotation: int | None = Field(default=None, ge=0, le=359, description=ROTATION_DESCRIPTION)
 
 
 class AreaOut(BaseModel):
@@ -759,6 +777,18 @@ class AreaOut(BaseModel):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class LayoutWithTablesOut(LayoutOut):
+    """``LayoutOut`` plus its tables/areas, returned by ``GET /api/layouts/{id}``
+    when ``include_tables=true`` is passed (or the MCP ``get_layout`` tool's
+    ``include_tables`` argument). ``tables``/``areas`` are ``None`` unless
+    requested, so a scoped single-layout read no longer requires a separate
+    global ``list_tables``/``list_areas`` scan and client-side join.
+    """
+
+    tables: list[TableOut] | None = None
+    areas: list[AreaOut] | None = None
 
 
 class VenuePlanRoomOut(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1048,7 +1048,6 @@ class FaqItemCreate(BaseModel):
     answer_en: str | None = Field(default=None, max_length=10000)
     question_fr: str | None = Field(default=None, max_length=500)
     answer_fr: str | None = Field(default=None, max_length=10000)
-    sort_order: int = 0
     active: bool = True
 
 
@@ -1063,8 +1062,18 @@ class FaqItemUpdate(BaseModel):
     answer_en: str | None = Field(default=None, max_length=10000)
     question_fr: str | None = Field(default=None, max_length=500)
     answer_fr: str | None = Field(default=None, max_length=10000)
-    sort_order: int | None = None
     active: bool | None = None
+
+
+class FaqItemReorder(BaseModel):
+    """The complete, ordered list of every existing FAQ item's ID.
+
+    `sort_order` isn't settable through create/update — this is the only way
+    to change display order, and it takes the whole collection at once so a
+    reorder can't leave things ambiguous or race another admin's reorder (#836).
+    """
+
+    ordered_ids: list[str] = Field(min_length=1)
 
 
 class FaqItemOut(BaseModel):

--- a/backend/app/services/areas_service.py
+++ b/backend/app/services/areas_service.py
@@ -64,7 +64,7 @@ async def create_area(db: AsyncSession, *, actor: str, body: AreaCreate, request
 
 async def list_areas(db: AsyncSession, layout_id: str | None = None) -> list[dict]:
     stmt = select(Area).order_by(Area.created_at, Area.id)
-    if layout_id:
+    if layout_id is not None:
         stmt = stmt.where(Area.layout_id == layout_id)
     result = await db.execute(stmt)
     return [area_to_dict(a) for a in result.scalars().all()]

--- a/backend/app/services/areas_service.py
+++ b/backend/app/services/areas_service.py
@@ -63,7 +63,7 @@ async def create_area(db: AsyncSession, *, actor: str, body: AreaCreate, request
 
 
 async def list_areas(db: AsyncSession, layout_id: str | None = None) -> list[dict]:
-    stmt = select(Area).order_by(Area.created_at)
+    stmt = select(Area).order_by(Area.created_at, Area.id)
     if layout_id:
         stmt = stmt.where(Area.layout_id == layout_id)
     result = await db.execute(stmt)

--- a/backend/app/services/faq_service.py
+++ b/backend/app/services/faq_service.py
@@ -1,0 +1,168 @@
+"""Shared application-service operations for FAQ items.
+
+Used by both ``app.routers.faq`` (REST) and ``app.mcp.admin.faq`` (MCP). See
+``app/services/rooms_service.py`` for the pattern this follows and
+``app/services/errors.py`` for the exception convention each adapter
+translates at its own boundary.
+
+``sort_order`` is enforced unique by a deferrable constraint (migration 012)
+so display order is always deterministic. It isn't client-settable through
+create/update — ``create_faq_item`` always appends after the current last
+item, and ``reorder_faq_items`` is the only supported way to change existing
+positions, taking the complete ordered list at once so a reorder can't be
+partial, stale, or racing another admin's reorder (#836).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.models import FaqItem
+from app.schemas import FaqItemCreate, FaqItemUpdate
+from app.services.errors import ConflictError, NotFoundError, ValidationFailedError
+from app.utils import faq_item_to_dict, make_id
+
+# A concurrent create can race this one for the same next `sort_order`; the
+# unique constraint (checked at commit) catches that, and this bounds how
+# many times we recompute-and-retry before giving up.
+_MAX_APPEND_ATTEMPTS = 5
+
+
+async def list_faq_items(db: AsyncSession) -> list[dict]:
+    """Every FAQ item and every locale, active or not, in display order (admin shape)."""
+    result = await db.execute(select(FaqItem).order_by(FaqItem.sort_order))
+    return [faq_item_to_dict(f) for f in result.scalars().all()]
+
+
+async def create_faq_item(db: AsyncSession, *, actor: str, body: FaqItemCreate, request_id: str | None = None) -> dict:
+    for _attempt in range(_MAX_APPEND_ATTEMPTS):
+        current_max = (await db.execute(select(func.max(FaqItem.sort_order)))).scalar_one()
+        f = FaqItem(
+            id=make_id("faq"),
+            question_nl=body.question_nl,
+            answer_nl=body.answer_nl,
+            question_en=body.question_en or None,
+            answer_en=body.answer_en or None,
+            question_fr=body.question_fr or None,
+            answer_fr=body.answer_fr or None,
+            sort_order=0 if current_max is None else current_max + 1,
+            active=body.active,
+        )
+        db.add(f)
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="faq_item_created",
+            resource_type="faq_item",
+            resource_id=f.id,
+            request_id=request_id,
+            details={"question_nl": f.question_nl},
+        )
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            continue
+        await db.refresh(f)
+        return faq_item_to_dict(f)
+    raise ConflictError("Could not assign a unique display position for the new FAQ item; please retry.")
+
+
+async def update_faq_item(
+    db: AsyncSession, *, actor: str, faq_item_id: str, body: FaqItemUpdate, request_id: str | None = None
+) -> dict:
+    f = await db.get(FaqItem, faq_item_id)
+    if f is None:
+        raise NotFoundError(f"FAQ item '{faq_item_id}' not found.")
+    if body.question_nl is not None:
+        f.question_nl = body.question_nl
+    if body.answer_nl is not None:
+        f.answer_nl = body.answer_nl
+    # Optional locales: presence, not None-ness, distinguishes "omitted" from
+    # "sent as '', clear it" — an empty string normalizes to NULL, hiding the
+    # item on that locale's FAQ.
+    fields_set = body.model_fields_set
+    if "question_en" in fields_set:
+        f.question_en = body.question_en or None
+    if "answer_en" in fields_set:
+        f.answer_en = body.answer_en or None
+    if "question_fr" in fields_set:
+        f.question_fr = body.question_fr or None
+    if "answer_fr" in fields_set:
+        f.answer_fr = body.answer_fr or None
+    if body.active is not None:
+        f.active = body.active
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="faq_item_updated",
+        resource_type="faq_item",
+        resource_id=f.id,
+        request_id=request_id,
+        details={"fields_changed": sorted(fields_set)},
+    )
+    await db.commit()
+    await db.refresh(f)
+    return faq_item_to_dict(f)
+
+
+async def delete_faq_item(db: AsyncSession, *, actor: str, faq_item_id: str, request_id: str | None = None) -> dict:
+    f = await db.get(FaqItem, faq_item_id)
+    if f is None:
+        raise NotFoundError(f"FAQ item '{faq_item_id}' not found.")
+    await db.delete(f)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="faq_item_deleted",
+        resource_type="faq_item",
+        resource_id=faq_item_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": faq_item_id}
+
+
+async def reorder_faq_items(
+    db: AsyncSession, *, actor: str, ordered_ids: list[str], request_id: str | None = None
+) -> list[dict]:
+    """Atomically reassign ``sort_order`` (0..N-1) to match ``ordered_ids``.
+
+    ``ordered_ids`` must name every existing FAQ item exactly once. A partial
+    or stale list — e.g. an item created or deleted by someone else since the
+    caller loaded its copy of the list — is rejected outright rather than
+    silently reordering a subset, which is what keeps concurrent reorders
+    well-defined: the loser of a race gets a 409 and has to reload, not a
+    merged/ambiguous result.
+    """
+    if len(ordered_ids) != len(set(ordered_ids)):
+        raise ValidationFailedError("ordered_ids contains duplicates.")
+
+    # Lock every row up front so a second reorder (or a create/delete) can't
+    # interleave with this one — it blocks until we commit, then its own
+    # existing-ids check below almost certainly fails against our new state.
+    result = await db.execute(select(FaqItem).order_by(FaqItem.sort_order).with_for_update())
+    items = {f.id: f for f in result.scalars().all()}
+    if set(ordered_ids) != set(items):
+        raise ConflictError(
+            "ordered_ids must name every existing FAQ item exactly once; the list is stale — reload and retry."
+        )
+
+    for index, item_id in enumerate(ordered_ids):
+        items[item_id].sort_order = index
+
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="faq_items_reordered",
+        resource_type="faq_item",
+        resource_id="faq_items",
+        request_id=request_id,
+        details={"ordered_ids": ordered_ids},
+    )
+    await db.commit()
+    return await list_faq_items(db)

--- a/backend/app/services/layouts_service.py
+++ b/backend/app/services/layouts_service.py
@@ -332,9 +332,9 @@ async def list_layouts(
     room_id: str | None = None,
 ) -> list[dict]:
     stmt = select(Layout).order_by(Layout.created_at, Layout.id).offset(offset)
-    if edition_id:
+    if edition_id is not None:
         stmt = stmt.where(Layout.edition_id == edition_id)
-    if room_id:
+    if room_id is not None:
         stmt = stmt.where(Layout.room_id == room_id)
     if limit is not None:
         stmt = stmt.limit(limit)

--- a/backend/app/services/layouts_service.py
+++ b/backend/app/services/layouts_service.py
@@ -19,10 +19,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.audit import write_audit_entry
-from app.models import Area, Edition, Exhibitor, Layout, Room, Table, TableType
+from app.models import Area, Edition, Exhibitor, Layout, Registration, Room, Table, TableType
 from app.schemas import LayoutCopyCreate, LayoutCreate
 from app.services.errors import ConflictError, NotFoundError, ValidationFailedError
-from app.utils import layout_to_dict, make_id
+from app.utils import area_to_dict, layout_to_dict, make_id, table_to_dict
 
 # Mirror the rendering constants from frontend/src/utils/layoutUtils.ts so that
 # the backend containment check matches the frontend's hit-testing exactly.
@@ -323,8 +323,19 @@ async def copy_layout(
     return layout_to_dict(cloned, date=resolved_date)
 
 
-async def list_layouts(db: AsyncSession, *, limit: int | None = None, offset: int = 0) -> list[dict]:
-    stmt = select(Layout).order_by(Layout.created_at).offset(offset)
+async def list_layouts(
+    db: AsyncSession,
+    *,
+    limit: int | None = None,
+    offset: int = 0,
+    edition_id: str | None = None,
+    room_id: str | None = None,
+) -> list[dict]:
+    stmt = select(Layout).order_by(Layout.created_at, Layout.id).offset(offset)
+    if edition_id:
+        stmt = stmt.where(Layout.edition_id == edition_id)
+    if room_id:
+        stmt = stmt.where(Layout.room_id == room_id)
     if limit is not None:
         stmt = stmt.limit(limit)
     result = await db.execute(stmt)
@@ -332,12 +343,32 @@ async def list_layouts(db: AsyncSession, *, limit: int | None = None, offset: in
     return await layout_payloads(db, layouts)
 
 
-async def get_layout(db: AsyncSession, layout_id: str) -> dict:
-    lay = await db.get(Layout, layout_id)
+async def get_layout(db: AsyncSession, layout_id: str, *, include_tables: bool = False) -> dict:
+    if include_tables:
+        result = await db.execute(
+            select(Layout)
+            .options(selectinload(Layout.tables), selectinload(Layout.areas))
+            .where(Layout.id == layout_id)
+        )
+        lay = result.scalar_one_or_none()
+    else:
+        lay = await db.get(Layout, layout_id)
     if lay is None:
         raise NotFoundError(f"Layout '{layout_id}' not found.")
     payloads = await layout_payloads(db, [lay])
-    return payloads[0]
+    payload = payloads[0]
+    if include_tables:
+        table_ids = [t.id for t in lay.tables]
+        table_res_map: dict[str, list[str]] = {}
+        if table_ids:
+            res_result = await db.execute(
+                select(Registration.id, Registration.table_id).where(Registration.table_id.in_(table_ids))
+            )
+            for res_id, tbl_id in res_result.all():
+                table_res_map.setdefault(tbl_id, []).append(res_id)
+        payload["tables"] = [table_to_dict(t, table_res_map.get(t.id, [])) for t in lay.tables]
+        payload["areas"] = [area_to_dict(a) for a in lay.areas]
+    return payload
 
 
 async def delete_layout(db: AsyncSession, *, actor: str, layout_id: str, request_id: str | None = None) -> dict:

--- a/backend/app/services/rooms_service.py
+++ b/backend/app/services/rooms_service.py
@@ -50,7 +50,7 @@ async def create_room(db: AsyncSession, *, actor: str, body: RoomCreate, request
 
 async def list_rooms(db: AsyncSession, venue_id: str | None = None) -> list[dict]:
     stmt = select(Room).order_by(Room.created_at, Room.id)
-    if venue_id:
+    if venue_id is not None:
         stmt = stmt.where(Room.venue_id == venue_id)
     result = await db.execute(stmt)
     return [room_to_dict(r) for r in result.scalars().all()]

--- a/backend/app/services/rooms_service.py
+++ b/backend/app/services/rooms_service.py
@@ -48,8 +48,11 @@ async def create_room(db: AsyncSession, *, actor: str, body: RoomCreate, request
     return room_to_dict(r)
 
 
-async def list_rooms(db: AsyncSession) -> list[dict]:
-    result = await db.execute(select(Room).order_by(Room.created_at))
+async def list_rooms(db: AsyncSession, venue_id: str | None = None) -> list[dict]:
+    stmt = select(Room).order_by(Room.created_at, Room.id)
+    if venue_id:
+        stmt = stmt.where(Room.venue_id == venue_id)
+    result = await db.execute(stmt)
     return [room_to_dict(r) for r in result.scalars().all()]
 
 

--- a/backend/app/services/tables_service.py
+++ b/backend/app/services/tables_service.py
@@ -77,7 +77,7 @@ async def create_table(db: AsyncSession, *, actor: str, body: TableCreate, reque
 
 async def list_tables(db: AsyncSession, layout_id: str | None = None) -> list[dict]:
     stmt = select(Table).order_by(Table.created_at, Table.id)
-    if layout_id:
+    if layout_id is not None:
         stmt = stmt.where(Table.layout_id == layout_id)
     result = await db.execute(stmt)
     tables = result.scalars().all()

--- a/backend/app/services/tables_service.py
+++ b/backend/app/services/tables_service.py
@@ -75,8 +75,11 @@ async def create_table(db: AsyncSession, *, actor: str, body: TableCreate, reque
     return table_to_dict(t, [])
 
 
-async def list_tables(db: AsyncSession) -> list[dict]:
-    result = await db.execute(select(Table).order_by(Table.created_at))
+async def list_tables(db: AsyncSession, layout_id: str | None = None) -> list[dict]:
+    stmt = select(Table).order_by(Table.created_at, Table.id)
+    if layout_id:
+        stmt = stmt.where(Table.layout_id == layout_id)
+    result = await db.execute(stmt)
     tables = result.scalars().all()
 
     # Compute registration_ids from the Registration.table_id FK (source of truth),

--- a/backend/tests/test_areas.py
+++ b/backend/tests/test_areas.py
@@ -99,6 +99,18 @@ async def test_area_linked_to_exhibitor(client):
 
 
 @pytest.mark.anyio
+async def test_list_areas_empty_string_layout_id_matches_nothing(client):
+    """An explicit layout_id="" filters on the (nonexistent) empty-string id, not
+    "no filter" — distinct from omitting the parameter entirely (#834 review)."""
+    layout_id = await _create_layout_prerequisites(client)
+    await client.post("/api/areas", json={"layout_id": layout_id, "label": "Zone A"}, headers=ADMIN_HEADERS)
+
+    r = await client.get("/api/areas", params={"layout_id": ""}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+@pytest.mark.anyio
 async def test_area_invalid_layout(client):
     r = await client.post(
         "/api/areas",

--- a/backend/tests/test_faq.py
+++ b/backend/tests/test_faq.py
@@ -47,7 +47,6 @@ async def test_faq_crud(client):
         json={
             "question_nl": "Wanneer?",
             "answer_nl": "Op 2 oktober.",
-            "sort_order": 0,
         },
         headers=ADMIN_HEADERS,
     )
@@ -171,14 +170,71 @@ async def test_faq_requires_dutch_question_and_answer(client):
 
 @pytest.mark.anyio
 async def test_active_faq_respects_sort_order(client):
-    r = await client.post(
-        "/api/faq", json={"question_nl": "Second", "answer_nl": "b", "sort_order": 1}, headers=ADMIN_HEADERS
-    )
-    assert r.status_code == 201
-    r = await client.post(
-        "/api/faq", json={"question_nl": "First", "answer_nl": "a", "sort_order": 0}, headers=ADMIN_HEADERS
-    )
-    assert r.status_code == 201
+    """Items are created in append order, then reordering (not sort_order on
+    create/update) is what changes display order — see test_faq_reorder_*
+    below for the dedicated reorder endpoint (#836)."""
+    r = await client.post("/api/faq", json={"question_nl": "First", "answer_nl": "a"}, headers=ADMIN_HEADERS)
+    first_id = r.json()["id"]
+    r = await client.post("/api/faq", json={"question_nl": "Second", "answer_nl": "b"}, headers=ADMIN_HEADERS)
+    second_id = r.json()["id"]
 
     r = await client.get("/api/faq/active", params={"locale": "nl"})
     assert [i["question"] for i in r.json()] == ["First", "Second"]
+
+    r = await client.post("/api/faq/reorder", json={"ordered_ids": [second_id, first_id]}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert [i["id"] for i in r.json()] == [second_id, first_id]
+
+    r = await client.get("/api/faq/active", params={"locale": "nl"})
+    assert [i["question"] for i in r.json()] == ["Second", "First"]
+
+
+@pytest.mark.anyio
+async def test_faq_create_appends_after_the_current_last_item(client):
+    r = await client.post("/api/faq", json=DUTCH_ONLY, headers=ADMIN_HEADERS)
+    first = r.json()
+    r = await client.post("/api/faq", json={"question_nl": "Tweede", "answer_nl": "b"}, headers=ADMIN_HEADERS)
+    second = r.json()
+    assert second["sort_order"] > first["sort_order"]
+
+
+@pytest.mark.anyio
+async def test_faq_reorder_rejects_stale_or_partial_list(client):
+    r = await client.post("/api/faq", json=DUTCH_ONLY, headers=ADMIN_HEADERS)
+    first_id = r.json()["id"]
+    r = await client.post("/api/faq", json={"question_nl": "Tweede", "answer_nl": "b"}, headers=ADMIN_HEADERS)
+    second_id = r.json()["id"]
+
+    # Missing an existing item.
+    r = await client.post("/api/faq/reorder", json={"ordered_ids": [first_id]}, headers=ADMIN_HEADERS)
+    assert r.status_code == 409
+
+    # Names an item that doesn't exist.
+    r = await client.post(
+        "/api/faq/reorder", json={"ordered_ids": [first_id, second_id, "faq_nonexistent"]}, headers=ADMIN_HEADERS
+    )
+    assert r.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_faq_reorder_rejects_duplicate_ids(client):
+    r = await client.post("/api/faq", json=DUTCH_ONLY, headers=ADMIN_HEADERS)
+    first_id = r.json()["id"]
+
+    r = await client.post("/api/faq/reorder", json={"ordered_ids": [first_id, first_id]}, headers=ADMIN_HEADERS)
+    assert r.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_faq_update_cannot_set_sort_order(client):
+    """sort_order isn't part of the update payload shape at all — reordering
+    only happens through /api/faq/reorder (#836)."""
+    r = await client.post("/api/faq", json=DUTCH_ONLY, headers=ADMIN_HEADERS)
+    item = r.json()
+
+    r = await client.put(
+        f"/api/faq/{item['id']}", json={"sort_order": 99, "question_nl": "Aangepast"}, headers=ADMIN_HEADERS
+    )
+    assert r.status_code == 200
+    assert r.json()["sort_order"] == item["sort_order"]
+    assert r.json()["question_nl"] == "Aangepast"

--- a/backend/tests/test_layouts.py
+++ b/backend/tests/test_layouts.py
@@ -23,6 +23,81 @@ async def test_layout_rejects_duplicate_room_day(client):
 
 
 @pytest.mark.anyio
+async def test_list_layouts_filters_by_edition_id_and_room_id(client):
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = r.json()["id"]
+    r = await client.post("/api/rooms", json={**ROOM_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+    room_a = r.json()["id"]
+    r = await client.post("/api/rooms", json={**ROOM_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+    room_b = r.json()["id"]
+    r = await client.post(
+        "/api/editions",
+        json={"id": "edition-834", "year": 2099, "month": "march", "venue_id": venue_id, "active": False},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+
+    r = await client.post(
+        "/api/layouts",
+        json={"room_id": room_a, "day_id": 1, "edition_id": "edition-834"},
+        headers=ADMIN_HEADERS,
+    )
+    layout_a = r.json()["id"]
+    await client.post("/api/layouts", json={"room_id": room_b, "day_id": 1}, headers=ADMIN_HEADERS)
+
+    r = await client.get("/api/layouts", params={"edition_id": "edition-834"}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert [lay["id"] for lay in r.json()] == [layout_a]
+
+    r = await client.get("/api/layouts", params={"room_id": room_a}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert [lay["id"] for lay in r.json()] == [layout_a]
+
+    r = await client.get("/api/layouts", params={"room_id": room_b}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert layout_a not in [lay["id"] for lay in r.json()]
+
+
+@pytest.mark.anyio
+async def test_get_layout_include_tables(client):
+    """get_layout(..., include_tables=True) returns the layout's tables and areas
+    in one call, without a separate global list_tables/list_areas scan (#834)."""
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = r.json()["id"]
+    r = await client.post("/api/rooms", json={**ROOM_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+    room_id = r.json()["id"]
+    r = await client.post("/api/layouts", json={"room_id": room_id, "day_id": 1}, headers=ADMIN_HEADERS)
+    layout_id = r.json()["id"]
+    r = await client.post("/api/table-types", json={**TABLE_TYPE_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+    tt_id = r.json()["id"]
+
+    r = await client.post(
+        "/api/tables",
+        json={"name": "T1", "capacity": 4, "table_type_id": tt_id, "layout_id": layout_id},
+        headers=ADMIN_HEADERS,
+    )
+    table_id = r.json()["id"]
+    r = await client.post(
+        "/api/areas",
+        json={"layout_id": layout_id, "label": "Zone A"},
+        headers=ADMIN_HEADERS,
+    )
+    area_id = r.json()["id"]
+
+    # Default: no tables/areas embedded.
+    r = await client.get(f"/api/layouts/{layout_id}", headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json()["tables"] is None
+    assert r.json()["areas"] is None
+
+    r = await client.get(f"/api/layouts/{layout_id}", params={"include_tables": True}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    data = r.json()
+    assert [t["id"] for t in data["tables"]] == [table_id]
+    assert [a["id"] for a in data["areas"]] == [area_id]
+
+
+@pytest.mark.anyio
 async def test_copy_layout_basic(client):
     """Copying a layout to a new day creates a new layout entry."""
     r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)

--- a/backend/tests/test_layouts.py
+++ b/backend/tests/test_layouts.py
@@ -57,6 +57,16 @@ async def test_list_layouts_filters_by_edition_id_and_room_id(client):
     assert r.status_code == 200
     assert layout_a not in [lay["id"] for lay in r.json()]
 
+    # An explicit edition_id="" / room_id="" filters on the (nonexistent) empty-string
+    # id, not "no filter" — distinct from omitting the parameter entirely (#834 review).
+    r = await client.get("/api/layouts", params={"edition_id": ""}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json() == []
+
+    r = await client.get("/api/layouts", params={"room_id": ""}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json() == []
+
 
 @pytest.mark.anyio
 async def test_get_layout_include_tables(client):

--- a/backend/tests/test_mcp_admin_faq.py
+++ b/backend/tests/test_mcp_admin_faq.py
@@ -69,3 +69,29 @@ async def test_delete_faq_item_not_found(db_session):
     factory = mcp_session_factory(db_session)
     with pytest.raises(ValueError, match="not found"):
         await mcp_faq.delete_faq_item(factory, "admin-1", "nonexistent")
+
+
+async def test_create_faq_item_appends_after_the_current_last_item(db_session):
+    factory = mcp_session_factory(db_session)
+    first = await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 1?", answer_nl="Antwoord 1.")
+    second = await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 2?", answer_nl="Antwoord 2.")
+    assert second["sort_order"] > first["sort_order"]
+
+
+async def test_reorder_faq_items(db_session):
+    factory = mcp_session_factory(db_session)
+    first = await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 1?", answer_nl="Antwoord 1.")
+    second = await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 2?", answer_nl="Antwoord 2.")
+
+    reordered = await mcp_faq.reorder_faq_items(factory, "admin-1", ordered_ids=[second["id"], first["id"]])
+    assert [item["id"] for item in reordered["faq_items"]] == [second["id"], first["id"]]
+    assert reordered["faq_items"][0]["sort_order"] < reordered["faq_items"][1]["sort_order"]
+
+
+async def test_reorder_faq_items_rejects_stale_list(db_session):
+    factory = mcp_session_factory(db_session)
+    first = await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 1?", answer_nl="Antwoord 1.")
+    await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 2?", answer_nl="Antwoord 2.")
+
+    with pytest.raises(ValueError, match="stale"):
+        await mcp_faq.reorder_faq_items(factory, "admin-1", ordered_ids=[first["id"]])

--- a/backend/tests/test_mcp_admin_layouts.py
+++ b/backend/tests/test_mcp_admin_layouts.py
@@ -35,6 +35,39 @@ async def test_create_get_list_layout(db_session):
     assert any(lay["id"] == layout_id for lay in listed["layouts"])
 
 
+async def test_list_layouts_filters_by_room_id(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_room(db_session, room_id="room-1")
+    db_session.add(Room(id="room-2", venue_id="venue-1", name="Second Room", width_m=25.0, length_m=18.0))
+    await db_session.commit()
+
+    created_a = await mcp_layouts.create_layout(factory, "admin-1", room_id="room-1", day_id=1)
+    await mcp_layouts.create_layout(factory, "admin-1", room_id="room-2", day_id=1)
+
+    listed = await mcp_layouts.list_layouts(factory, room_id="room-1")
+    assert [lay["id"] for lay in listed["layouts"]] == [created_a["id"]]
+
+
+async def test_get_layout_include_tables(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_room(db_session)
+    created = await mcp_layouts.create_layout(factory, "admin-1", room_id="room-1", day_id=1)
+
+    db_session.add(TableType(id="ttype-1", name="Standard", venue_id="venue-1", max_capacity=6))
+    await db_session.flush()
+    db_session.add(Table(id="tbl-1", name="T1", capacity=4, table_type_id="ttype-1", layout_id=created["id"]))
+    db_session.add(Area(id="area-1", layout_id=created["id"], label="Zone A"))
+    await db_session.commit()
+
+    without_tables = await mcp_layouts.get_layout(factory, created["id"])
+    assert "tables" not in without_tables
+    assert "areas" not in without_tables
+
+    with_tables = await mcp_layouts.get_layout(factory, created["id"], include_tables=True)
+    assert [t["id"] for t in with_tables["tables"]] == ["tbl-1"]
+    assert [a["id"] for a in with_tables["areas"]] == ["area-1"]
+
+
 async def test_create_layout_rejects_invalid_input(db_session):
     factory = mcp_session_factory(db_session)
     await _seed_room(db_session)

--- a/backend/tests/test_mcp_admin_registrations.py
+++ b/backend/tests/test_mcp_admin_registrations.py
@@ -167,6 +167,23 @@ async def test_list_registrations_pagination(db_session):
     assert page2["next_offset"] is None
 
 
+async def test_list_registrations_next_offset_null_when_page_exactly_fills_limit(db_session):
+    """A result set whose size is an exact multiple of `limit` must not advertise
+    a `next_offset` pointing at an empty page (regression: previously any full
+    page — len(rows) == effective_limit — got a next_offset regardless of
+    whether another matching row actually existed)."""
+    factory = mcp_session_factory(db_session)
+    person, event = await _seed_event(db_session, with_product=False)
+    for _ in range(2):
+        await mcp_registrations.create_registration(
+            factory, "admin-1", person_id=person.id, event_id=event.id, guest_count=1
+        )
+
+    result = await mcp_registrations.list_registrations(factory, "admin", limit=2)
+    assert len(result["registrations"]) == 2
+    assert result["next_offset"] is None
+
+
 async def test_list_registrations_rejects_negative_offset(db_session):
     factory = mcp_session_factory(db_session)
     with pytest.raises(ValueError, match="offset"):

--- a/backend/tests/test_mcp_admin_registrations.py
+++ b/backend/tests/test_mcp_admin_registrations.py
@@ -38,6 +38,141 @@ async def _seed_event(db_session, *, with_product: bool = True) -> tuple[Person,
     return person, event
 
 
+async def test_list_registrations_empty(db_session):
+    factory = mcp_session_factory(db_session)
+    result = await mcp_registrations.list_registrations(factory, "admin")
+    assert result == {"registrations": [], "count": 0, "next_offset": None}
+
+
+async def test_list_registrations_returns_compact_projection(db_session):
+    factory = mcp_session_factory(db_session)
+    person, event = await _seed_event(db_session, with_product=False)
+    created = await mcp_registrations.create_registration(
+        factory, "admin-1", person_id=person.id, event_id=event.id, guest_count=2, notes="secret note"
+    )
+
+    result = await mcp_registrations.list_registrations(factory, "admin")
+    assert result["count"] == 1
+    assert result["next_offset"] is None
+    item = result["registrations"][0]
+    assert item["id"] == created["id"]
+    assert item["event_id"] == event.id
+    assert item["edition_id"] == "edition-1"
+    assert item["guest_count"] == 2
+    assert item["person"]["id"] == person.id
+    assert item["person"]["email"] == person.email  # admin role sees contact info
+    assert "notes" not in item  # compact projection — use get_guest_registration for full detail
+
+
+async def test_list_registrations_redacts_pii_for_public_role(db_session):
+    """``list_registrations`` reuses ``registration_base_dict``'s role-based redaction,
+    even though only admins can reach it through the MCP server today."""
+    factory = mcp_session_factory(db_session)
+    person, event = await _seed_event(db_session, with_product=False)
+    await mcp_registrations.create_registration(
+        factory, "admin-1", person_id=person.id, event_id=event.id, guest_count=1
+    )
+
+    result = await mcp_registrations.list_registrations(factory, "public")
+    item = result["registrations"][0]
+    assert "email" not in item["person"]
+    assert "phone" not in item["person"]
+
+
+async def test_list_registrations_filters_by_status_and_checked_in(db_session):
+    factory = mcp_session_factory(db_session)
+    person, event = await _seed_event(db_session, with_product=False)
+    confirmed = await mcp_registrations.create_registration(
+        factory, "admin-1", person_id=person.id, event_id=event.id, guest_count=1, status="confirmed"
+    )
+    await mcp_registrations.create_registration(
+        factory, "admin-1", person_id=person.id, event_id=event.id, guest_count=1, status="pending"
+    )
+    await mcp_registrations.update_registration(factory, "admin-1", confirmed["id"], checked_in=True)
+
+    result = await mcp_registrations.list_registrations(factory, "admin", status="confirmed")
+    assert [r["id"] for r in result["registrations"]] == [confirmed["id"]]
+
+    result = await mcp_registrations.list_registrations(factory, "admin", checked_in=True)
+    assert [r["id"] for r in result["registrations"]] == [confirmed["id"]]
+
+    result = await mcp_registrations.list_registrations(factory, "admin", checked_in=False)
+    assert confirmed["id"] not in [r["id"] for r in result["registrations"]]
+
+
+async def test_list_registrations_filters_by_edition_and_event(db_session):
+    factory = mcp_session_factory(db_session)
+    person, event = await _seed_event(db_session, with_product=False)
+    other_event = Event(
+        id="evt-2",
+        edition_id="edition-1",
+        title="Zaterdagmiddag",
+        date=date(2099, 3, 22),
+        start_time="14:00",
+        category="festival",
+        registration_required=True,
+    )
+    db_session.add(other_event)
+    await db_session.commit()
+
+    reg1 = await mcp_registrations.create_registration(
+        factory, "admin-1", person_id=person.id, event_id=event.id, guest_count=1
+    )
+    reg2 = await mcp_registrations.create_registration(
+        factory, "admin-1", person_id=person.id, event_id=other_event.id, guest_count=1
+    )
+
+    result = await mcp_registrations.list_registrations(factory, "admin", event_id=event.id)
+    assert [r["id"] for r in result["registrations"]] == [reg1["id"]]
+
+    result = await mcp_registrations.list_registrations(factory, "admin", edition_id="edition-1")
+    assert {r["id"] for r in result["registrations"]} == {reg1["id"], reg2["id"]}
+
+    result = await mcp_registrations.list_registrations(factory, "admin", edition_id="nonexistent")
+    assert result["registrations"] == []
+
+
+async def test_list_registrations_search_by_name(db_session):
+    factory = mcp_session_factory(db_session)
+    person, event = await _seed_event(db_session, with_product=False)
+    created = await mcp_registrations.create_registration(
+        factory, "admin-1", person_id=person.id, event_id=event.id, guest_count=1
+    )
+
+    result = await mcp_registrations.list_registrations(factory, "admin", q="Jean Dupont")
+    assert [r["id"] for r in result["registrations"]] == [created["id"]]
+
+    result = await mcp_registrations.list_registrations(factory, "admin", q="Nobody Here")
+    assert result["registrations"] == []
+
+
+async def test_list_registrations_pagination(db_session):
+    factory = mcp_session_factory(db_session)
+    person, event = await _seed_event(db_session, with_product=False)
+    created = [
+        await mcp_registrations.create_registration(
+            factory, "admin-1", person_id=person.id, event_id=event.id, guest_count=1
+        )
+        for _ in range(3)
+    ]
+    # Newest first: reverse creation order.
+    expected_ids = [r["id"] for r in reversed(created)]
+
+    page1 = await mcp_registrations.list_registrations(factory, "admin", limit=2)
+    assert [r["id"] for r in page1["registrations"]] == expected_ids[:2]
+    assert page1["next_offset"] == 2
+
+    page2 = await mcp_registrations.list_registrations(factory, "admin", limit=2, offset=page1["next_offset"])
+    assert [r["id"] for r in page2["registrations"]] == expected_ids[2:]
+    assert page2["next_offset"] is None
+
+
+async def test_list_registrations_rejects_negative_offset(db_session):
+    factory = mcp_session_factory(db_session)
+    with pytest.raises(ValueError, match="offset"):
+        await mcp_registrations.list_registrations(factory, "admin", offset=-1)
+
+
 async def test_create_registration_resolves_order_items(db_session):
     factory = mcp_session_factory(db_session)
     person, event = await _seed_event(db_session)

--- a/backend/tests/test_mcp_admin_rooms.py
+++ b/backend/tests/test_mcp_admin_rooms.py
@@ -35,6 +35,19 @@ async def test_create_get_list_room(db_session):
     assert any(r["id"] == room_id for r in listed["rooms"])
 
 
+async def test_list_rooms_filters_by_venue_id(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session, "venue-1")
+    await _seed_venue(db_session, "venue-2")
+    created_a = await mcp_rooms.create_room(
+        factory, "admin-1", name="Room A", venue_id="venue-1", width_m=25.0, length_m=18.0
+    )
+    await mcp_rooms.create_room(factory, "admin-1", name="Room B", venue_id="venue-2", width_m=25.0, length_m=18.0)
+
+    listed = await mcp_rooms.list_rooms(factory, venue_id="venue-1")
+    assert [r["id"] for r in listed["rooms"]] == [created_a["id"]]
+
+
 async def test_create_room_venue_not_found(db_session):
     factory = mcp_session_factory(db_session)
     with pytest.raises(ValueError, match="not found"):

--- a/backend/tests/test_mcp_admin_tables.py
+++ b/backend/tests/test_mcp_admin_tables.py
@@ -51,6 +51,22 @@ async def test_create_get_list_table(db_session):
     assert any(t["id"] == table_id for t in listed["tables"])
 
 
+async def test_list_tables_filters_by_layout_id(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_layout(db_session, layout_id="lay-1")
+    db_session.add(Layout(id="lay-2", edition_id=None, room_id="room-1", day_id=2))
+    await db_session.commit()
+    await _seed_table_type(db_session)
+
+    created_a = await mcp_tables.create_table(
+        factory, "admin-1", name="A1", capacity=6, table_type_id="ttype-1", layout_id="lay-1"
+    )
+    await mcp_tables.create_table(factory, "admin-1", name="B1", capacity=6, table_type_id="ttype-1", layout_id="lay-2")
+
+    listed = await mcp_tables.list_tables(factory, layout_id="lay-1")
+    assert [t["id"] for t in listed["tables"]] == [created_a["id"]]
+
+
 async def test_create_table_rejects_invalid_input(db_session):
     factory = mcp_session_factory(db_session)
     await _seed_layout(db_session)

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -538,6 +538,40 @@ class TestAdminToolWiring:
         )
 
     @pytest.mark.anyio
+    async def test_list_registrations_requires_admin(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        token = _make_access_token(["volunteer"])
+        with patch.object(mcp_module, "get_access_token", return_value=token), pytest.raises(PermissionError):
+            await backend.list_registrations()
+
+    @pytest.mark.anyio
+    async def test_list_registrations_delegates_with_role_and_filters(self):
+        backend = ChampagneFestivalMcpBackend(MagicMock())
+        token = SimpleNamespace(claims={"sub": "admin-1", "realm_access": {"roles": ["admin"]}})
+        with (
+            patch.object(mcp_module, "get_access_token", return_value=token),
+            patch.object(
+                mcp_module.mcp_admin_registrations,
+                "list_registrations",
+                new=AsyncMock(return_value={"registrations": [], "count": 0, "next_offset": None}),
+            ) as mocked,
+        ):
+            result = await backend.list_registrations(edition_id="edition-1", status="confirmed", limit=10)
+        assert result == {"registrations": [], "count": 0, "next_offset": None}
+        mocked.assert_awaited_once_with(
+            backend.session_factory,
+            "admin",
+            edition_id="edition-1",
+            event_id=None,
+            status="confirmed",
+            payment_status=None,
+            checked_in=None,
+            q=None,
+            limit=10,
+            offset=0,
+        )
+
+    @pytest.mark.anyio
     async def test_delete_registration_requires_admin(self):
         backend = ChampagneFestivalMcpBackend(MagicMock())
         token = _make_access_token(["volunteer"])

--- a/backend/tests/test_mcp_tool_schemas.py
+++ b/backend/tests/test_mcp_tool_schemas.py
@@ -75,6 +75,37 @@ class TestRequiredPhysicalDimensions:
         assert {"width_m", "length_m"} <= required
 
 
+class TestCoordinateContract:
+    """Regression tests for #834: x/y/rotation must expose both a description
+    (unit/origin/direction — otherwise a caller has no way to know 50.0 means
+    "50% of the rendered canvas, top-left origin") and their numeric bounds via
+    the JSON schema, on every tool that accepts them."""
+
+    @pytest.mark.parametrize("tool_name", ["create_table", "create_area"])
+    @pytest.mark.parametrize("field", ["x", "y", "rotation"])
+    async def test_create_exposes_coordinate_description_and_bounds(self, tool_schemas, tool_name, field):
+        prop = tool_schemas[tool_name]["properties"][field]
+        assert prop.get("description"), f"{tool_name}.{field} has no description"
+        if field == "rotation":
+            assert prop["minimum"] == 0
+            assert prop["maximum"] == 359
+        else:
+            assert prop["minimum"] == 0
+            assert prop["maximum"] == 100
+
+    @pytest.mark.parametrize("tool_name", ["update_table", "update_area"])
+    @pytest.mark.parametrize("field", ["x", "y", "rotation"])
+    async def test_update_exposes_coordinate_description_and_bounds(self, tool_schemas, tool_name, field):
+        variant = _optional_variants(tool_schemas[tool_name]["properties"][field])[0]
+        assert variant.get("description"), f"{tool_name}.{field} has no description"
+        if field == "rotation":
+            assert variant["minimum"] == 0
+            assert variant["maximum"] == 359
+        else:
+            assert variant["minimum"] == 0
+            assert variant["maximum"] == 100
+
+
 class TestNoRedundantDateUnions:
     """A ``dt_date | str`` (or ``datetime | str``) annotation renders as two
     functionally-overlapping 'string' variants in the JSON schema's ``anyOf``

--- a/backend/tests/test_rooms.py
+++ b/backend/tests/test_rooms.py
@@ -52,6 +52,23 @@ async def test_room_crud(client):
 
 
 @pytest.mark.anyio
+async def test_list_rooms_filters_by_venue_id(client):
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_a = r.json()["id"]
+    r = await client.post("/api/venues", json={"name": "Other Venue"}, headers=ADMIN_HEADERS)
+    venue_b = r.json()["id"]
+
+    r = await client.post("/api/rooms", json={**ROOM_PAYLOAD, "venue_id": venue_a}, headers=ADMIN_HEADERS)
+    room_a = r.json()["id"]
+    await client.post("/api/rooms", json={**ROOM_PAYLOAD, "venue_id": venue_b}, headers=ADMIN_HEADERS)
+
+    r = await client.get("/api/rooms", params={"venue_id": venue_a}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    ids = [room["id"] for room in r.json()]
+    assert ids == [room_a]
+
+
+@pytest.mark.anyio
 async def test_room_update_all_editable_fields_together(client):
     r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
     venue_id = r.json()["id"]

--- a/backend/tests/test_rooms.py
+++ b/backend/tests/test_rooms.py
@@ -69,6 +69,19 @@ async def test_list_rooms_filters_by_venue_id(client):
 
 
 @pytest.mark.anyio
+async def test_list_rooms_empty_string_venue_id_matches_nothing(client):
+    """An explicit venue_id="" is a filter for the (nonexistent) empty-string id,
+    not "no filter" — distinct from omitting the parameter entirely (#834 review)."""
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = r.json()["id"]
+    await client.post("/api/rooms", json={**ROOM_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+
+    r = await client.get("/api/rooms", params={"venue_id": ""}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+@pytest.mark.anyio
 async def test_room_update_all_editable_fields_together(client):
     r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
     venue_id = r.json()["id"]

--- a/backend/tests/test_tables.py
+++ b/backend/tests/test_tables.py
@@ -52,6 +52,60 @@ async def test_table_crud(client):
 
 
 @pytest.mark.anyio
+async def test_list_tables_filters_by_layout_id(client):
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = r.json()["id"]
+    r = await client.post("/api/rooms", json={**ROOM_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+    room_id = r.json()["id"]
+    r = await client.post("/api/layouts", json={"room_id": room_id, "day_id": 1}, headers=ADMIN_HEADERS)
+    layout_a = r.json()["id"]
+    r = await client.post("/api/layouts", json={"room_id": room_id, "day_id": 2}, headers=ADMIN_HEADERS)
+    layout_b = r.json()["id"]
+    r = await client.post("/api/table-types", json={**TABLE_TYPE_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+    tt_id = r.json()["id"]
+
+    r = await client.post(
+        "/api/tables",
+        json={"name": "A1", "capacity": 4, "table_type_id": tt_id, "layout_id": layout_a},
+        headers=ADMIN_HEADERS,
+    )
+    table_a = r.json()["id"]
+    await client.post(
+        "/api/tables",
+        json={"name": "B1", "capacity": 4, "table_type_id": tt_id, "layout_id": layout_b},
+        headers=ADMIN_HEADERS,
+    )
+
+    r = await client.get("/api/tables", params={"layout_id": layout_a}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    ids = [t["id"] for t in r.json()]
+    assert ids == [table_a]
+
+
+@pytest.mark.anyio
+async def test_table_position_bounds_rejected(client):
+    """x/y outside [0, 100] and rotation outside [0, 359] are rejected consistently (#834)."""
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    venue_id = r.json()["id"]
+    r = await client.post("/api/rooms", json={**ROOM_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+    room_id = r.json()["id"]
+    r = await client.post("/api/layouts", json={"room_id": room_id, "day_id": 1}, headers=ADMIN_HEADERS)
+    layout_id = r.json()["id"]
+    r = await client.post("/api/table-types", json={**TABLE_TYPE_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+    tt_id = r.json()["id"]
+
+    base = {"name": "T1", "capacity": 4, "table_type_id": tt_id, "layout_id": layout_id}
+
+    for bad in ({"x": -0.1}, {"x": 100.1}, {"y": -0.1}, {"y": 100.1}, {"rotation": -1}, {"rotation": 360}):
+        r = await client.post("/api/tables", json={**base, **bad}, headers=ADMIN_HEADERS)
+        assert r.status_code == 422, f"{bad} should have been rejected"
+
+    for good in ({"x": 0.0}, {"x": 100.0}, {"y": 0.0}, {"y": 100.0}, {"rotation": 0}, {"rotation": 359}):
+        r = await client.post("/api/tables", json={**base, **good}, headers=ADMIN_HEADERS)
+        assert r.status_code == 201, f"{good} should have been accepted"
+
+
+@pytest.mark.anyio
 async def test_table_with_layout_id(client):
     """Tables can be assigned a layout_id and it is persisted."""
     # Build the prerequisite chain: venue → room → layout + table_type

--- a/backend/tests/test_tables.py
+++ b/backend/tests/test_tables.py
@@ -81,6 +81,12 @@ async def test_list_tables_filters_by_layout_id(client):
     ids = [t["id"] for t in r.json()]
     assert ids == [table_a]
 
+    # An explicit layout_id="" filters on the (nonexistent) empty-string id, not
+    # "no filter" — distinct from omitting the parameter entirely (#834 review).
+    r = await client.get("/api/tables", params={"layout_id": ""}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json() == []
+
 
 @pytest.mark.anyio
 async def test_table_position_bounds_rejected(client):

--- a/docs/floor-plan-coordinates.md
+++ b/docs/floor-plan-coordinates.md
@@ -1,0 +1,76 @@
+# Floor-plan coordinate contract
+
+This document defines the coordinate system used by `Table.x`/`Table.y`/`Table.rotation`
+and `Area.x`/`Area.y`/`Area.rotation` — the fields that place a table or area on a
+floor-plan `Layout`. It is the single source of truth referenced by the model
+docstrings (`backend/app/models.py`), the Pydantic schema field descriptions
+(`backend/app/schemas.py`), the MCP tool docstrings (`backend/app/mcp_server.py`),
+and the web admin floor-plan editor (`frontend/src/components/admin/LayoutEditor.tsx`).
+
+It does **not** cover `Room.width_m`/`length_m`, `TableType.width_m`/`length_m`, or
+`Area.width_m`/`length_m` — those are real physical measurements in metres (see #835)
+and are independent of the `x`/`y`/`rotation` contract described here. It also does not
+cover `Layout.day_id`/`edition_id` resolution or seating/reservation assignment — see
+issue #802 for that.
+
+## Position (`x`, `y`)
+
+- **Type:** float, range `[0, 100]` inclusive — enforced by `TableCreate`/`TableUpdate`/
+  `AreaCreate`/`AreaUpdate` in `backend/app/schemas.py`. A value outside this range is
+  rejected (422 over REST, `ValueError` over MCP) rather than clamped or silently stored.
+- **Unit:** a **percentage of the layout's rendered canvas** — not the room's physical
+  `width_m`/`length_m` directly, and not raw pixels or metres.
+- **Origin:** the top-left corner of the canvas is `(0, 0)`. `x` increases rightward,
+  `y` increases downward.
+- **Anchor point:** the top-left corner of the table's/area's own rendered bounding box
+  (not its center).
+
+### Canvas size
+
+The canvas a percentage is relative to is *derived* from the room's `width_m`/`length_m`,
+not used verbatim:
+
+```
+canvas_width_px  = max(280, room.width_m  * 28)
+canvas_height_px = max(180, room.length_m * 28)
+```
+
+The `28` px/metre scale and the `280`/`180` px minimums originate in
+`frontend/src/utils/layoutUtils.ts` (`LAYOUT_PX_PER_M`, `LAYOUT_MIN_CANVAS_WIDTH_PX`,
+`LAYOUT_MIN_CANVAS_HEIGHT_PX`) and are intentionally mirrored — same constants, same
+rounding — in `backend/app/services/layouts_service.py` (`_PX_PER_M`,
+`_MIN_CANVAS_WIDTH_PX`, `_MIN_CANVAS_HEIGHT_PX`, `_js_round`) so the backend's
+area-containment check (used when copying a layout) agrees with what the editor renders.
+
+**Because of the minimum floor, a small room's canvas can be wider/taller than
+`width_m * 28`px** — e.g. a 5m-wide room still gets a 280px-wide canvas, not 140px. For
+rooms under roughly 10m × 6.4m, `x`/`y` are therefore *not* a clean percentage of the
+room's physical dimensions. Treat `x`/`y` as canvas-relative, always — never derive a
+metre position from them without applying this formula first.
+
+## Rotation
+
+- **Type:** integer degrees, range `[0, 359]` inclusive.
+- **Direction:** clockwise.
+- **Pivot:** the element's own center (CSS `transform: rotate(Ndeg)` around the default
+  `transform-origin: center`), matching `LayoutEditor.tsx`.
+
+## Out-of-bounds handling
+
+`x`, `y`, and `rotation` are range-checked at the schema layer on every write path — REST,
+MCP admin tools, and layout-copy (which clones existing values as-is, so a row that
+predates this contract can't silently violate it once touched again). An out-of-range
+value is rejected consistently across all three surfaces; there is no separate
+normalization path.
+
+The web editor additionally clamps drag operations so an element's *bounding box* never
+extends past the canvas edge — that stricter bound depends on the referenced table
+type's/area's own physical width/length (via `getTableSizePx`/`getAreaSizePx`), so it is a
+rendering-time constraint the editor enforces on the user's behalf, not part of the
+`[0, 100]` wire contract enforced by the schema.
+
+## Scope
+
+This document covers the coordinate and scoped-read contract addressed by issue #834.
+The deeper event/day layout key (`Layout.day_id`/`edition_id` resolution) and the
+seating/reservation assignment model are issue #802's territory.

--- a/docs/floor-plan-coordinates.md
+++ b/docs/floor-plan-coordinates.md
@@ -30,7 +30,7 @@ issue #802 for that.
 The canvas a percentage is relative to is *derived* from the room's `width_m`/`length_m`,
 not used verbatim:
 
-```
+```text
 canvas_width_px  = max(280, room.width_m  * 28)
 canvas_height_px = max(180, room.length_m * 28)
 ```

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -82,13 +82,13 @@ complete regardless of which surface made the change. All are `admin`-only excep
 | Tables | `create_table`, `list_tables` (`layout_id` filter), `get_table`, `update_table`, `delete_table` |
 | Layouts | `create_layout`, `copy_layout`, `list_layouts` (`edition_id`/`room_id` filters), `get_layout` (`include_tables` to also return its tables/areas), `delete_layout` |
 | Areas | `create_area`, `list_areas` (`layout_id` filter), `get_area`, `update_area`, `delete_area` |
-| FAQ | `create_faq_item`, `list_faq_items`, `update_faq_item`, `delete_faq_item` |
+| FAQ | `create_faq_item`, `list_faq_items`, `update_faq_item`, `delete_faq_item`, `reorder_faq_items` |
 | Settings | `get_settings` (public), `set_maintenance_mode` |
 | Exhibitors | `create_exhibitor`, `get_exhibitor`, `list_exhibitors`, `update_exhibitor`, `delete_exhibitor` |
 | People | `create_person`, `get_person`, `update_person`, `delete_person`, `merge_people` |
 | Members | `create_member`, `get_member`, `list_members`, `update_member`, `delete_member` |
 | Volunteers | `create_volunteer`, `get_volunteer`, `list_volunteers`, `update_volunteer`, `delete_volunteer` |
-| Registrations | `create_registration`, `update_registration`, `delete_registration` |
+| Registrations | `list_registrations` (`edition_id`/`event_id`/`status`/`payment_status`/`checked_in`/`q` filters, paginated), `create_registration`, `update_registration`, `delete_registration` |
 | Audit trail | `list_audit_entries`, `list_audit_resource_types` |
 | Integration clients | `create_integration_client`, `list_integration_clients`, `revoke_integration_client`, `rotate_integration_client` |
 

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -77,11 +77,11 @@ complete regardless of which surface made the change. All are `admin`-only excep
 | Editions | `create_edition`, `get_edition`, `update_edition`, `delete_edition` |
 | Events | `create_event`, `get_event`, `update_event`, `delete_event` |
 | Venues | `create_venue`, `list_venues`, `get_venue`, `update_venue`, `delete_venue` |
-| Rooms | `create_room`, `list_rooms`, `get_room`, `update_room`, `delete_room` |
+| Rooms | `create_room`, `list_rooms` (`venue_id` filter), `get_room`, `update_room`, `delete_room` |
 | Table types | `create_table_type`, `list_table_types`, `get_table_type`, `update_table_type`, `delete_table_type` |
-| Tables | `create_table`, `list_tables`, `get_table`, `update_table`, `delete_table` |
-| Layouts | `create_layout`, `copy_layout`, `list_layouts`, `get_layout`, `delete_layout` |
-| Areas | `create_area`, `list_areas`, `get_area`, `update_area`, `delete_area` |
+| Tables | `create_table`, `list_tables` (`layout_id` filter), `get_table`, `update_table`, `delete_table` |
+| Layouts | `create_layout`, `copy_layout`, `list_layouts` (`edition_id`/`room_id` filters), `get_layout` (`include_tables` to also return its tables/areas), `delete_layout` |
+| Areas | `create_area`, `list_areas` (`layout_id` filter), `get_area`, `update_area`, `delete_area` |
 | FAQ | `create_faq_item`, `list_faq_items`, `update_faq_item`, `delete_faq_item` |
 | Settings | `get_settings` (public), `set_maintenance_mode` |
 | Exhibitors | `create_exhibitor`, `get_exhibitor`, `list_exhibitors`, `update_exhibitor`, `delete_exhibitor` |
@@ -91,6 +91,11 @@ complete regardless of which surface made the change. All are `admin`-only excep
 | Registrations | `create_registration`, `update_registration`, `delete_registration` |
 | Audit trail | `list_audit_entries`, `list_audit_resource_types` |
 | Integration clients | `create_integration_client`, `list_integration_clients`, `revoke_integration_client`, `rotate_integration_client` |
+
+A table's/area's `x`/`y`/`rotation` fields follow a documented coordinate contract
+(percentage of the layout's rendered canvas, top-left origin, clockwise degrees) shared
+by REST, MCP, and the web admin editor — see
+[`docs/floor-plan-coordinates.md`](../floor-plan-coordinates.md).
 
 Partial updates follow one convention throughout: an omitted keyword argument (`None`)
 leaves that field unchanged. Nullable fields with no natural "clear" value (an id, not

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -446,6 +446,7 @@
   "admin_error_add_faq_item": "Failed to add the question.",
   "admin_error_update_faq_item": "Failed to update the question.",
   "admin_error_delete_faq_item": "Failed to delete the question.",
+  "admin_error_reorder_faq_items": "Failed to reorder the questions.",
   "admin_settings_maintenance_mode_label": "Maintenance mode",
   "admin_settings_maintenance_mode_help": "Shows visitors a page with just an image and a link to Facebook instead of the full website. The admin dashboard stays reachable.",
   "admin_error_load_settings": "Failed to load settings.",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -446,6 +446,7 @@
   "admin_error_add_faq_item": "Échec de l'ajout de la question.",
   "admin_error_update_faq_item": "Échec de la mise à jour de la question.",
   "admin_error_delete_faq_item": "Échec de la suppression de la question.",
+  "admin_error_reorder_faq_items": "Échec de la réorganisation des questions.",
   "admin_settings_maintenance_mode_label": "Mode maintenance",
   "admin_settings_maintenance_mode_help": "Affiche aux visiteurs une page avec uniquement une image et un lien vers Facebook au lieu du site complet. Le tableau de bord admin reste accessible.",
   "admin_error_load_settings": "Échec du chargement des paramètres.",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -446,6 +446,7 @@
   "admin_error_add_faq_item": "Toevoegen van de vraag is mislukt.",
   "admin_error_update_faq_item": "Bijwerken van de vraag is mislukt.",
   "admin_error_delete_faq_item": "Verwijderen van de vraag is mislukt.",
+  "admin_error_reorder_faq_items": "Herordenen van de vragen is mislukt.",
   "admin_settings_maintenance_mode_label": "Onderhoudsmodus",
   "admin_settings_maintenance_mode_help": "Toont bezoekers een pagina met alleen een afbeelding en een link naar Facebook in plaats van de volledige website. Het admin-dashboard blijft bereikbaar.",
   "admin_error_load_settings": "Laden van de instellingen is mislukt.",

--- a/frontend/src/components/admin/FaqManagement.tsx
+++ b/frontend/src/components/admin/FaqManagement.tsx
@@ -56,7 +56,6 @@ const emptyForm: FaqFormState = {
 interface FaqLocaleData {
   question: string;
   answer: string;
-  sortOrder: number;
 }
 
 function faqPayload(data: FaqLocaleData & Omit<FaqFormState, "questionNl" | "answerNl">) {
@@ -67,7 +66,6 @@ function faqPayload(data: FaqLocaleData & Omit<FaqFormState, "questionNl" | "ans
     answer_en: data.answerEn,
     question_fr: data.questionFr,
     answer_fr: data.answerFr,
-    sort_order: data.sortOrder,
   };
 }
 
@@ -116,11 +114,25 @@ export default function FaqManagement({ authHeaders }: FaqManagementProps) {
             ...(data.answerEn !== undefined && { answer_en: data.answerEn ?? "" }),
             ...(data.questionFr !== undefined && { question_fr: data.questionFr ?? "" }),
             ...(data.answerFr !== undefined && { answer_fr: data.answerFr ?? "" }),
-            ...(data.sortOrder !== undefined && { sort_order: data.sortOrder }),
             ...(data.active !== undefined && { active: data.active }),
           }),
         },
         m.admin_error_update_faq_item(),
+      ),
+    onSettled: () => void invalidateAdmin(queryClient, [faqItemsQueryKey, ["faq"]]),
+    retry: false,
+  });
+
+  const reorderMutation = useMutation({
+    mutationFn: (orderedIds: string[]) =>
+      fetchJsonOrThrowWithUnauthorized<Record<string, unknown>>(
+        "/api/faq/reorder",
+        {
+          method: "POST",
+          headers: authHeaders(),
+          body: JSON.stringify({ ordered_ids: orderedIds }),
+        },
+        m.admin_error_reorder_faq_items(),
       ),
     onSettled: () => void invalidateAdmin(queryClient, [faqItemsQueryKey, ["faq"]]),
     retry: false,
@@ -188,11 +200,9 @@ export default function FaqManagement({ authHeaders }: FaqManagementProps) {
           },
         });
       } else {
-        const nextSortOrder = faqItems.reduce((max, i) => Math.max(max, i.sortOrder), -1) + 1;
         await createMutation.mutateAsync({
           question: form.questionNl.trim(),
           answer: form.answerNl.trim(),
-          sortOrder: nextSortOrder,
           ...locales,
         });
       }
@@ -200,7 +210,7 @@ export default function FaqManagement({ authHeaders }: FaqManagementProps) {
     } catch (err) {
       setError(err instanceof Error ? err.message : m.admin_content_error_save());
     }
-  }, [form, editingId, faqItems, createMutation, updateMutation]);
+  }, [form, editingId, createMutation, updateMutation]);
 
   const handleToggleActive = useCallback(
     async (item: FaqItem) => {
@@ -232,26 +242,23 @@ export default function FaqManagement({ authHeaders }: FaqManagementProps) {
       const sorted = [...faqItems].sort((a, b) => a.sortOrder - b.sortOrder);
       const index = sorted.findIndex((i) => i.id === item.id);
       const swapIndex = direction === "up" ? index - 1 : index + 1;
-      const swapWith = sorted[swapIndex];
-      if (!swapWith) return;
+      if (index === -1 || swapIndex < 0 || swapIndex >= sorted.length) return;
+      const reordered = sorted.map((entry, i) => {
+        if (i === index) return sorted[swapIndex]!;
+        if (i === swapIndex) return sorted[index]!;
+        return entry;
+      });
       setRowError(null);
-      // Sequential, not Promise.all: if the second write fails after the
-      // first succeeds, both rows would otherwise share one sort_order
-      // (ambiguous order, and the next move on either item becomes a no-op
-      // since they compare equal). Roll the first write back instead.
-      await updateMutation.mutateAsync({ id: item.id, data: { sortOrder: swapWith.sortOrder } });
       try {
-        await updateMutation.mutateAsync({ id: swapWith.id, data: { sortOrder: item.sortOrder } });
+        // One atomic call for the whole list rather than two independent
+        // per-item writes — the backend rejects a stale/partial list outright
+        // instead of risking an ambiguous half-applied order (#836).
+        await reorderMutation.mutateAsync(reordered.map((i) => i.id));
       } catch (err) {
-        try {
-          await updateMutation.mutateAsync({ id: item.id, data: { sortOrder: item.sortOrder } });
-        } catch {
-          // Rollback failure doesn't get to hide the original error.
-        }
         setRowError(err instanceof Error ? err.message : m.admin_content_error_save());
       }
     },
-    [faqItems, updateMutation],
+    [faqItems, reorderMutation],
   );
 
   const sortedItems = useMemo(
@@ -259,7 +266,7 @@ export default function FaqManagement({ authHeaders }: FaqManagementProps) {
     [faqItems],
   );
 
-  const isMutating = updateMutation.isPending || deleteMutation.isPending;
+  const isMutating = updateMutation.isPending || deleteMutation.isPending || reorderMutation.isPending;
 
   const localeBadge = (label: string, translated: boolean) => (
     <Badge

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -22,13 +22,13 @@ export interface FloorTable {
   id: string;
   name: string;
   capacity: number;
-  /** X position (percentage of room width) */
+  /** X position: percentage [0, 100] of the layout's rendered canvas width, top-left origin. See docs/floor-plan-coordinates.md. */
   x: number;
-  /** Y position (percentage of room height) */
+  /** Y position: percentage [0, 100] of the layout's rendered canvas height, top-left origin. See docs/floor-plan-coordinates.md. */
   y: number;
   /** Table type defining shape/dimensions */
   tableTypeId: string;
-  /** Rotation angle in whole degrees [0, 359], clockwise */
+  /** Rotation angle in whole degrees [0, 359], clockwise around this table's own center */
   rotation: number;
   /** Layout this table belongs to */
   layoutId: string;
@@ -41,6 +41,7 @@ export interface FloorArea {
   icon: string;
   exhibitorId: number | null;
   label: string;
+  /** Same x/y/rotation contract as FloorTable — see docs/floor-plan-coordinates.md. */
   x: number;
   y: number;
   rotation: number;

--- a/frontend/src/utils/layoutUtils.ts
+++ b/frontend/src/utils/layoutUtils.ts
@@ -1,5 +1,8 @@
 import type { FloorTable, TableType } from "@/types/admin";
 
+// These constants define the canvas a table's/area's x/y percentage is relative to.
+// Mirrored in backend/app/services/layouts_service.py for the area-containment check —
+// see docs/floor-plan-coordinates.md for the full coordinate contract.
 export const LAYOUT_PX_PER_M = 28;
 export const LAYOUT_MIN_CANVAS_WIDTH_PX = 280;
 export const LAYOUT_MIN_CANVAS_HEIGHT_PX = 180;


### PR DESCRIPTION
## Summary

Closes #834.

- Documents the `x`/`y`/`rotation` contract shared by REST, MCP, and the web admin floor-plan editor in a new `docs/floor-plan-coordinates.md`: `x`/`y` are a percentage `[0, 100]` of the layout's *rendered canvas* (not the room's raw `width_m`/`length_m`), top-left origin, anchored at the element's own top-left corner; `rotation` is clockwise degrees `[0, 359]` pivoting around the element's own center. Explains the canvas-size derivation (`max(280, width_m*28)` / `max(180, length_m*28)`) and why that means `x`/`y` aren't a clean percentage of physical room size for small rooms.
- Encodes that contract directly in the MCP tool schemas for `create_table`/`update_table`/`create_area`/`update_area` (description + `minimum`/`maximum` now show up in the tool's JSON schema, not just prose in a docstring) and in the REST/MCP Pydantic `Field(description=...)` for the same fields.
- Adds scoped reads so a client no longer has to download-and-join unrelated records:
  - `list_rooms(venue_id=...)`
  - `list_tables(layout_id=...)`
  - `list_layouts(edition_id=..., room_id=...)`
  - `get_layout(..., include_tables=true)` returns the layout's tables/areas in the same response
- Standardizes list ordering on a `(created_at, id)` tiebreaker across rooms/tables/layouts/areas (matching the existing `table_types` convention) so pagination is deterministic even when rows share a `created_at` timestamp.
- Out-of-bounds `x`/`y`/`rotation` values were already schema-rejected (`ge`/`le` bounds); added regression tests locking that in across REST and MCP.

Deliberately out of scope (per the issue's own boundary with #802): `Layout.day_id`/`edition_id` resolution and the seating/reservation assignment model.

## Test plan

- [x] `uv run ruff check app tests`
- [x] `uv run ty check app`
- [x] `uv run pytest` (808 passed)
- [x] `pnpm typecheck`
- [x] `pnpm lint`


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8D4Y2qKSqcshci7h1vVeM)_