### PR TITLE
Enforce deterministic and conflict-free FAQ ordering

### DIFF
--- a/backend/alembic/versions/012_enforce_unique_faq_sort_order.py
+++ b/backend/alembic/versions/012_enforce_unique_faq_sort_order.py
@@ -1,0 +1,54 @@
+"""Enforce unique, deterministic FAQ sort_order.
+
+`faq_items.sort_order` had no uniqueness or secondary tie-break, so two items
+could share a position and the resulting display order depended on
+database/query tie-breaking rather than an explicit rule (#836). Before adding
+the constraint, existing rows are renumbered densely (0..N-1) in their current
+effective order — `sort_order` first, `id` second as the same stable tie-break
+the application now uses — so any pre-existing duplicates or gaps are repaired
+rather than rejected by the new constraint.
+
+The constraint is DEFERRABLE INITIALLY DEFERRED: it's only checked at commit,
+so a reorder that touches several rows in one transaction can pass through a
+transient duplicate state without failing mid-transaction.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-08-13
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "012"
+down_revision: str | None = "011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE faq_items
+        SET sort_order = ranked.new_order
+        FROM (
+            SELECT id, ROW_NUMBER() OVER (ORDER BY sort_order, id) - 1 AS new_order
+            FROM faq_items
+        ) AS ranked
+        WHERE faq_items.id = ranked.id AND faq_items.sort_order != ranked.new_order
+        """
+    )
+    op.create_unique_constraint(
+        "uq_faq_items_sort_order",
+        "faq_items",
+        ["sort_order"],
+        deferrable=True,
+        initially="DEFERRED",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_faq_items_sort_order", "faq_items", type_="unique")

--- a/backend/app/mcp/admin/faq.py
+++ b/backend/app/mcp/admin/faq.py
@@ -1,19 +1,17 @@
 """Admin (write) MCP tool implementations for FAQ item management.
 
-Mirrors ``app.routers.faq``.
+Mirrors ``app.routers.faq``. Business logic lives in
+``app.services.faq_service`` and is shared with the REST router.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import select
-
-from app.audit import write_audit_entry
-from app.mcp.utils import get_or_error, validate_with_schema
-from app.models import FaqItem
-from app.schemas import FaqItemCreate, FaqItemUpdate
-from app.utils import faq_item_to_dict, make_id
+from app.mcp.utils import MCPToolError, validate_with_schema
+from app.schemas import FaqItemCreate, FaqItemReorder, FaqItemUpdate
+from app.services import faq_service
+from app.services.errors import ServiceError
 
 
 async def create_faq_item(
@@ -26,7 +24,6 @@ async def create_faq_item(
     answer_en: str | None = None,
     question_fr: str | None = None,
     answer_fr: str | None = None,
-    sort_order: int = 0,
     active: bool = True,
 ) -> dict:
     body = validate_with_schema(
@@ -37,40 +34,19 @@ async def create_faq_item(
         answer_en=answer_en or None,
         question_fr=question_fr or None,
         answer_fr=answer_fr or None,
-        sort_order=sort_order,
         active=active,
     )
     async with session_factory() as db:
-        f = FaqItem(
-            id=make_id("faq"),
-            question_nl=body.question_nl,
-            answer_nl=body.answer_nl,
-            question_en=body.question_en,
-            answer_en=body.answer_en,
-            question_fr=body.question_fr,
-            answer_fr=body.answer_fr,
-            sort_order=body.sort_order,
-            active=body.active,
-        )
-        db.add(f)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="faq_item_created",
-            resource_type="faq_item",
-            resource_id=f.id,
-            details={"question_nl": f.question_nl},
-        )
-        await db.commit()
-        await db.refresh(f)
-        return faq_item_to_dict(f)
+        try:
+            return await faq_service.create_faq_item(db, actor=actor, body=body)
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
 
 
 async def list_faq_items(session_factory: Any) -> dict:
     """Every FAQ item and every locale, active or not, in display order (admin shape)."""
     async with session_factory() as db:
-        result = await db.execute(select(FaqItem).order_by(FaqItem.sort_order))
-        return {"faq_items": [faq_item_to_dict(f) for f in result.scalars().all()]}
+        return {"faq_items": await faq_service.list_faq_items(db)}
 
 
 async def update_faq_item(
@@ -84,7 +60,6 @@ async def update_faq_item(
     answer_en: str | None = None,
     question_fr: str | None = None,
     answer_fr: str | None = None,
-    sort_order: int | None = None,
     active: bool | None = None,
 ) -> dict:
     """Update an FAQ item.
@@ -102,47 +77,35 @@ async def update_faq_item(
             "answer_en": answer_en,
             "question_fr": question_fr,
             "answer_fr": answer_fr,
-            "sort_order": sort_order,
             "active": active,
         }.items()
         if v is not None
     }
     body = validate_with_schema(FaqItemUpdate, **provided)
     async with session_factory() as db:
-        f = await get_or_error(db, FaqItem, faq_item_id, f"FAQ item '{faq_item_id}' not found.")
-        # Apply from the validated `body`, not the raw arguments — any coercion or
-        # normalisation FaqItemUpdate performs must land on the row, matching
-        # create_faq_item and the REST router's own update_faq_item.
-        optional_locales = {"question_en", "answer_en", "question_fr", "answer_fr"}
-        for field in body.model_fields_set:
-            value = getattr(body, field)
-            if field in optional_locales:
-                value = value or None
-            setattr(f, field, value)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="faq_item_updated",
-            resource_type="faq_item",
-            resource_id=f.id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        await db.commit()
-        await db.refresh(f)
-        return faq_item_to_dict(f)
+        try:
+            return await faq_service.update_faq_item(db, actor=actor, faq_item_id=faq_item_id, body=body)
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
 
 
 async def delete_faq_item(session_factory: Any, actor: str, faq_item_id: str) -> dict:
     async with session_factory() as db:
-        f = await get_or_error(db, FaqItem, faq_item_id, f"FAQ item '{faq_item_id}' not found.")
-        await db.delete(f)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="faq_item_deleted",
-            resource_type="faq_item",
-            resource_id=faq_item_id,
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": faq_item_id}
+        try:
+            return await faq_service.delete_faq_item(db, actor=actor, faq_item_id=faq_item_id)
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
+
+
+async def reorder_faq_items(session_factory: Any, actor: str, *, ordered_ids: list[str]) -> dict:
+    """Reassign every FAQ item's display position to match ``ordered_ids``.
+
+    ``ordered_ids`` must name every existing FAQ item exactly once — the same
+    semantics the admin UI's reorder control uses (#836).
+    """
+    body = validate_with_schema(FaqItemReorder, ordered_ids=ordered_ids)
+    async with session_factory() as db:
+        try:
+            return {"faq_items": await faq_service.reorder_faq_items(db, actor=actor, ordered_ids=body.ordered_ids)}
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -1038,10 +1038,12 @@ class ChampagneFestivalMcpBackend:
         answer_en: str | None = None,
         question_fr: str | None = None,
         answer_fr: str | None = None,
-        sort_order: int = 0,
         active: bool = True,
     ) -> dict:
-        """Create an FAQ item. Requires the ``admin`` role."""
+        """Create an FAQ item, appended after the current last one. Requires the ``admin`` role.
+
+        Display position isn't settable here — use ``reorder_faq_items`` to change it.
+        """
         self._require_admin()
         return await mcp_admin_faq.create_faq_item(
             self.session_factory,
@@ -1052,7 +1054,6 @@ class ChampagneFestivalMcpBackend:
             answer_en=answer_en,
             question_fr=question_fr,
             answer_fr=answer_fr,
-            sort_order=sort_order,
             active=active,
         )
 
@@ -1070,14 +1071,14 @@ class ChampagneFestivalMcpBackend:
         answer_en: str | None = None,
         question_fr: str | None = None,
         answer_fr: str | None = None,
-        sort_order: int | None = None,
         active: bool | None = None,
     ) -> dict:
         """Partially update an FAQ item; omitted fields are left unchanged.
 
         For the optional ``en``/``fr`` locale fields, an explicit empty string
         clears that locale's translation (hiding the item on that locale's FAQ)
-        rather than leaving it unchanged. Requires the ``admin`` role.
+        rather than leaving it unchanged. Display position isn't settable here —
+        use ``reorder_faq_items`` to change it. Requires the ``admin`` role.
         """
         self._require_admin()
         return await mcp_admin_faq.update_faq_item(
@@ -1090,7 +1091,6 @@ class ChampagneFestivalMcpBackend:
             answer_en=answer_en,
             question_fr=question_fr,
             answer_fr=answer_fr,
-            sort_order=sort_order,
             active=active,
         )
 
@@ -1098,6 +1098,17 @@ class ChampagneFestivalMcpBackend:
         """Delete an FAQ item. Requires the ``admin`` role."""
         self._require_admin()
         return await mcp_admin_faq.delete_faq_item(self.session_factory, self._actor(), faq_item_id)
+
+    async def reorder_faq_items(self, ordered_ids: list[str]) -> dict:
+        """Reassign every FAQ item's display position to match ``ordered_ids``.
+
+        ``ordered_ids`` must name every existing FAQ item exactly once — the
+        same all-at-once semantics the admin UI's reorder control uses, so a
+        reorder can't be partial, stale, or racing another admin's reorder.
+        Requires the ``admin`` role.
+        """
+        self._require_admin()
+        return await mcp_admin_faq.reorder_faq_items(self.session_factory, self._actor(), ordered_ids=ordered_ids)
 
     # -- Settings ------------------------------------------------------
 
@@ -1758,6 +1769,7 @@ def create_mcp_server(
     register_tool(backend.list_faq_items)
     register_tool(backend.update_faq_item)
     register_tool(backend.delete_faq_item)
+    register_tool(backend.reorder_faq_items)
     register_tool(backend.get_settings)
     register_tool(backend.set_maintenance_mode)
     register_tool(backend.create_exhibitor)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    UniqueConstraint,
     text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -604,6 +605,12 @@ class FaqItem(Base):
     """
 
     __tablename__ = "faq_items"
+    __table_args__ = (
+        # Deferred so a reorder can touch several rows in one transaction
+        # without a transient duplicate mid-transaction tripping the check —
+        # only the state at commit has to be unique (#836).
+        UniqueConstraint("sort_order", name="uq_faq_items_sort_order", deferrable=True, initially="DEFERRED"),
+    )
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     question_nl: Mapped[str] = mapped_column(String(500))

--- a/backend/app/routers/faq.py
+++ b/backend/app/routers/faq.py
@@ -1,15 +1,21 @@
-"""FAQ item management endpoints."""
+"""FAQ item management endpoints.
+
+Business logic lives in ``app.services.faq_service`` and is shared with
+``app.mcp.admin.faq`` — this router is a thin adapter that translates
+``ServiceError`` into ``HTTPException`` (see #807, #836).
+"""
 
 from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
 from app.models import FaqItem
-from app.schemas import FaqItemCreate, FaqItemOut, FaqItemPublicOut, FaqItemUpdate, FaqLocale
-from app.utils import faq_item_to_dict, faq_item_to_public_dict, get_or_404, make_id
+from app.schemas import FaqItemCreate, FaqItemOut, FaqItemPublicOut, FaqItemReorder, FaqItemUpdate, FaqLocale
+from app.services import faq_service
+from app.services.errors import ServiceError, to_http_exception
+from app.utils import faq_item_to_public_dict
 
 router = APIRouter(
     prefix="/api/faq",
@@ -42,106 +48,78 @@ async def list_active_faq_items(
 @router.get("", response_model=list[FaqItemOut], dependencies=[Depends(require_admin)])
 async def list_faq_items(db: AsyncSession = Depends(get_db)) -> list[dict]:
     """Admin: every FAQ item and every locale, active or not, in display order."""
-    stmt = select(FaqItem).order_by(FaqItem.sort_order)
-    result = await db.execute(stmt)
-    return [faq_item_to_dict(f) for f in result.scalars().all()]
+    return await faq_service.list_faq_items(db)
 
 
-@router.post("", response_model=FaqItemOut, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=FaqItemOut, status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_admin)])
 async def create_faq_item(
     body: FaqItemCreate,
     request: Request,
-    _: None = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    f = FaqItem(
-        id=make_id("faq"),
-        question_nl=body.question_nl,
-        answer_nl=body.answer_nl,
-        question_en=body.question_en or None,
-        answer_en=body.answer_en or None,
-        question_fr=body.question_fr or None,
-        answer_fr=body.answer_fr or None,
-        sort_order=body.sort_order,
-        active=body.active,
-    )
-    db.add(f)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="faq_item_created",
-        resource_type="faq_item",
-        resource_id=f.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"question_nl": f.question_nl},
-    )
-    await db.commit()
-    await db.refresh(f)
-    return faq_item_to_dict(f)
+    try:
+        return await faq_service.create_faq_item(
+            db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
-@router.put("/{faq_item_id}", response_model=FaqItemOut)
+@router.put("/{faq_item_id}", response_model=FaqItemOut, dependencies=[Depends(require_admin)])
 async def update_faq_item(
     faq_item_id: str,
     body: FaqItemUpdate,
     request: Request,
-    _: None = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    f = await get_or_404(db, FaqItem, faq_item_id, "FAQ item not found.")
-    if body.question_nl is not None:
-        f.question_nl = body.question_nl
-    if body.answer_nl is not None:
-        f.answer_nl = body.answer_nl
-    # Optional locales: presence, not None-ness, distinguishes "omitted" from
-    # "sent as '', clear it" — an empty string normalizes to NULL, hiding the
-    # item on that locale's FAQ.
-    fields_set = body.model_fields_set
-    if "question_en" in fields_set:
-        f.question_en = body.question_en or None
-    if "answer_en" in fields_set:
-        f.answer_en = body.answer_en or None
-    if "question_fr" in fields_set:
-        f.question_fr = body.question_fr or None
-    if "answer_fr" in fields_set:
-        f.answer_fr = body.answer_fr or None
-    if body.sort_order is not None:
-        f.sort_order = body.sort_order
-    if body.active is not None:
-        f.active = body.active
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="faq_item_updated",
-        resource_type="faq_item",
-        resource_id=f.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(fields_set)},
-    )
-    await db.commit()
-    await db.refresh(f)
-    return faq_item_to_dict(f)
+    try:
+        return await faq_service.update_faq_item(
+            db,
+            actor=actor,
+            faq_item_id=faq_item_id,
+            body=body,
+            request_id=getattr(request.state, "request_id", None),
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
-@router.delete("/{faq_item_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.post("/reorder", response_model=list[FaqItemOut], dependencies=[Depends(require_admin)])
+async def reorder_faq_items(
+    body: FaqItemReorder,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> list[dict]:
+    """Reassign every FAQ item's display position to match ``body.ordered_ids``.
+
+    The dedicated, all-at-once operation (rather than one PUT per item) is
+    what keeps a reorder from landing in a partially-applied, ambiguous state
+    (#836).
+    """
+    try:
+        return await faq_service.reorder_faq_items(
+            db,
+            actor=actor,
+            ordered_ids=body.ordered_ids,
+            request_id=getattr(request.state, "request_id", None),
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
+
+
+@router.delete("/{faq_item_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_admin)])
 async def delete_faq_item(
     faq_item_id: str,
     request: Request,
-    _: None = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    f = await get_or_404(db, FaqItem, faq_item_id, "FAQ item not found.")
-    await db.delete(f)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="faq_item_deleted",
-        resource_type="faq_item",
-        resource_id=faq_item_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={},
-    )
-    await db.commit()
+    try:
+        await faq_service.delete_faq_item(
+            db, actor=actor, faq_item_id=faq_item_id, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1048,7 +1048,6 @@ class FaqItemCreate(BaseModel):
     answer_en: str | None = Field(default=None, max_length=10000)
     question_fr: str | None = Field(default=None, max_length=500)
     answer_fr: str | None = Field(default=None, max_length=10000)
-    sort_order: int = 0
     active: bool = True
 
 
@@ -1063,8 +1062,18 @@ class FaqItemUpdate(BaseModel):
     answer_en: str | None = Field(default=None, max_length=10000)
     question_fr: str | None = Field(default=None, max_length=500)
     answer_fr: str | None = Field(default=None, max_length=10000)
-    sort_order: int | None = None
     active: bool | None = None
+
+
+class FaqItemReorder(BaseModel):
+    """The complete, ordered list of every existing FAQ item's ID.
+
+    `sort_order` isn't settable through create/update — this is the only way
+    to change display order, and it takes the whole collection at once so a
+    reorder can't leave things ambiguous or race another admin's reorder (#836).
+    """
+
+    ordered_ids: list[str] = Field(min_length=1)
 
 
 class FaqItemOut(BaseModel):

--- a/backend/app/services/faq_service.py
+++ b/backend/app/services/faq_service.py
@@ -1,0 +1,168 @@
+"""Shared application-service operations for FAQ items.
+
+Used by both ``app.routers.faq`` (REST) and ``app.mcp.admin.faq`` (MCP). See
+``app/services/rooms_service.py`` for the pattern this follows and
+``app/services/errors.py`` for the exception convention each adapter
+translates at its own boundary.
+
+``sort_order`` is enforced unique by a deferrable constraint (migration 012)
+so display order is always deterministic. It isn't client-settable through
+create/update — ``create_faq_item`` always appends after the current last
+item, and ``reorder_faq_items`` is the only supported way to change existing
+positions, taking the complete ordered list at once so a reorder can't be
+partial, stale, or racing another admin's reorder (#836).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.models import FaqItem
+from app.schemas import FaqItemCreate, FaqItemUpdate
+from app.services.errors import ConflictError, NotFoundError, ValidationFailedError
+from app.utils import faq_item_to_dict, make_id
+
+# A concurrent create can race this one for the same next `sort_order`; the
+# unique constraint (checked at commit) catches that, and this bounds how
+# many times we recompute-and-retry before giving up.
+_MAX_APPEND_ATTEMPTS = 5
+
+
+async def list_faq_items(db: AsyncSession) -> list[dict]:
+    """Every FAQ item and every locale, active or not, in display order (admin shape)."""
+    result = await db.execute(select(FaqItem).order_by(FaqItem.sort_order))
+    return [faq_item_to_dict(f) for f in result.scalars().all()]
+
+
+async def create_faq_item(db: AsyncSession, *, actor: str, body: FaqItemCreate, request_id: str | None = None) -> dict:
+    for _attempt in range(_MAX_APPEND_ATTEMPTS):
+        current_max = (await db.execute(select(func.max(FaqItem.sort_order)))).scalar_one()
+        f = FaqItem(
+            id=make_id("faq"),
+            question_nl=body.question_nl,
+            answer_nl=body.answer_nl,
+            question_en=body.question_en or None,
+            answer_en=body.answer_en or None,
+            question_fr=body.question_fr or None,
+            answer_fr=body.answer_fr or None,
+            sort_order=0 if current_max is None else current_max + 1,
+            active=body.active,
+        )
+        db.add(f)
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="faq_item_created",
+            resource_type="faq_item",
+            resource_id=f.id,
+            request_id=request_id,
+            details={"question_nl": f.question_nl},
+        )
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            continue
+        await db.refresh(f)
+        return faq_item_to_dict(f)
+    raise ConflictError("Could not assign a unique display position for the new FAQ item; please retry.")
+
+
+async def update_faq_item(
+    db: AsyncSession, *, actor: str, faq_item_id: str, body: FaqItemUpdate, request_id: str | None = None
+) -> dict:
+    f = await db.get(FaqItem, faq_item_id)
+    if f is None:
+        raise NotFoundError(f"FAQ item '{faq_item_id}' not found.")
+    if body.question_nl is not None:
+        f.question_nl = body.question_nl
+    if body.answer_nl is not None:
+        f.answer_nl = body.answer_nl
+    # Optional locales: presence, not None-ness, distinguishes "omitted" from
+    # "sent as '', clear it" — an empty string normalizes to NULL, hiding the
+    # item on that locale's FAQ.
+    fields_set = body.model_fields_set
+    if "question_en" in fields_set:
+        f.question_en = body.question_en or None
+    if "answer_en" in fields_set:
+        f.answer_en = body.answer_en or None
+    if "question_fr" in fields_set:
+        f.question_fr = body.question_fr or None
+    if "answer_fr" in fields_set:
+        f.answer_fr = body.answer_fr or None
+    if body.active is not None:
+        f.active = body.active
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="faq_item_updated",
+        resource_type="faq_item",
+        resource_id=f.id,
+        request_id=request_id,
+        details={"fields_changed": sorted(fields_set)},
+    )
+    await db.commit()
+    await db.refresh(f)
+    return faq_item_to_dict(f)
+
+
+async def delete_faq_item(db: AsyncSession, *, actor: str, faq_item_id: str, request_id: str | None = None) -> dict:
+    f = await db.get(FaqItem, faq_item_id)
+    if f is None:
+        raise NotFoundError(f"FAQ item '{faq_item_id}' not found.")
+    await db.delete(f)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="faq_item_deleted",
+        resource_type="faq_item",
+        resource_id=faq_item_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": faq_item_id}
+
+
+async def reorder_faq_items(
+    db: AsyncSession, *, actor: str, ordered_ids: list[str], request_id: str | None = None
+) -> list[dict]:
+    """Atomically reassign ``sort_order`` (0..N-1) to match ``ordered_ids``.
+
+    ``ordered_ids`` must name every existing FAQ item exactly once. A partial
+    or stale list — e.g. an item created or deleted by someone else since the
+    caller loaded its copy of the list — is rejected outright rather than
+    silently reordering a subset, which is what keeps concurrent reorders
+    well-defined: the loser of a race gets a 409 and has to reload, not a
+    merged/ambiguous result.
+    """
+    if len(ordered_ids) != len(set(ordered_ids)):
+        raise ValidationFailedError("ordered_ids contains duplicates.")
+
+    # Lock every row up front so a second reorder (or a create/delete) can't
+    # interleave with this one — it blocks until we commit, then its own
+    # existing-ids check below almost certainly fails against our new state.
+    result = await db.execute(select(FaqItem).order_by(FaqItem.sort_order).with_for_update())
+    items = {f.id: f for f in result.scalars().all()}
+    if set(ordered_ids) != set(items):
+        raise ConflictError(
+            "ordered_ids must name every existing FAQ item exactly once; the list is stale — reload and retry."
+        )
+
+    for index, item_id in enumerate(ordered_ids):
+        items[item_id].sort_order = index
+
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="faq_items_reordered",
+        resource_type="faq_item",
+        resource_id="faq_items",
+        request_id=request_id,
+        details={"ordered_ids": ordered_ids},
+    )
+    await db.commit()
+    return await list_faq_items(db)

--- a/backend/tests/test_faq.py
+++ b/backend/tests/test_faq.py
@@ -47,7 +47,6 @@ async def test_faq_crud(client):
         json={
             "question_nl": "Wanneer?",
             "answer_nl": "Op 2 oktober.",
-            "sort_order": 0,
         },
         headers=ADMIN_HEADERS,
     )
@@ -171,14 +170,71 @@ async def test_faq_requires_dutch_question_and_answer(client):
 
 @pytest.mark.anyio
 async def test_active_faq_respects_sort_order(client):
-    r = await client.post(
-        "/api/faq", json={"question_nl": "Second", "answer_nl": "b", "sort_order": 1}, headers=ADMIN_HEADERS
-    )
-    assert r.status_code == 201
-    r = await client.post(
-        "/api/faq", json={"question_nl": "First", "answer_nl": "a", "sort_order": 0}, headers=ADMIN_HEADERS
-    )
-    assert r.status_code == 201
+    """Items are created in append order, then reordering (not sort_order on
+    create/update) is what changes display order — see test_faq_reorder_*
+    below for the dedicated reorder endpoint (#836)."""
+    r = await client.post("/api/faq", json={"question_nl": "First", "answer_nl": "a"}, headers=ADMIN_HEADERS)
+    first_id = r.json()["id"]
+    r = await client.post("/api/faq", json={"question_nl": "Second", "answer_nl": "b"}, headers=ADMIN_HEADERS)
+    second_id = r.json()["id"]
 
     r = await client.get("/api/faq/active", params={"locale": "nl"})
     assert [i["question"] for i in r.json()] == ["First", "Second"]
+
+    r = await client.post("/api/faq/reorder", json={"ordered_ids": [second_id, first_id]}, headers=ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert [i["id"] for i in r.json()] == [second_id, first_id]
+
+    r = await client.get("/api/faq/active", params={"locale": "nl"})
+    assert [i["question"] for i in r.json()] == ["Second", "First"]
+
+
+@pytest.mark.anyio
+async def test_faq_create_appends_after_the_current_last_item(client):
+    r = await client.post("/api/faq", json=DUTCH_ONLY, headers=ADMIN_HEADERS)
+    first = r.json()
+    r = await client.post("/api/faq", json={"question_nl": "Tweede", "answer_nl": "b"}, headers=ADMIN_HEADERS)
+    second = r.json()
+    assert second["sort_order"] > first["sort_order"]
+
+
+@pytest.mark.anyio
+async def test_faq_reorder_rejects_stale_or_partial_list(client):
+    r = await client.post("/api/faq", json=DUTCH_ONLY, headers=ADMIN_HEADERS)
+    first_id = r.json()["id"]
+    r = await client.post("/api/faq", json={"question_nl": "Tweede", "answer_nl": "b"}, headers=ADMIN_HEADERS)
+    second_id = r.json()["id"]
+
+    # Missing an existing item.
+    r = await client.post("/api/faq/reorder", json={"ordered_ids": [first_id]}, headers=ADMIN_HEADERS)
+    assert r.status_code == 409
+
+    # Names an item that doesn't exist.
+    r = await client.post(
+        "/api/faq/reorder", json={"ordered_ids": [first_id, second_id, "faq_nonexistent"]}, headers=ADMIN_HEADERS
+    )
+    assert r.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_faq_reorder_rejects_duplicate_ids(client):
+    r = await client.post("/api/faq", json=DUTCH_ONLY, headers=ADMIN_HEADERS)
+    first_id = r.json()["id"]
+
+    r = await client.post("/api/faq/reorder", json={"ordered_ids": [first_id, first_id]}, headers=ADMIN_HEADERS)
+    assert r.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_faq_update_cannot_set_sort_order(client):
+    """sort_order isn't part of the update payload shape at all — reordering
+    only happens through /api/faq/reorder (#836)."""
+    r = await client.post("/api/faq", json=DUTCH_ONLY, headers=ADMIN_HEADERS)
+    item = r.json()
+
+    r = await client.put(
+        f"/api/faq/{item['id']}", json={"sort_order": 99, "question_nl": "Aangepast"}, headers=ADMIN_HEADERS
+    )
+    assert r.status_code == 200
+    assert r.json()["sort_order"] == item["sort_order"]
+    assert r.json()["question_nl"] == "Aangepast"

--- a/backend/tests/test_mcp_admin_faq.py
+++ b/backend/tests/test_mcp_admin_faq.py
@@ -69,3 +69,29 @@ async def test_delete_faq_item_not_found(db_session):
     factory = mcp_session_factory(db_session)
     with pytest.raises(ValueError, match="not found"):
         await mcp_faq.delete_faq_item(factory, "admin-1", "nonexistent")
+
+
+async def test_create_faq_item_appends_after_the_current_last_item(db_session):
+    factory = mcp_session_factory(db_session)
+    first = await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 1?", answer_nl="Antwoord 1.")
+    second = await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 2?", answer_nl="Antwoord 2.")
+    assert second["sort_order"] > first["sort_order"]
+
+
+async def test_reorder_faq_items(db_session):
+    factory = mcp_session_factory(db_session)
+    first = await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 1?", answer_nl="Antwoord 1.")
+    second = await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 2?", answer_nl="Antwoord 2.")
+
+    reordered = await mcp_faq.reorder_faq_items(factory, "admin-1", ordered_ids=[second["id"], first["id"]])
+    assert [item["id"] for item in reordered["faq_items"]] == [second["id"], first["id"]]
+    assert reordered["faq_items"][0]["sort_order"] < reordered["faq_items"][1]["sort_order"]
+
+
+async def test_reorder_faq_items_rejects_stale_list(db_session):
+    factory = mcp_session_factory(db_session)
+    first = await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 1?", answer_nl="Antwoord 1.")
+    await mcp_faq.create_faq_item(factory, "admin-1", question_nl="Vraag 2?", answer_nl="Antwoord 2.")
+
+    with pytest.raises(ValueError, match="stale"):
+        await mcp_faq.reorder_faq_items(factory, "admin-1", ordered_ids=[first["id"]])

--- a/docs/integrations/LOCAL_MCP_SERVER.md
+++ b/docs/integrations/LOCAL_MCP_SERVER.md
@@ -82,7 +82,7 @@ complete regardless of which surface made the change. All are `admin`-only excep
 | Tables | `create_table`, `list_tables` (`layout_id` filter), `get_table`, `update_table`, `delete_table` |
 | Layouts | `create_layout`, `copy_layout`, `list_layouts` (`edition_id`/`room_id` filters), `get_layout` (`include_tables` to also return its tables/areas), `delete_layout` |
 | Areas | `create_area`, `list_areas` (`layout_id` filter), `get_area`, `update_area`, `delete_area` |
-| FAQ | `create_faq_item`, `list_faq_items`, `update_faq_item`, `delete_faq_item` |
+| FAQ | `create_faq_item`, `list_faq_items`, `update_faq_item`, `delete_faq_item`, `reorder_faq_items` |
 | Settings | `get_settings` (public), `set_maintenance_mode` |
 | Exhibitors | `create_exhibitor`, `get_exhibitor`, `list_exhibitors`, `update_exhibitor`, `delete_exhibitor` |
 | People | `create_person`, `get_person`, `update_person`, `delete_person`, `merge_people` |

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -446,6 +446,7 @@
   "admin_error_add_faq_item": "Failed to add the question.",
   "admin_error_update_faq_item": "Failed to update the question.",
   "admin_error_delete_faq_item": "Failed to delete the question.",
+  "admin_error_reorder_faq_items": "Failed to reorder the questions.",
   "admin_settings_maintenance_mode_label": "Maintenance mode",
   "admin_settings_maintenance_mode_help": "Shows visitors a page with just an image and a link to Facebook instead of the full website. The admin dashboard stays reachable.",
   "admin_error_load_settings": "Failed to load settings.",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -446,6 +446,7 @@
   "admin_error_add_faq_item": "Échec de l'ajout de la question.",
   "admin_error_update_faq_item": "Échec de la mise à jour de la question.",
   "admin_error_delete_faq_item": "Échec de la suppression de la question.",
+  "admin_error_reorder_faq_items": "Échec de la réorganisation des questions.",
   "admin_settings_maintenance_mode_label": "Mode maintenance",
   "admin_settings_maintenance_mode_help": "Affiche aux visiteurs une page avec uniquement une image et un lien vers Facebook au lieu du site complet. Le tableau de bord admin reste accessible.",
   "admin_error_load_settings": "Échec du chargement des paramètres.",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -446,6 +446,7 @@
   "admin_error_add_faq_item": "Toevoegen van de vraag is mislukt.",
   "admin_error_update_faq_item": "Bijwerken van de vraag is mislukt.",
   "admin_error_delete_faq_item": "Verwijderen van de vraag is mislukt.",
+  "admin_error_reorder_faq_items": "Herordenen van de vragen is mislukt.",
   "admin_settings_maintenance_mode_label": "Onderhoudsmodus",
   "admin_settings_maintenance_mode_help": "Toont bezoekers een pagina met alleen een afbeelding en een link naar Facebook in plaats van de volledige website. Het admin-dashboard blijft bereikbaar.",
   "admin_error_load_settings": "Laden van de instellingen is mislukt.",

--- a/frontend/src/components/admin/FaqManagement.tsx
+++ b/frontend/src/components/admin/FaqManagement.tsx
@@ -56,7 +56,6 @@ const emptyForm: FaqFormState = {
 interface FaqLocaleData {
   question: string;
   answer: string;
-  sortOrder: number;
 }
 
 function faqPayload(data: FaqLocaleData & Omit<FaqFormState, "questionNl" | "answerNl">) {
@@ -67,7 +66,6 @@ function faqPayload(data: FaqLocaleData & Omit<FaqFormState, "questionNl" | "ans
     answer_en: data.answerEn,
     question_fr: data.questionFr,
     answer_fr: data.answerFr,
-    sort_order: data.sortOrder,
   };
 }
 
@@ -116,11 +114,25 @@ export default function FaqManagement({ authHeaders }: FaqManagementProps) {
             ...(data.answerEn !== undefined && { answer_en: data.answerEn ?? "" }),
             ...(data.questionFr !== undefined && { question_fr: data.questionFr ?? "" }),
             ...(data.answerFr !== undefined && { answer_fr: data.answerFr ?? "" }),
-            ...(data.sortOrder !== undefined && { sort_order: data.sortOrder }),
             ...(data.active !== undefined && { active: data.active }),
           }),
         },
         m.admin_error_update_faq_item(),
+      ),
+    onSettled: () => void invalidateAdmin(queryClient, [faqItemsQueryKey, ["faq"]]),
+    retry: false,
+  });
+
+  const reorderMutation = useMutation({
+    mutationFn: (orderedIds: string[]) =>
+      fetchJsonOrThrowWithUnauthorized<Record<string, unknown>>(
+        "/api/faq/reorder",
+        {
+          method: "POST",
+          headers: authHeaders(),
+          body: JSON.stringify({ ordered_ids: orderedIds }),
+        },
+        m.admin_error_reorder_faq_items(),
       ),
     onSettled: () => void invalidateAdmin(queryClient, [faqItemsQueryKey, ["faq"]]),
     retry: false,
@@ -188,11 +200,9 @@ export default function FaqManagement({ authHeaders }: FaqManagementProps) {
           },
         });
       } else {
-        const nextSortOrder = faqItems.reduce((max, i) => Math.max(max, i.sortOrder), -1) + 1;
         await createMutation.mutateAsync({
           question: form.questionNl.trim(),
           answer: form.answerNl.trim(),
-          sortOrder: nextSortOrder,
           ...locales,
         });
       }
@@ -200,7 +210,7 @@ export default function FaqManagement({ authHeaders }: FaqManagementProps) {
     } catch (err) {
       setError(err instanceof Error ? err.message : m.admin_content_error_save());
     }
-  }, [form, editingId, faqItems, createMutation, updateMutation]);
+  }, [form, editingId, createMutation, updateMutation]);
 
   const handleToggleActive = useCallback(
     async (item: FaqItem) => {
@@ -232,26 +242,23 @@ export default function FaqManagement({ authHeaders }: FaqManagementProps) {
       const sorted = [...faqItems].sort((a, b) => a.sortOrder - b.sortOrder);
       const index = sorted.findIndex((i) => i.id === item.id);
       const swapIndex = direction === "up" ? index - 1 : index + 1;
-      const swapWith = sorted[swapIndex];
-      if (!swapWith) return;
+      if (index === -1 || swapIndex < 0 || swapIndex >= sorted.length) return;
+      const reordered = sorted.map((entry, i) => {
+        if (i === index) return sorted[swapIndex]!;
+        if (i === swapIndex) return sorted[index]!;
+        return entry;
+      });
       setRowError(null);
-      // Sequential, not Promise.all: if the second write fails after the
-      // first succeeds, both rows would otherwise share one sort_order
-      // (ambiguous order, and the next move on either item becomes a no-op
-      // since they compare equal). Roll the first write back instead.
-      await updateMutation.mutateAsync({ id: item.id, data: { sortOrder: swapWith.sortOrder } });
       try {
-        await updateMutation.mutateAsync({ id: swapWith.id, data: { sortOrder: item.sortOrder } });
+        // One atomic call for the whole list rather than two independent
+        // per-item writes — the backend rejects a stale/partial list outright
+        // instead of risking an ambiguous half-applied order (#836).
+        await reorderMutation.mutateAsync(reordered.map((i) => i.id));
       } catch (err) {
-        try {
-          await updateMutation.mutateAsync({ id: item.id, data: { sortOrder: item.sortOrder } });
-        } catch {
-          // Rollback failure doesn't get to hide the original error.
-        }
         setRowError(err instanceof Error ? err.message : m.admin_content_error_save());
       }
     },
-    [faqItems, updateMutation],
+    [faqItems, reorderMutation],
   );
 
   const sortedItems = useMemo(
@@ -259,7 +266,7 @@ export default function FaqManagement({ authHeaders }: FaqManagementProps) {
     [faqItems],
   );
 
-  const isMutating = updateMutation.isPending || deleteMutation.isPending;
+  const isMutating = updateMutation.isPending || deleteMutation.isPending || reorderMutation.isPending;
 
   const localeBadge = (label: string, translated: boolean) => (
     <Badge


### PR DESCRIPTION
## Summary

Closes #836.

> **Note:** This branch was forked from a lineage that already carries the commits for #834 and #831, which have their own open draft PRs (#862, #863) — those show up in this diff too. The FAQ-ordering work described below is the last commit, `Enforce deterministic, conflict-free FAQ ordering`.

`faq_items.sort_order` had no uniqueness or secondary tie-break, so two items could land at the same position (observed in production: an imported FAQ and an old demo FAQ both at `sort_order = 0`) and the resulting order depended on undefined database/query tie-breaking. `sort_order` was also directly client-settable through the single-item create/update endpoints (REST and MCP), so the admin UI's up/down "move" issued two independent, non-atomic `PUT` requests with manual best-effort rollback if the second one failed.

- Adds a `DEFERRABLE INITIALLY DEFERRED` unique constraint on `faq_items.sort_order` (migration `012`), so display order is always well-defined. The migration first renumbers any existing duplicates/gaps densely (`sort_order` then `id` as the tie-break), repairing pre-existing bad data before the constraint is added.
- Moves FAQ business logic into a new shared `app.services.faq_service`, used by both `app.routers.faq` (REST) and `app.mcp.admin.faq` (MCP) — matching the existing pattern for rooms/tables/venues (#807) — so both surfaces share identical reorder semantics.
- `sort_order` is no longer client-settable via create/update:
  - `create_faq_item` always appends after the current last item (retrying on a rare concurrent-create race, since the unique constraint is the actual source of truth).
  - A new `reorder_faq_items` operation (`POST /api/faq/reorder`, MCP `reorder_faq_items`) takes the *complete* ordered list of every existing item's ID and reassigns `0..N-1` atomically in one transaction. A partial or stale list (e.g. an item created/deleted elsewhere since the caller's copy was loaded) is rejected with 409 rather than silently reordering a subset — that's what keeps concurrent reorders well-defined.
- Updates `FaqManagement`'s move-up/down to call the new batch reorder endpoint instead of issuing two sequential `PUT`s.
- Updates `docs/integrations/LOCAL_MCP_SERVER.md`'s FAQ tool list.

### Acceptance criteria

- [x] FAQ display order is deterministic (unique constraint + append-only create).
- [x] Inserts and moves cannot silently create ambiguous ordering (no client-settable `sort_order`; reorder validates the full ID set).
- [x] Concurrent reorder attempts have defined behavior (row locks + stale-list rejection with 409; concurrent creates retry past a raced append).
- [x] Admin UI and MCP use the same reorder semantics (shared `faq_service`).
- [x] Existing duplicate positions are repaired by migration (`012`'s renumbering pass).

## Test plan

- [x] `uv run ruff check app tests` / `uv run ruff format --check app tests`
- [x] `uv run ty check app`
- [x] `uv run pytest` — full backend suite passes (825 passed), including new tests for append-on-create, reorder success, stale/partial-list rejection (409), duplicate-id rejection (400), and that `PUT` can no longer move an item
- [x] Manually ran migration `012` against a seeded database with duplicate/gapped `sort_order` values (mirroring the production scenario from the issue) and confirmed it renumbers deterministically; verified a same-transaction multi-row swap commits cleanly under the deferred constraint; verified downgrade/upgrade round-trips
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` (526 passed) / `pnpm build`
- [x] Started the real backend + frontend dev servers and exercised the live API end-to-end through an actual browser: seeded FAQ items via the real API, confirmed the public FAQ accordion renders them in append order, called `/api/faq/reorder`, and confirmed the browser (real fetch, real DB) now shows the new order; also confirmed a stale/partial reorder list returns 409, a duplicate-id list returns 400, and `PUT .../faq/{id}` with `sort_order` no longer moves the item


---
_Generated by [Claude Code](https://claude.ai/code/session_01XB2vjAEXk6fW4RD8P3f6V3)_