### PR TITLE
Add bulk/import and idempotent write operations for rooms, table types, tables, layouts

### DIFF
--- a/backend/alembic/versions/013_add_idempotency_keys.py
+++ b/backend/alembic/versions/013_add_idempotency_keys.py
@@ -1,0 +1,49 @@
+"""Add idempotency_keys table for bulk/import write operations.
+
+Backs the idempotency-key mechanism for the new bulk-create endpoints (rooms,
+table types, tables, layouts — see issue #837): a client-supplied key, scoped
+per operation, whose successful result is cached so a retried call (after a
+partial failure or timeout) replays the original response instead of
+creating duplicate records. A key reused with a different request body is
+rejected rather than silently applied — enforced by the unique constraint on
+(``scope``, ``key``) plus a request-body hash comparison in the application
+layer (``app.services.idempotency``).
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-08-13
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "013"
+down_revision: str | None = "012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "idempotency_keys",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("scope", sa.String(100), nullable=False),
+        sa.Column("key", sa.String(200), nullable=False),
+        sa.Column("actor", sa.String(255), nullable=False),
+        sa.Column("request_hash", sa.String(64), nullable=False),
+        sa.Column("response_body", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_unique_constraint("uq_idempotency_keys_scope_key", "idempotency_keys", ["scope", "key"])
+    op.create_index("ix_idempotency_keys_created_at", "idempotency_keys", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_idempotency_keys_created_at", table_name="idempotency_keys")
+    op.drop_constraint("uq_idempotency_keys_scope_key", "idempotency_keys", type_="unique")
+    op.drop_table("idempotency_keys")

--- a/backend/app/mcp/admin/layouts.py
+++ b/backend/app/mcp/admin/layouts.py
@@ -72,6 +72,22 @@ async def copy_layout(
             raise MCPToolError(str(exc)) from exc
 
 
+async def bulk_create_layouts(
+    session_factory: Any,
+    actor: str,
+    *,
+    items: list[LayoutCreate],
+    idempotency_key: str | None = None,
+) -> dict:
+    async with session_factory() as db:
+        try:
+            return await layouts_service.bulk_create_layouts(
+                db, actor=actor, items=items, idempotency_key=idempotency_key
+            )
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
+
+
 async def list_layouts(
     session_factory: Any,
     edition_id: str | None = None,

--- a/backend/app/mcp/admin/layouts.py
+++ b/backend/app/mcp/admin/layouts.py
@@ -12,7 +12,7 @@ from datetime import date as dt_date
 from typing import Any
 
 from app.mcp.utils import MCPToolError, validate_with_schema
-from app.schemas import LayoutCopyCreate, LayoutCreate
+from app.schemas import LayoutBulkCreate, LayoutCopyCreate, LayoutCreate
 from app.services import layouts_service
 from app.services.errors import ServiceError
 
@@ -79,6 +79,7 @@ async def bulk_create_layouts(
     items: list[LayoutCreate],
     idempotency_key: str | None = None,
 ) -> dict:
+    validate_with_schema(LayoutBulkCreate, items=items, idempotency_key=idempotency_key)
     async with session_factory() as db:
         try:
             return await layouts_service.bulk_create_layouts(

--- a/backend/app/mcp/admin/rooms.py
+++ b/backend/app/mcp/admin/rooms.py
@@ -41,6 +41,20 @@ async def create_room(
             raise MCPToolError(str(exc)) from exc
 
 
+async def bulk_create_rooms(
+    session_factory: Any,
+    actor: str,
+    *,
+    items: list[RoomCreate],
+    idempotency_key: str | None = None,
+) -> dict:
+    async with session_factory() as db:
+        try:
+            return await rooms_service.bulk_create_rooms(db, actor=actor, items=items, idempotency_key=idempotency_key)
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
+
+
 async def list_rooms(session_factory: Any, venue_id: str | None = None) -> dict:
     async with session_factory() as db:
         return {"rooms": await rooms_service.list_rooms(db, venue_id)}

--- a/backend/app/mcp/admin/rooms.py
+++ b/backend/app/mcp/admin/rooms.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.mcp.utils import MCPToolError, validate_with_schema
-from app.schemas import RoomCreate, RoomUpdate
+from app.schemas import RoomBulkCreate, RoomCreate, RoomUpdate
 from app.services import rooms_service
 from app.services.errors import ServiceError
 
@@ -48,6 +48,10 @@ async def bulk_create_rooms(
     items: list[RoomCreate],
     idempotency_key: str | None = None,
 ) -> dict:
+    # Reuse RoomBulkCreate's Field(min_length=1, max_length=200) so the MCP
+    # surface enforces the same batch-size bound as the REST endpoint (#837
+    # review) instead of a second, easily-drifting magic number.
+    validate_with_schema(RoomBulkCreate, items=items, idempotency_key=idempotency_key)
     async with session_factory() as db:
         try:
             return await rooms_service.bulk_create_rooms(db, actor=actor, items=items, idempotency_key=idempotency_key)

--- a/backend/app/mcp/admin/table_types.py
+++ b/backend/app/mcp/admin/table_types.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from app.mcp.utils import MCPToolError, validate_with_schema
-from app.schemas import TableTypeCreate, TableTypeUpdate
+from app.schemas import TableTypeBulkCreate, TableTypeCreate, TableTypeUpdate
 from app.services import table_types_service
 from app.services.errors import ServiceError
 
@@ -52,6 +52,7 @@ async def bulk_create_table_types(
     items: list[TableTypeCreate],
     idempotency_key: str | None = None,
 ) -> dict:
+    validate_with_schema(TableTypeBulkCreate, items=items, idempotency_key=idempotency_key)
     async with session_factory() as db:
         try:
             return await table_types_service.bulk_create_table_types(

--- a/backend/app/mcp/admin/table_types.py
+++ b/backend/app/mcp/admin/table_types.py
@@ -45,6 +45,22 @@ async def create_table_type(
             raise MCPToolError(str(exc)) from exc
 
 
+async def bulk_create_table_types(
+    session_factory: Any,
+    actor: str,
+    *,
+    items: list[TableTypeCreate],
+    idempotency_key: str | None = None,
+) -> dict:
+    async with session_factory() as db:
+        try:
+            return await table_types_service.bulk_create_table_types(
+                db, actor=actor, items=items, idempotency_key=idempotency_key
+            )
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
+
+
 async def list_table_types(session_factory: Any) -> dict:
     async with session_factory() as db:
         return {"table_types": await table_types_service.list_table_types(db)}

--- a/backend/app/mcp/admin/tables.py
+++ b/backend/app/mcp/admin/tables.py
@@ -43,6 +43,22 @@ async def create_table(
             raise MCPToolError(str(exc)) from exc
 
 
+async def bulk_create_tables(
+    session_factory: Any,
+    actor: str,
+    *,
+    items: list[TableCreate],
+    idempotency_key: str | None = None,
+) -> dict:
+    async with session_factory() as db:
+        try:
+            return await tables_service.bulk_create_tables(
+                db, actor=actor, items=items, idempotency_key=idempotency_key
+            )
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
+
+
 async def list_tables(session_factory: Any, layout_id: str | None = None) -> dict:
     async with session_factory() as db:
         return {"tables": await tables_service.list_tables(db, layout_id)}

--- a/backend/app/mcp/admin/tables.py
+++ b/backend/app/mcp/admin/tables.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.mcp.utils import MCPToolError, validate_with_schema
-from app.schemas import TableCreate, TableUpdate
+from app.schemas import TableBulkCreate, TableCreate, TableUpdate
 from app.services import tables_service
 from app.services.errors import ServiceError
 
@@ -50,6 +50,7 @@ async def bulk_create_tables(
     items: list[TableCreate],
     idempotency_key: str | None = None,
 ) -> dict:
+    validate_with_schema(TableBulkCreate, items=items, idempotency_key=idempotency_key)
     async with session_factory() as db:
         try:
             return await tables_service.bulk_create_tables(

--- a/backend/app/mcp/capabilities.py
+++ b/backend/app/mcp/capabilities.py
@@ -39,7 +39,7 @@ VOLUNTEER_TOOL_NAMES: frozenset[str] = frozenset(
 )
 
 _READ_PREFIXES = ("find_", "get_", "list_", "resolve_")
-_NON_DESTRUCTIVE_WRITE_PREFIXES = ("copy_", "create_")
+_NON_DESTRUCTIVE_WRITE_PREFIXES = ("copy_", "create_", "bulk_create_")
 _INTERACTIVE_ADMIN_TOOLS = frozenset(
     {
         "create_integration_client",

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -66,7 +66,16 @@ from app.mcp.capabilities import (
     tool_annotations,
     tool_auth,
 )
-from app.schemas import ROTATION_DESCRIPTION, X_POSITION_DESCRIPTION, Y_POSITION_DESCRIPTION, EditionType
+from app.schemas import (
+    ROTATION_DESCRIPTION,
+    X_POSITION_DESCRIPTION,
+    Y_POSITION_DESCRIPTION,
+    EditionType,
+    LayoutCreate,
+    RoomCreate,
+    TableCreate,
+    TableTypeCreate,
+)
 from app.services.integration_clients_service import DEFAULT_RATE_LIMIT_PER_MINUTE
 from app.version import APP_VERSION
 
@@ -539,6 +548,20 @@ class ChampagneFestivalMcpBackend:
         self._require_admin()
         return await mcp_admin_rooms.delete_room(self.session_factory, self._actor(), room_id)
 
+    async def bulk_create_rooms(self, items: list[RoomCreate], idempotency_key: str | None = None) -> dict:
+        """Create several rooms in one atomic transaction. Requires the ``admin`` role.
+
+        All rooms are validated up front; if any item is invalid, none are
+        created. Pass the same ``idempotency_key`` on a retry (e.g. after a
+        timeout) to safely replay the original result instead of creating
+        duplicates — reusing the key with a different ``items`` payload is
+        rejected.
+        """
+        self._require_admin()
+        return await mcp_admin_rooms.bulk_create_rooms(
+            self.session_factory, self._actor(), items=items, idempotency_key=idempotency_key
+        )
+
     # -- Table types -------------------------------------------------------
 
     async def create_table_type(
@@ -624,6 +647,20 @@ class ChampagneFestivalMcpBackend:
         self._require_admin()
         return await mcp_admin_table_types.delete_table_type(self.session_factory, self._actor(), type_id)
 
+    async def bulk_create_table_types(self, items: list[TableTypeCreate], idempotency_key: str | None = None) -> dict:
+        """Create several table types in one atomic transaction. Requires the ``admin`` role.
+
+        All items are validated up front; if any is invalid, none are
+        created. Pass the same ``idempotency_key`` on a retry (e.g. after a
+        timeout) to safely replay the original result instead of creating
+        duplicates — reusing the key with a different ``items`` payload is
+        rejected.
+        """
+        self._require_admin()
+        return await mcp_admin_table_types.bulk_create_table_types(
+            self.session_factory, self._actor(), items=items, idempotency_key=idempotency_key
+        )
+
     # -- Tables ----------------------------------------------------------
 
     async def create_table(
@@ -698,6 +735,21 @@ class ChampagneFestivalMcpBackend:
         self._require_admin()
         return await mcp_admin_tables.delete_table(self.session_factory, self._actor(), table_id)
 
+    async def bulk_create_tables(self, items: list[TableCreate], idempotency_key: str | None = None) -> dict:
+        """Create several tables in one atomic transaction. Requires the ``admin`` role.
+
+        All tables are validated up front; if any item is invalid, none are
+        created. Pass the same ``idempotency_key`` on a retry (e.g. after a
+        timeout) to safely replay the original result instead of creating
+        duplicates — reusing the key with a different ``items`` payload is
+        rejected. See ``create_table`` for the ``x``/``y``/``rotation``
+        coordinate contract.
+        """
+        self._require_admin()
+        return await mcp_admin_tables.bulk_create_tables(
+            self.session_factory, self._actor(), items=items, idempotency_key=idempotency_key
+        )
+
     # -- Layouts -----------------------------------------------------------
 
     async def create_layout(
@@ -747,6 +799,21 @@ class ChampagneFestivalMcpBackend:
             label=label,
             copy_tables=copy_tables,
             copy_areas=copy_areas,
+        )
+
+    async def bulk_create_layouts(self, items: list[LayoutCreate], idempotency_key: str | None = None) -> dict:
+        """Create several floor-plan layouts in one atomic transaction. Requires the ``admin`` role.
+
+        All items are validated up front — including duplicate room+day+edition
+        combinations both against existing layouts and within the batch itself
+        — so if any is invalid, none are created. Pass the same
+        ``idempotency_key`` on a retry (e.g. after a timeout) to safely replay
+        the original result instead of creating duplicates — reusing the key
+        with a different ``items`` payload is rejected.
+        """
+        self._require_admin()
+        return await mcp_admin_layouts.bulk_create_layouts(
+            self.session_factory, self._actor(), items=items, idempotency_key=idempotency_key
         )
 
     async def list_layouts(self, edition_id: str | None = None, room_id: str | None = None) -> dict:
@@ -1733,22 +1800,26 @@ def create_mcp_server(
     register_tool(backend.update_venue)
     register_tool(backend.delete_venue)
     register_tool(backend.create_room)
+    register_tool(backend.bulk_create_rooms)
     register_tool(backend.list_rooms)
     register_tool(backend.get_room)
     register_tool(backend.update_room)
     register_tool(backend.delete_room)
     register_tool(backend.create_table_type)
+    register_tool(backend.bulk_create_table_types)
     register_tool(backend.list_table_types)
     register_tool(backend.get_table_type)
     register_tool(backend.update_table_type)
     register_tool(backend.delete_table_type)
     register_tool(backend.create_table)
+    register_tool(backend.bulk_create_tables)
     register_tool(backend.list_tables)
     register_tool(backend.get_table)
     register_tool(backend.update_table)
     register_tool(backend.delete_table)
     register_tool(backend.create_layout)
     register_tool(backend.copy_layout)
+    register_tool(backend.bulk_create_layouts)
     register_tool(backend.list_layouts)
     register_tool(backend.get_layout)
     register_tool(backend.delete_layout)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -552,6 +552,31 @@ class AuditEntry(Base):
     details: Mapped[dict] = mapped_column(JSON, default=dict)
 
 
+class IdempotencyKey(Base):
+    """Replay cache guarding idempotency-key-protected bulk/import writes (#837).
+
+    Scoped by ``scope`` (e.g. ``"rooms.bulk_create"``) so the same
+    client-supplied ``key`` can't collide across unrelated operations. A
+    retried call with the same (``scope``, ``key``) and an identical request
+    body replays ``response_body`` instead of re-executing the write; the same
+    key reused with a different body is rejected as a conflict. See
+    ``app.services.idempotency``.
+    """
+
+    __tablename__ = "idempotency_keys"
+    __table_args__ = (UniqueConstraint("scope", "key", name="uq_idempotency_keys_scope_key"),)
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    scope: Mapped[str] = mapped_column(String(100), nullable=False)
+    key: Mapped[str] = mapped_column(String(200), nullable=False)
+    actor: Mapped[str] = mapped_column(String(255), nullable=False)
+    request_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    """sha256 hex digest of the canonicalised request body — detects the same
+    key being reused for a genuinely different request."""
+    response_body: Mapped[dict] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow, index=True)
+
+
 class IntegrationClient(Base):
     """A managed, database-backed credential for machine automation (MCP).
 

--- a/backend/app/routers/layouts.py
+++ b/backend/app/routers/layouts.py
@@ -10,7 +10,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.schemas import LayoutCopyCreate, LayoutCreate, LayoutOut, LayoutWithTablesOut
+from app.schemas import (
+    LayoutBulkCreate,
+    LayoutBulkOut,
+    LayoutCopyCreate,
+    LayoutCreate,
+    LayoutOut,
+    LayoutWithTablesOut,
+)
 from app.services import layouts_service
 from app.services.errors import ServiceError, to_http_exception
 
@@ -50,6 +57,25 @@ async def copy_layout(
             actor=actor,
             source_layout_id=source_layout_id,
             body=body,
+            request_id=getattr(request.state, "request_id", None),
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
+
+
+@router.post("/bulk", response_model=LayoutBulkOut, status_code=status.HTTP_201_CREATED)
+async def bulk_create_layouts(
+    body: LayoutBulkCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> dict:
+    try:
+        return await layouts_service.bulk_create_layouts(
+            db,
+            actor=actor,
+            items=body.items,
+            idempotency_key=body.idempotency_key,
             request_id=getattr(request.state, "request_id", None),
         )
     except ServiceError as exc:

--- a/backend/app/routers/rooms.py
+++ b/backend/app/routers/rooms.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.schemas import RoomCreate, RoomOut, RoomUpdate
+from app.schemas import RoomBulkCreate, RoomBulkOut, RoomCreate, RoomOut, RoomUpdate
 from app.services import rooms_service
 from app.services.errors import ServiceError, to_http_exception
 
@@ -31,6 +31,25 @@ async def create_room(
     try:
         return await rooms_service.create_room(
             db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
+
+
+@router.post("/bulk", response_model=RoomBulkOut, status_code=status.HTTP_201_CREATED)
+async def bulk_create_rooms(
+    body: RoomBulkCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> dict:
+    try:
+        return await rooms_service.bulk_create_rooms(
+            db,
+            actor=actor,
+            items=body.items,
+            idempotency_key=body.idempotency_key,
+            request_id=getattr(request.state, "request_id", None),
         )
     except ServiceError as exc:
         raise to_http_exception(exc) from exc

--- a/backend/app/routers/table_types.py
+++ b/backend/app/routers/table_types.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.schemas import TableTypeCreate, TableTypeOut, TableTypeUpdate
+from app.schemas import TableTypeBulkCreate, TableTypeBulkOut, TableTypeCreate, TableTypeOut, TableTypeUpdate
 from app.services import table_types_service
 from app.services.errors import ServiceError, to_http_exception
 
@@ -31,6 +31,25 @@ async def create_table_type(
     try:
         return await table_types_service.create_table_type(
             db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
+
+
+@router.post("/bulk", response_model=TableTypeBulkOut, status_code=status.HTTP_201_CREATED)
+async def bulk_create_table_types(
+    body: TableTypeBulkCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> dict:
+    try:
+        return await table_types_service.bulk_create_table_types(
+            db,
+            actor=actor,
+            items=body.items,
+            idempotency_key=body.idempotency_key,
+            request_id=getattr(request.state, "request_id", None),
         )
     except ServiceError as exc:
         raise to_http_exception(exc) from exc

--- a/backend/app/routers/tables.py
+++ b/backend/app/routers/tables.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.schemas import TableCreate, TableOut, TableUpdate
+from app.schemas import TableBulkCreate, TableBulkOut, TableCreate, TableOut, TableUpdate
 from app.services import tables_service
 from app.services.errors import ServiceError, to_http_exception
 
@@ -31,6 +31,25 @@ async def create_table(
     try:
         return await tables_service.create_table(
             db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
+
+
+@router.post("/bulk", response_model=TableBulkOut, status_code=status.HTTP_201_CREATED)
+async def bulk_create_tables(
+    body: TableBulkCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(get_actor_id),
+) -> dict:
+    try:
+        return await tables_service.bulk_create_tables(
+            db,
+            actor=actor,
+            items=body.items,
+            idempotency_key=body.idempotency_key,
+            request_id=getattr(request.state, "request_id", None),
         )
     except ServiceError as exc:
         raise to_http_exception(exc) from exc

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -622,6 +622,24 @@ class LayoutOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class LayoutBulkCreate(BaseModel):
+    """Create several layouts in one atomic transaction (#837).
+
+    All items are validated and, within the batch, checked against each other
+    for the same room+day+edition duplication ``create_layout`` already
+    rejects — a failure partway through leaves no layout created. Pass
+    ``idempotency_key`` to safely retry after a timeout or partial failure
+    without risking duplicates.
+    """
+
+    items: list[LayoutCreate] = Field(min_length=1, max_length=200)
+    idempotency_key: str | None = Field(default=None, min_length=1, max_length=200)
+
+
+class LayoutBulkOut(BaseModel):
+    items: list[LayoutOut]
+
+
 # ---------------------------------------------------------------------------
 # Table types
 # ---------------------------------------------------------------------------
@@ -673,6 +691,22 @@ class TableTypeOut(BaseModel):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class TableTypeBulkCreate(BaseModel):
+    """Create several table types in one atomic transaction (#837).
+
+    A failure partway through (e.g. an unknown ``venue_id`` on any item)
+    leaves no table type created. Pass ``idempotency_key`` to safely retry
+    after a timeout or partial failure without risking duplicates.
+    """
+
+    items: list[TableTypeCreate] = Field(min_length=1, max_length=200)
+    idempotency_key: str | None = Field(default=None, min_length=1, max_length=200)
+
+
+class TableTypeBulkOut(BaseModel):
+    items: list[TableTypeOut]
 
 
 # ---------------------------------------------------------------------------
@@ -732,6 +766,23 @@ class TableOut(BaseModel):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class TableBulkCreate(BaseModel):
+    """Create several tables in one atomic transaction (#837).
+
+    A failure partway through (e.g. an unknown ``table_type_id`` or
+    ``layout_id`` on any item) leaves no table created. Pass
+    ``idempotency_key`` to safely retry after a timeout or partial failure
+    without risking duplicates.
+    """
+
+    items: list[TableCreate] = Field(min_length=1, max_length=200)
+    idempotency_key: str | None = Field(default=None, min_length=1, max_length=200)
+
+
+class TableBulkOut(BaseModel):
+    items: list[TableOut]
 
 
 # ---------------------------------------------------------------------------
@@ -918,6 +969,22 @@ class RoomOut(BaseModel):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class RoomBulkCreate(BaseModel):
+    """Create several rooms in one atomic transaction (#837).
+
+    A failure partway through (e.g. an unknown ``venue_id`` on any item)
+    leaves no room created. Pass ``idempotency_key`` to safely retry after a
+    timeout or partial failure without risking duplicates.
+    """
+
+    items: list[RoomCreate] = Field(min_length=1, max_length=200)
+    idempotency_key: str | None = Field(default=None, min_length=1, max_length=200)
+
+
+class RoomBulkOut(BaseModel):
+    items: list[RoomOut]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/idempotency.py
+++ b/backend/app/services/idempotency.py
@@ -1,0 +1,101 @@
+"""Idempotency-key support for bulk/import write operations (#837).
+
+A caller may pass a client-supplied ``idempotency_key`` alongside a bulk
+create request. The first successful call stores its result keyed by
+(``scope``, ``key``); a retried call with the same key and an identical
+request body (detected via a hash of the canonicalised payload) replays that
+stored result instead of re-executing the write, so a retry after a timeout
+or partial failure can't create duplicate records. Reusing the same key with
+a *different* body is rejected as a conflict rather than silently applied or
+silently replayed.
+
+Used by every ``bulk_create_*`` function in ``app.services.*_service`` — see
+those for the pattern: check the key first (short-circuiting all validation
+if it's a safe replay), do the work, then stage the key's result in the same
+transaction as the records it describes via ``record_idempotency_key`` so it
+only becomes visible once the write actually commits.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import IdempotencyKey
+from app.services.errors import ConflictError
+from app.utils import make_id
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return value
+
+
+def hash_request(payload: Any) -> str:
+    """Return a stable hash of a JSON-serialisable request payload."""
+    canonical = json.dumps(_json_safe(payload), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+async def check_idempotency_key(db: AsyncSession, *, scope: str, key: str, request_hash: str) -> dict | None:
+    """Return the stored response to replay, or None if this is a first use.
+
+    Raises ``ConflictError`` if ``key`` was already used within ``scope`` for
+    a request with a different body — that's not a safe retry.
+    """
+    result = await db.execute(select(IdempotencyKey).where(IdempotencyKey.scope == scope, IdempotencyKey.key == key))
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    if row.request_hash != request_hash:
+        raise ConflictError(f"Idempotency key '{key}' was already used for a different request.")
+    return row.response_body
+
+
+def record_idempotency_key(
+    db: AsyncSession, *, scope: str, key: str, actor: str, request_hash: str, response_body: dict
+) -> None:
+    """Stage the (uncommitted) result for (``scope``, ``key``).
+
+    Caller commits as part of the same transaction as the records the
+    response describes — see ``commit_with_idempotency_guard``.
+    """
+    db.add(
+        IdempotencyKey(
+            id=make_id("idem"),
+            scope=scope,
+            key=key,
+            actor=actor,
+            request_hash=request_hash,
+            response_body=_json_safe(response_body),
+        )
+    )
+
+
+async def commit_with_idempotency_guard(db: AsyncSession, *, idempotency_key: str | None) -> None:
+    """Commit, translating a concurrent duplicate-key race into a clean ConflictError.
+
+    Two concurrent retries with the same key can both pass ``check_idempotency_key``
+    (neither has committed yet) and both attempt to insert the same (scope, key)
+    row; the loser hits the unique constraint at commit time rather than earlier.
+    """
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        if idempotency_key:
+            raise ConflictError(
+                f"Idempotency key '{idempotency_key}' is already in use by a concurrent request; retry."
+            ) from exc
+        raise

--- a/backend/app/services/idempotency.py
+++ b/backend/app/services/idempotency.py
@@ -48,16 +48,22 @@ def hash_request(payload: Any) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-async def check_idempotency_key(db: AsyncSession, *, scope: str, key: str, request_hash: str) -> dict | None:
+async def check_idempotency_key(
+    db: AsyncSession, *, scope: str, key: str, actor: str, request_hash: str
+) -> dict | None:
     """Return the stored response to replay, or None if this is a first use.
 
-    Raises ``ConflictError`` if ``key`` was already used within ``scope`` for
-    a request with a different body — that's not a safe retry.
+    Raises ``ConflictError`` if ``key`` was already used within ``scope`` by a
+    *different* actor, or for a request with a different body — neither is a
+    safe retry (the former would otherwise leak one admin's created records to
+    another admin who happens to reuse the same key value).
     """
     result = await db.execute(select(IdempotencyKey).where(IdempotencyKey.scope == scope, IdempotencyKey.key == key))
     row = result.scalar_one_or_none()
     if row is None:
         return None
+    if row.actor != actor:
+        raise ConflictError(f"Idempotency key '{key}' is already in use by another actor.")
     if row.request_hash != request_hash:
         raise ConflictError(f"Idempotency key '{key}' was already used for a different request.")
     return row.response_body
@@ -83,18 +89,43 @@ def record_idempotency_key(
     )
 
 
+_IDEMPOTENCY_CONSTRAINT_NAME = "uq_idempotency_keys_scope_key"
+
+
+def _violates_idempotency_constraint(exc: IntegrityError) -> bool:
+    """Best-effort check that ``exc`` is specifically the (scope, key) unique violation.
+
+    Constraint-name attribute access differs by DB-API driver (e.g. asyncpg
+    nests it under ``exc.orig.__cause__``, psycopg exposes it via
+    ``exc.orig.diag``); fall back to a substring check of the rendered
+    exception so an unrecognised driver shape still classifies correctly
+    rather than silently mismatching every commit-time IntegrityError as an
+    idempotency conflict.
+    """
+    for candidate in (
+        getattr(getattr(exc.orig, "__cause__", None), "constraint_name", None),
+        getattr(exc.orig, "constraint_name", None),
+    ):
+        if candidate is not None:
+            return candidate == _IDEMPOTENCY_CONSTRAINT_NAME
+    return _IDEMPOTENCY_CONSTRAINT_NAME in str(exc)
+
+
 async def commit_with_idempotency_guard(db: AsyncSession, *, idempotency_key: str | None) -> None:
     """Commit, translating a concurrent duplicate-key race into a clean ConflictError.
 
     Two concurrent retries with the same key can both pass ``check_idempotency_key``
     (neither has committed yet) and both attempt to insert the same (scope, key)
     row; the loser hits the unique constraint at commit time rather than earlier.
+    Only that specific constraint is translated — any other IntegrityError (e.g.
+    an unrelated FK violation racing the same commit) is re-raised unchanged so
+    it isn't misreported as an idempotency conflict.
     """
     try:
         await db.commit()
     except IntegrityError as exc:
         await db.rollback()
-        if idempotency_key:
+        if idempotency_key and _violates_idempotency_constraint(exc):
             raise ConflictError(
                 f"Idempotency key '{idempotency_key}' is already in use by a concurrent request; retry."
             ) from exc

--- a/backend/app/services/layouts_service.py
+++ b/backend/app/services/layouts_service.py
@@ -22,7 +22,15 @@ from app.audit import write_audit_entry
 from app.models import Area, Edition, Exhibitor, Layout, Registration, Room, Table, TableType
 from app.schemas import LayoutCopyCreate, LayoutCreate
 from app.services.errors import ConflictError, NotFoundError, ValidationFailedError
+from app.services.idempotency import (
+    check_idempotency_key,
+    commit_with_idempotency_guard,
+    hash_request,
+    record_idempotency_key,
+)
 from app.utils import area_to_dict, layout_to_dict, make_id, table_to_dict
+
+_BULK_SCOPE = "layouts.bulk_create"
 
 # Mirror the rendering constants from frontend/src/utils/layoutUtils.ts so that
 # the backend containment check matches the frontend's hit-testing exactly.
@@ -192,6 +200,82 @@ async def create_layout(
     await db.commit()
     await db.refresh(lay)
     return layout_to_dict(lay, date=resolved_date)
+
+
+async def bulk_create_layouts(
+    db: AsyncSession,
+    *,
+    actor: str,
+    items: list[LayoutCreate],
+    idempotency_key: str | None = None,
+    request_id: str | None = None,
+) -> dict:
+    """Create several layouts in a single transaction; all-or-nothing (#837).
+
+    Rejects duplicate room+day+edition combinations both against existing
+    rows (``_reject_if_duplicate``) and *within* the batch itself, since
+    nothing in the batch is flushed until every item has passed validation.
+    See ``app.services.idempotency`` for the retry-safety contract of
+    ``idempotency_key``.
+    """
+    request_hash = hash_request([item.model_dump(mode="json") for item in items])
+    if idempotency_key:
+        cached = await check_idempotency_key(db, scope=_BULK_SCOPE, key=idempotency_key, request_hash=request_hash)
+        if cached is not None:
+            return cached
+
+    # Lock every referenced room up front — also doubles as the existence
+    # check, same as create_layout.
+    room_ids = {item.room_id for item in items}
+    locked_rooms = await db.execute(select(Room.id).where(Room.id.in_(room_ids)).with_for_update())
+    missing_rooms = room_ids - set(locked_rooms.scalars().all())
+    if missing_rooms:
+        raise NotFoundError(f"Room(s) not found: {sorted(missing_rooms)}.")
+
+    resolved_days: list[int] = []
+    resolved_dates: list[dt_date | None] = []
+    seen_in_batch: set[tuple[str, int, str | None]] = set()
+    for item in items:
+        day_id, date = await resolve_layout_day(db, item)
+        dedupe_key = (item.room_id, day_id, item.edition_id)
+        if dedupe_key in seen_in_batch:
+            raise ConflictError(f"Duplicate layout for room '{item.room_id}' and day {day_id} within this batch.")
+        seen_in_batch.add(dedupe_key)
+        await _reject_if_duplicate(db, room_id=item.room_id, day_id=day_id, edition_id=item.edition_id)
+        resolved_days.append(day_id)
+        resolved_dates.append(date)
+
+    rows = [
+        Layout(
+            id=make_id("lay"),
+            edition_id=item.edition_id,
+            room_id=item.room_id,
+            day_id=day_id,
+            label=item.label.strip(),
+        )
+        for item, day_id in zip(items, resolved_days, strict=True)
+    ]
+    db.add_all(rows)
+    await db.flush()
+
+    for lay in rows:
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="layout_created",
+            resource_type="layout",
+            resource_id=lay.id,
+            request_id=request_id,
+            details={"room_id": lay.room_id, "day_id": lay.day_id, "bulk": True},
+        )
+
+    response = {"items": [layout_to_dict(lay, date=date) for lay, date in zip(rows, resolved_dates, strict=True)]}
+    if idempotency_key:
+        record_idempotency_key(
+            db, scope=_BULK_SCOPE, key=idempotency_key, actor=actor, request_hash=request_hash, response_body=response
+        )
+    await commit_with_idempotency_guard(db, idempotency_key=idempotency_key)
+    return response
 
 
 async def copy_layout(

--- a/backend/app/services/layouts_service.py
+++ b/backend/app/services/layouts_service.py
@@ -220,14 +220,17 @@ async def bulk_create_layouts(
     """
     request_hash = hash_request([item.model_dump(mode="json") for item in items])
     if idempotency_key:
-        cached = await check_idempotency_key(db, scope=_BULK_SCOPE, key=idempotency_key, request_hash=request_hash)
+        cached = await check_idempotency_key(
+            db, scope=_BULK_SCOPE, key=idempotency_key, actor=actor, request_hash=request_hash
+        )
         if cached is not None:
             return cached
 
     # Lock every referenced room up front — also doubles as the existence
-    # check, same as create_layout.
+    # check, same as create_layout. Ordered by id so two overlapping batches
+    # always acquire their locks in the same sequence and can't deadlock.
     room_ids = {item.room_id for item in items}
-    locked_rooms = await db.execute(select(Room.id).where(Room.id.in_(room_ids)).with_for_update())
+    locked_rooms = await db.execute(select(Room.id).where(Room.id.in_(room_ids)).order_by(Room.id).with_for_update())
     missing_rooms = room_ids - set(locked_rooms.scalars().all())
     if missing_rooms:
         raise NotFoundError(f"Room(s) not found: {sorted(missing_rooms)}.")

--- a/backend/app/services/rooms_service.py
+++ b/backend/app/services/rooms_service.py
@@ -71,7 +71,9 @@ async def bulk_create_rooms(
     """
     request_hash = hash_request([item.model_dump(mode="json") for item in items])
     if idempotency_key:
-        cached = await check_idempotency_key(db, scope=_BULK_SCOPE, key=idempotency_key, request_hash=request_hash)
+        cached = await check_idempotency_key(
+            db, scope=_BULK_SCOPE, key=idempotency_key, actor=actor, request_hash=request_hash
+        )
         if cached is not None:
             return cached
 

--- a/backend/app/services/rooms_service.py
+++ b/backend/app/services/rooms_service.py
@@ -15,7 +15,15 @@ from app.audit import write_audit_entry
 from app.models import Layout, Room, Venue
 from app.schemas import RoomCreate, RoomUpdate
 from app.services.errors import ConflictError, NotFoundError
+from app.services.idempotency import (
+    check_idempotency_key,
+    commit_with_idempotency_guard,
+    hash_request,
+    record_idempotency_key,
+)
 from app.utils import make_id, room_to_dict
+
+_BULK_SCOPE = "rooms.bulk_create"
 
 
 async def create_room(db: AsyncSession, *, actor: str, body: RoomCreate, request_id: str | None = None) -> dict:
@@ -46,6 +54,67 @@ async def create_room(db: AsyncSession, *, actor: str, body: RoomCreate, request
     await db.commit()
     await db.refresh(r)
     return room_to_dict(r)
+
+
+async def bulk_create_rooms(
+    db: AsyncSession,
+    *,
+    actor: str,
+    items: list[RoomCreate],
+    idempotency_key: str | None = None,
+    request_id: str | None = None,
+) -> dict:
+    """Create several rooms in a single transaction; all-or-nothing (#837).
+
+    See ``app.services.idempotency`` for the retry-safety contract of
+    ``idempotency_key``.
+    """
+    request_hash = hash_request([item.model_dump(mode="json") for item in items])
+    if idempotency_key:
+        cached = await check_idempotency_key(db, scope=_BULK_SCOPE, key=idempotency_key, request_hash=request_hash)
+        if cached is not None:
+            return cached
+
+    venue_ids = {item.venue_id for item in items}
+    found = await db.execute(select(Venue.id).where(Venue.id.in_(venue_ids)))
+    missing = venue_ids - set(found.scalars().all())
+    if missing:
+        raise NotFoundError(f"Venue(s) not found: {sorted(missing)}.")
+
+    rows = [
+        Room(
+            id=make_id("room"),
+            venue_id=item.venue_id,
+            name=item.name,
+            width_m=item.width_m,
+            length_m=item.length_m,
+            color=item.color,
+            active=item.active,
+            dimensions_placeholder=False,
+        )
+        for item in items
+    ]
+    db.add_all(rows)
+    await db.flush()
+
+    for r in rows:
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="room_created",
+            resource_type="room",
+            resource_id=r.id,
+            request_id=request_id,
+            details={"name": r.name, "venue_id": r.venue_id, "bulk": True},
+        )
+
+    response = {"items": [room_to_dict(r) for r in rows]}
+    if idempotency_key:
+        record_idempotency_key(
+            db, scope=_BULK_SCOPE, key=idempotency_key, actor=actor, request_hash=request_hash, response_body=response
+        )
+    await commit_with_idempotency_guard(db, idempotency_key=idempotency_key)
+    return response
 
 
 async def list_rooms(db: AsyncSession, venue_id: str | None = None) -> list[dict]:

--- a/backend/app/services/table_types_service.py
+++ b/backend/app/services/table_types_service.py
@@ -15,7 +15,15 @@ from app.audit import write_audit_entry
 from app.models import Layout, Room, Table, TableType, Venue
 from app.schemas import TableTypeCreate, TableTypeUpdate
 from app.services.errors import ConflictError, NotFoundError
+from app.services.idempotency import (
+    check_idempotency_key,
+    commit_with_idempotency_guard,
+    hash_request,
+    record_idempotency_key,
+)
 from app.utils import make_id, table_type_to_dict
+
+_BULK_SCOPE = "table_types.bulk_create"
 
 
 async def create_table_type(
@@ -53,6 +61,70 @@ async def create_table_type(
     await db.commit()
     await db.refresh(tt)
     return table_type_to_dict(tt)
+
+
+async def bulk_create_table_types(
+    db: AsyncSession,
+    *,
+    actor: str,
+    items: list[TableTypeCreate],
+    idempotency_key: str | None = None,
+    request_id: str | None = None,
+) -> dict:
+    """Create several table types in a single transaction; all-or-nothing (#837).
+
+    See ``app.services.idempotency`` for the retry-safety contract of
+    ``idempotency_key``.
+    """
+    request_hash = hash_request([item.model_dump(mode="json") for item in items])
+    if idempotency_key:
+        cached = await check_idempotency_key(db, scope=_BULK_SCOPE, key=idempotency_key, request_hash=request_hash)
+        if cached is not None:
+            return cached
+
+    venue_ids = {item.venue_id for item in items}
+    found = await db.execute(select(Venue.id).where(Venue.id.in_(venue_ids)))
+    missing = venue_ids - set(found.scalars().all())
+    if missing:
+        raise NotFoundError(f"Venue(s) not found: {sorted(missing)}.")
+
+    # TableTypeCreate.normalise_dimensions already ran on each item at the
+    # REST/MCP boundary — see create_table_type.
+    rows = [
+        TableType(
+            id=make_id("ttype"),
+            name=item.name,
+            venue_id=item.venue_id,
+            shape=item.shape,
+            width_m=item.width_m,
+            length_m=item.length_m,
+            height_type=item.height_type,
+            max_capacity=item.max_capacity,
+            active=item.active,
+        )
+        for item in items
+    ]
+    db.add_all(rows)
+    await db.flush()
+
+    for tt in rows:
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="table_type_created",
+            resource_type="table_type",
+            resource_id=tt.id,
+            request_id=request_id,
+            details={"name": tt.name, "shape": tt.shape, "venue_id": tt.venue_id, "bulk": True},
+        )
+
+    response = {"items": [table_type_to_dict(tt) for tt in rows]}
+    if idempotency_key:
+        record_idempotency_key(
+            db, scope=_BULK_SCOPE, key=idempotency_key, actor=actor, request_hash=request_hash, response_body=response
+        )
+    await commit_with_idempotency_guard(db, idempotency_key=idempotency_key)
+    return response
 
 
 async def list_table_types(db: AsyncSession, *, limit: int | None = None, offset: int = 0) -> list[dict]:

--- a/backend/app/services/table_types_service.py
+++ b/backend/app/services/table_types_service.py
@@ -78,7 +78,9 @@ async def bulk_create_table_types(
     """
     request_hash = hash_request([item.model_dump(mode="json") for item in items])
     if idempotency_key:
-        cached = await check_idempotency_key(db, scope=_BULK_SCOPE, key=idempotency_key, request_hash=request_hash)
+        cached = await check_idempotency_key(
+            db, scope=_BULK_SCOPE, key=idempotency_key, actor=actor, request_hash=request_hash
+        )
         if cached is not None:
             return cached
 

--- a/backend/app/services/tables_service.py
+++ b/backend/app/services/tables_service.py
@@ -98,7 +98,9 @@ async def bulk_create_tables(
     """
     request_hash = hash_request([item.model_dump(mode="json") for item in items])
     if idempotency_key:
-        cached = await check_idempotency_key(db, scope=_BULK_SCOPE, key=idempotency_key, request_hash=request_hash)
+        cached = await check_idempotency_key(
+            db, scope=_BULK_SCOPE, key=idempotency_key, actor=actor, request_hash=request_hash
+        )
         if cached is not None:
             return cached
 
@@ -106,8 +108,11 @@ async def bulk_create_tables(
     layout_ids = {item.layout_id for item in items}
 
     # Lock the referenced TableType rows so a concurrent delete_table_type can't
-    # race this insert — see create_table.
-    locked_tt = await db.execute(select(TableType.id).where(TableType.id.in_(table_type_ids)).with_for_update())
+    # race this insert — see create_table. Ordered by id so two overlapping
+    # batches always acquire their locks in the same sequence and can't deadlock.
+    locked_tt = await db.execute(
+        select(TableType.id).where(TableType.id.in_(table_type_ids)).order_by(TableType.id).with_for_update()
+    )
     missing_tt = table_type_ids - set(locked_tt.scalars().all())
     if missing_tt:
         raise NotFoundError(f"TableType(s) not found: {sorted(missing_tt)}.")

--- a/backend/app/services/tables_service.py
+++ b/backend/app/services/tables_service.py
@@ -19,9 +19,17 @@ from app.live import mapping as live_mapping
 from app.models import Layout, Registration, Table, TableType
 from app.schemas import TableCreate, TableUpdate
 from app.services.errors import ConflictError, NotFoundError
+from app.services.idempotency import (
+    check_idempotency_key,
+    commit_with_idempotency_guard,
+    hash_request,
+    record_idempotency_key,
+)
 from app.utils import make_id, table_to_dict
 
 logger = logging.getLogger(__name__)
+
+_BULK_SCOPE = "tables.bulk_create"
 
 
 async def _get_layout_edition_id(db: AsyncSession, layout_id: str) -> str | None:
@@ -73,6 +81,86 @@ async def create_table(db: AsyncSession, *, actor: str, body: TableCreate, reque
     await _publish_seating_changed(action="created", table_id=t.id, edition_id=edition_id)
     # New tables have no reservations yet
     return table_to_dict(t, [])
+
+
+async def bulk_create_tables(
+    db: AsyncSession,
+    *,
+    actor: str,
+    items: list[TableCreate],
+    idempotency_key: str | None = None,
+    request_id: str | None = None,
+) -> dict:
+    """Create several tables in a single transaction; all-or-nothing (#837).
+
+    See ``app.services.idempotency`` for the retry-safety contract of
+    ``idempotency_key``.
+    """
+    request_hash = hash_request([item.model_dump(mode="json") for item in items])
+    if idempotency_key:
+        cached = await check_idempotency_key(db, scope=_BULK_SCOPE, key=idempotency_key, request_hash=request_hash)
+        if cached is not None:
+            return cached
+
+    table_type_ids = {item.table_type_id for item in items}
+    layout_ids = {item.layout_id for item in items}
+
+    # Lock the referenced TableType rows so a concurrent delete_table_type can't
+    # race this insert — see create_table.
+    locked_tt = await db.execute(select(TableType.id).where(TableType.id.in_(table_type_ids)).with_for_update())
+    missing_tt = table_type_ids - set(locked_tt.scalars().all())
+    if missing_tt:
+        raise NotFoundError(f"TableType(s) not found: {sorted(missing_tt)}.")
+
+    found_layouts = await db.execute(select(Layout.id, Layout.edition_id).where(Layout.id.in_(layout_ids)))
+    layout_edition_by_id: dict[str, str | None] = {}
+    for layout_id, edition_id in found_layouts.all():
+        layout_edition_by_id[layout_id] = edition_id
+    missing_layouts = layout_ids - set(layout_edition_by_id.keys())
+    if missing_layouts:
+        raise NotFoundError(f"Layout(s) not found: {sorted(missing_layouts)}.")
+
+    rows: list[Table] = []
+    for item in items:
+        t = Table(
+            id=make_id("tbl"),
+            name=item.name,
+            capacity=item.capacity,
+            x=item.x,
+            y=item.y,
+            table_type_id=item.table_type_id,
+            rotation=item.rotation,
+            layout_id=item.layout_id,
+        )
+        t.reservation_ids = []
+        db.add(t)
+        rows.append(t)
+    await db.flush()
+
+    for t in rows:
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="table_created",
+            resource_type="table",
+            resource_id=t.id,
+            request_id=request_id,
+            details={"layout_id": t.layout_id, "name": t.name, "bulk": True},
+        )
+
+    # New tables have no reservations yet.
+    response = {"items": [table_to_dict(t, []) for t in rows]}
+    if idempotency_key:
+        record_idempotency_key(
+            db, scope=_BULK_SCOPE, key=idempotency_key, actor=actor, request_hash=request_hash, response_body=response
+        )
+    await commit_with_idempotency_guard(db, idempotency_key=idempotency_key)
+
+    for t in rows:
+        await _publish_seating_changed(
+            action="created", table_id=t.id, edition_id=layout_edition_by_id.get(t.layout_id)
+        )
+    return response
 
 
 async def list_tables(db: AsyncSession, layout_id: str | None = None) -> list[dict]:

--- a/backend/tests/test_bulk_create.py
+++ b/backend/tests/test_bulk_create.py
@@ -70,6 +70,14 @@ async def test_bulk_create_rooms_rejects_empty_batch(client):
 
 
 @pytest.mark.anyio
+async def test_bulk_create_rooms_rejects_batch_over_limit(client):
+    venue_id = await _create_venue(client)
+    items = [{**ROOM_PAYLOAD, "name": f"Room {i}", "venue_id": venue_id} for i in range(201)]
+    r = await client.post("/api/rooms/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 422
+
+
+@pytest.mark.anyio
 async def test_bulk_create_rooms_idempotency_key_replays_result(client):
     venue_id = await _create_venue(client)
     body = {"items": [{**ROOM_PAYLOAD, "venue_id": venue_id}], "idempotency_key": "retry-key-1"}
@@ -144,6 +152,31 @@ async def test_bulk_create_rooms_stores_idempotency_key_scoped_to_rooms(client, 
     result = await db_session.execute(select(IdempotencyKey).where(IdempotencyKey.key == "scoped-key"))
     row = result.scalar_one()
     assert row.scope == "rooms.bulk_create"
+
+
+@pytest.mark.anyio
+async def test_bulk_create_idempotency_key_isolated_across_scopes(client, db_session):
+    """The same key value reused for a different resource type is a distinct
+    (scope, key) row, not a collision — scope is part of the identity."""
+    venue_id = await _create_venue(client)
+
+    r1 = await client.post(
+        "/api/rooms/bulk",
+        json={"items": [{**ROOM_PAYLOAD, "venue_id": venue_id}], "idempotency_key": "cross-scope-key"},
+        headers=ADMIN_HEADERS,
+    )
+    assert r1.status_code == 201
+
+    r2 = await client.post(
+        "/api/table-types/bulk",
+        json={"items": [{**TABLE_TYPE_PAYLOAD, "venue_id": venue_id}], "idempotency_key": "cross-scope-key"},
+        headers=ADMIN_HEADERS,
+    )
+    assert r2.status_code == 201
+
+    result = await db_session.execute(select(IdempotencyKey).where(IdempotencyKey.key == "cross-scope-key"))
+    rows = result.scalars().all()
+    assert {row.scope for row in rows} == {"rooms.bulk_create", "table_types.bulk_create"}
 
 
 # ---------------------------------------------------------------------------
@@ -363,6 +396,10 @@ async def test_bulk_create_layouts_idempotency_key_replays_result(client):
 
 
 @pytest.mark.anyio
-async def test_bulk_create_endpoints_require_admin(unauth_client):
-    r = await unauth_client.post("/api/rooms/bulk", json={"items": [ROOM_PAYLOAD]})
+@pytest.mark.parametrize(
+    "path",
+    ["/api/rooms/bulk", "/api/table-types/bulk", "/api/tables/bulk", "/api/layouts/bulk"],
+)
+async def test_bulk_create_endpoints_require_admin(unauth_client, path):
+    r = await unauth_client.post(path, json={"items": []})
     assert r.status_code == 401

--- a/backend/tests/test_bulk_create.py
+++ b/backend/tests/test_bulk_create.py
@@ -70,6 +70,15 @@ async def test_bulk_create_rooms_rejects_empty_batch(client):
 
 
 @pytest.mark.anyio
+async def test_bulk_create_rooms_accepts_batch_at_limit(client):
+    venue_id = await _create_venue(client)
+    items = [{**ROOM_PAYLOAD, "name": f"Room {i}", "venue_id": venue_id} for i in range(200)]
+    r = await client.post("/api/rooms/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    assert len(r.json()["items"]) == 200
+
+
+@pytest.mark.anyio
 async def test_bulk_create_rooms_rejects_batch_over_limit(client):
     venue_id = await _create_venue(client)
     items = [{**ROOM_PAYLOAD, "name": f"Room {i}", "venue_id": venue_id} for i in range(201)]

--- a/backend/tests/test_bulk_create.py
+++ b/backend/tests/test_bulk_create.py
@@ -1,0 +1,368 @@
+"""Tests for bulk/import admin write endpoints and idempotency (#837).
+
+Covers the REST surface (``POST /api/<resource>/bulk``) for rooms, table
+types, tables, and layouts: happy-path creation, atomic rollback on a
+partial failure, and idempotency-key replay/conflict semantics. See
+``test_mcp_admin_bulk_create.py`` for the equivalent MCP-surface coverage.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from app.models import IdempotencyKey, Layout, Room, Table, TableType
+from tests.helpers import ADMIN_HEADERS, ROOM_PAYLOAD, TABLE_TYPE_PAYLOAD, VENUE_PAYLOAD
+
+
+async def _create_venue(client) -> str:
+    r = await client.post("/api/venues", json=VENUE_PAYLOAD, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+async def _create_room(client, venue_id: str) -> str:
+    r = await client.post("/api/rooms", json={**ROOM_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Rooms
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_bulk_create_rooms_happy_path(client):
+    venue_id = await _create_venue(client)
+    items = [{**ROOM_PAYLOAD, "name": f"Room {i}", "venue_id": venue_id} for i in range(3)]
+
+    r = await client.post("/api/rooms/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    data = r.json()
+    assert [room["name"] for room in data["items"]] == ["Room 0", "Room 1", "Room 2"]
+    assert all(room["venue_id"] == venue_id for room in data["items"])
+    assert len({room["id"] for room in data["items"]}) == 3
+
+    r = await client.get("/api/rooms", headers=ADMIN_HEADERS)
+    assert len(r.json()) == 3
+
+
+@pytest.mark.anyio
+async def test_bulk_create_rooms_rolls_back_on_partial_failure(client, db_session):
+    venue_id = await _create_venue(client)
+    items = [
+        {**ROOM_PAYLOAD, "name": "Room OK", "venue_id": venue_id},
+        {**ROOM_PAYLOAD, "name": "Room Bad", "venue_id": "venue-missing"},
+    ]
+
+    r = await client.post("/api/rooms/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 404
+
+    result = await db_session.execute(select(Room))
+    assert result.scalars().all() == []
+
+
+@pytest.mark.anyio
+async def test_bulk_create_rooms_rejects_empty_batch(client):
+    r = await client.post("/api/rooms/bulk", json={"items": []}, headers=ADMIN_HEADERS)
+    assert r.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_bulk_create_rooms_idempotency_key_replays_result(client):
+    venue_id = await _create_venue(client)
+    body = {"items": [{**ROOM_PAYLOAD, "venue_id": venue_id}], "idempotency_key": "retry-key-1"}
+
+    r1 = await client.post("/api/rooms/bulk", json=body, headers=ADMIN_HEADERS)
+    assert r1.status_code == 201
+    first = r1.json()
+
+    r2 = await client.post("/api/rooms/bulk", json=body, headers=ADMIN_HEADERS)
+    assert r2.status_code == 201
+    assert r2.json() == first
+
+    r = await client.get("/api/rooms", headers=ADMIN_HEADERS)
+    assert len(r.json()) == 1
+
+
+@pytest.mark.anyio
+async def test_bulk_create_rooms_idempotency_key_reused_with_different_payload_conflicts(client):
+    venue_id = await _create_venue(client)
+    r1 = await client.post(
+        "/api/rooms/bulk",
+        json={"items": [{**ROOM_PAYLOAD, "name": "Room A", "venue_id": venue_id}], "idempotency_key": "shared-key"},
+        headers=ADMIN_HEADERS,
+    )
+    assert r1.status_code == 201
+
+    r2 = await client.post(
+        "/api/rooms/bulk",
+        json={"items": [{**ROOM_PAYLOAD, "name": "Room B", "venue_id": venue_id}], "idempotency_key": "shared-key"},
+        headers=ADMIN_HEADERS,
+    )
+    assert r2.status_code == 409
+
+    r = await client.get("/api/rooms", headers=ADMIN_HEADERS)
+    assert len(r.json()) == 1
+
+
+@pytest.mark.anyio
+async def test_bulk_create_rooms_failed_attempt_does_not_consume_idempotency_key(client):
+    """A validation failure shouldn't burn the key — a corrected retry with the
+    same key must still go through rather than replaying a nonexistent result."""
+    venue_id = await _create_venue(client)
+    key = "retry-after-failure"
+
+    r1 = await client.post(
+        "/api/rooms/bulk",
+        json={"items": [{**ROOM_PAYLOAD, "venue_id": "venue-missing"}], "idempotency_key": key},
+        headers=ADMIN_HEADERS,
+    )
+    assert r1.status_code == 404
+
+    r2 = await client.post(
+        "/api/rooms/bulk",
+        json={"items": [{**ROOM_PAYLOAD, "venue_id": venue_id}], "idempotency_key": key},
+        headers=ADMIN_HEADERS,
+    )
+    assert r2.status_code == 201
+
+    r = await client.get("/api/rooms", headers=ADMIN_HEADERS)
+    assert len(r.json()) == 1
+
+
+@pytest.mark.anyio
+async def test_bulk_create_rooms_stores_idempotency_key_scoped_to_rooms(client, db_session):
+    venue_id = await _create_venue(client)
+    await client.post(
+        "/api/rooms/bulk",
+        json={"items": [{**ROOM_PAYLOAD, "venue_id": venue_id}], "idempotency_key": "scoped-key"},
+        headers=ADMIN_HEADERS,
+    )
+
+    result = await db_session.execute(select(IdempotencyKey).where(IdempotencyKey.key == "scoped-key"))
+    row = result.scalar_one()
+    assert row.scope == "rooms.bulk_create"
+
+
+# ---------------------------------------------------------------------------
+# Table types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_bulk_create_table_types_happy_path(client):
+    venue_id = await _create_venue(client)
+    items = [{**TABLE_TYPE_PAYLOAD, "name": f"Type {i}", "venue_id": venue_id} for i in range(2)]
+
+    r = await client.post("/api/table-types/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    assert [tt["name"] for tt in r.json()["items"]] == ["Type 0", "Type 1"]
+
+    r = await client.get("/api/table-types", headers=ADMIN_HEADERS)
+    assert len(r.json()) == 2
+
+
+@pytest.mark.anyio
+async def test_bulk_create_table_types_rolls_back_on_partial_failure(client, db_session):
+    venue_id = await _create_venue(client)
+    items = [
+        {**TABLE_TYPE_PAYLOAD, "name": "Type OK", "venue_id": venue_id},
+        {**TABLE_TYPE_PAYLOAD, "name": "Type Bad", "venue_id": "venue-missing"},
+    ]
+
+    r = await client.post("/api/table-types/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 404
+
+    result = await db_session.execute(select(TableType))
+    assert result.scalars().all() == []
+
+
+@pytest.mark.anyio
+async def test_bulk_create_table_types_normalises_round_dimensions(client):
+    """Bulk creation must apply the same shape-dimension normalisation as a single create."""
+    venue_id = await _create_venue(client)
+    items = [{**TABLE_TYPE_PAYLOAD, "venue_id": venue_id, "shape": "round", "width_m": 1.5, "length_m": 0.9}]
+
+    r = await client.post("/api/table-types/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    tt = r.json()["items"][0]
+    assert tt["width_m"] == tt["length_m"] == 1.5
+
+
+@pytest.mark.anyio
+async def test_bulk_create_table_types_idempotency_key_replays_result(client):
+    venue_id = await _create_venue(client)
+    body = {"items": [{**TABLE_TYPE_PAYLOAD, "venue_id": venue_id}], "idempotency_key": "tt-retry-key"}
+
+    r1 = await client.post("/api/table-types/bulk", json=body, headers=ADMIN_HEADERS)
+    assert r1.status_code == 201
+
+    r2 = await client.post("/api/table-types/bulk", json=body, headers=ADMIN_HEADERS)
+    assert r2.status_code == 201
+    assert r2.json() == r1.json()
+
+    r = await client.get("/api/table-types", headers=ADMIN_HEADERS)
+    assert len(r.json()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tables
+# ---------------------------------------------------------------------------
+
+
+async def _create_table_type(client, venue_id: str) -> str:
+    r = await client.post("/api/table-types", json={**TABLE_TYPE_PAYLOAD, "venue_id": venue_id}, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+async def _create_layout(client, room_id: str, day_id: int = 1) -> str:
+    r = await client.post("/api/layouts", json={"room_id": room_id, "day_id": day_id}, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+@pytest.mark.anyio
+async def test_bulk_create_tables_happy_path(client):
+    venue_id = await _create_venue(client)
+    room_id = await _create_room(client, venue_id)
+    table_type_id = await _create_table_type(client, venue_id)
+    layout_id = await _create_layout(client, room_id)
+
+    items = [
+        {"name": f"Table {i}", "capacity": 4, "table_type_id": table_type_id, "layout_id": layout_id} for i in range(4)
+    ]
+    r = await client.post("/api/tables/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    data = r.json()
+    assert [t["name"] for t in data["items"]] == [f"Table {i}" for i in range(4)]
+    assert all(t["registration_ids"] == [] for t in data["items"])
+
+    r = await client.get("/api/tables", params={"layout_id": layout_id}, headers=ADMIN_HEADERS)
+    assert len(r.json()) == 4
+
+
+@pytest.mark.anyio
+async def test_bulk_create_tables_rolls_back_on_partial_failure(client, db_session):
+    venue_id = await _create_venue(client)
+    room_id = await _create_room(client, venue_id)
+    table_type_id = await _create_table_type(client, venue_id)
+    layout_id = await _create_layout(client, room_id)
+
+    items = [
+        {"name": "Table OK", "capacity": 4, "table_type_id": table_type_id, "layout_id": layout_id},
+        {"name": "Table Bad", "capacity": 4, "table_type_id": table_type_id, "layout_id": "layout-missing"},
+    ]
+    r = await client.post("/api/tables/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 404
+
+    result = await db_session.execute(select(Table))
+    assert result.scalars().all() == []
+
+
+@pytest.mark.anyio
+async def test_bulk_create_tables_idempotency_key_replays_result(client):
+    venue_id = await _create_venue(client)
+    room_id = await _create_room(client, venue_id)
+    table_type_id = await _create_table_type(client, venue_id)
+    layout_id = await _create_layout(client, room_id)
+
+    body = {
+        "items": [{"name": "Table A", "capacity": 4, "table_type_id": table_type_id, "layout_id": layout_id}],
+        "idempotency_key": "table-retry-key",
+    }
+    r1 = await client.post("/api/tables/bulk", json=body, headers=ADMIN_HEADERS)
+    assert r1.status_code == 201
+
+    r2 = await client.post("/api/tables/bulk", json=body, headers=ADMIN_HEADERS)
+    assert r2.status_code == 201
+    assert r2.json() == r1.json()
+
+    r = await client.get("/api/tables", params={"layout_id": layout_id}, headers=ADMIN_HEADERS)
+    assert len(r.json()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Layouts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_bulk_create_layouts_happy_path(client):
+    venue_id = await _create_venue(client)
+    room_a = await _create_room(client, venue_id)
+    room_b = await _create_room(client, venue_id)
+
+    items = [{"room_id": room_a, "day_id": 1}, {"room_id": room_b, "day_id": 1}]
+    r = await client.post("/api/layouts/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+    assert {lay["room_id"] for lay in r.json()["items"]} == {room_a, room_b}
+
+    r = await client.get("/api/layouts", headers=ADMIN_HEADERS)
+    assert len(r.json()) == 2
+
+
+@pytest.mark.anyio
+async def test_bulk_create_layouts_rolls_back_on_partial_failure(client, db_session):
+    venue_id = await _create_venue(client)
+    room_id = await _create_room(client, venue_id)
+
+    items = [{"room_id": room_id, "day_id": 1}, {"room_id": "room-missing", "day_id": 1}]
+    r = await client.post("/api/layouts/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 404
+
+    result = await db_session.execute(select(Layout))
+    assert result.scalars().all() == []
+
+
+@pytest.mark.anyio
+async def test_bulk_create_layouts_rejects_duplicate_within_batch(client, db_session):
+    venue_id = await _create_venue(client)
+    room_id = await _create_room(client, venue_id)
+
+    items = [{"room_id": room_id, "day_id": 1}, {"room_id": room_id, "day_id": 1}]
+    r = await client.post("/api/layouts/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 409
+
+    result = await db_session.execute(select(Layout))
+    assert result.scalars().all() == []
+
+
+@pytest.mark.anyio
+async def test_bulk_create_layouts_rejects_duplicate_against_existing(client, db_session):
+    venue_id = await _create_venue(client)
+    room_id = await _create_room(client, venue_id)
+    await _create_layout(client, room_id, day_id=1)
+
+    items = [{"room_id": room_id, "day_id": 2}, {"room_id": room_id, "day_id": 1}]
+    r = await client.post("/api/layouts/bulk", json={"items": items}, headers=ADMIN_HEADERS)
+    assert r.status_code == 409
+
+    result = await db_session.execute(select(Layout))
+    # Only the pre-existing layout survives — the batch's own valid item never committed.
+    assert len(result.scalars().all()) == 1
+
+
+@pytest.mark.anyio
+async def test_bulk_create_layouts_idempotency_key_replays_result(client):
+    venue_id = await _create_venue(client)
+    room_id = await _create_room(client, venue_id)
+
+    body = {"items": [{"room_id": room_id, "day_id": 1}], "idempotency_key": "layout-retry-key"}
+    r1 = await client.post("/api/layouts/bulk", json=body, headers=ADMIN_HEADERS)
+    assert r1.status_code == 201
+
+    r2 = await client.post("/api/layouts/bulk", json=body, headers=ADMIN_HEADERS)
+    assert r2.status_code == 201
+    assert r2.json() == r1.json()
+
+    r = await client.get("/api/layouts", headers=ADMIN_HEADERS)
+    assert len(r.json()) == 1
+
+
+@pytest.mark.anyio
+async def test_bulk_create_endpoints_require_admin(unauth_client):
+    r = await unauth_client.post("/api/rooms/bulk", json={"items": [ROOM_PAYLOAD]})
+    assert r.status_code == 401

--- a/backend/tests/test_mcp_admin_bulk_create.py
+++ b/backend/tests/test_mcp_admin_bulk_create.py
@@ -17,6 +17,7 @@ from app.mcp.admin import layouts as mcp_layouts
 from app.mcp.admin import rooms as mcp_rooms
 from app.mcp.admin import table_types as mcp_table_types
 from app.mcp.admin import tables as mcp_tables
+from app.mcp.utils import MCPToolError
 from app.models import IdempotencyKey, Layout, Room, Table, TableType, Venue
 from app.schemas import LayoutCreate, RoomCreate, TableCreate, TableTypeCreate
 from tests.helpers import mcp_session_factory
@@ -97,7 +98,7 @@ async def test_bulk_create_rooms_rolls_back_on_partial_failure(db_session):
         RoomCreate(venue_id="venue-1", name="Room A", width_m=10, length_m=10),
         RoomCreate(venue_id="nonexistent", name="Room B", width_m=10, length_m=10),
     ]
-    with pytest.raises(ValueError, match="not found"):
+    with pytest.raises(MCPToolError, match="not found"):
         await mcp_rooms.bulk_create_rooms(factory, "admin-1", items=items)
 
     rows = (await db_session.execute(select(Room))).scalars().all()
@@ -127,7 +128,7 @@ async def test_bulk_create_rooms_idempotency_key_reused_with_different_payload_c
         items=[RoomCreate(venue_id="venue-1", name="Room A", width_m=10, length_m=10)],
         idempotency_key="shared-key",
     )
-    with pytest.raises(ValueError, match="different request"):
+    with pytest.raises(MCPToolError, match="different request"):
         await mcp_rooms.bulk_create_rooms(
             factory,
             "admin-1",
@@ -137,6 +138,35 @@ async def test_bulk_create_rooms_idempotency_key_reused_with_different_payload_c
 
     rows = (await db_session.execute(select(Room))).scalars().all()
     assert len(rows) == 1
+
+
+async def test_bulk_create_rooms_idempotency_key_reused_by_different_actor_conflicts(db_session):
+    """A key is scoped per-actor: a different admin reusing the same key value
+    (even with the same request body) must not silently replay another
+    admin's cached result."""
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    items = [RoomCreate(venue_id="venue-1", name="Room A", width_m=10, length_m=10)]
+
+    await mcp_rooms.bulk_create_rooms(factory, "admin-a", items=items, idempotency_key="actor-scoped-key")
+    with pytest.raises(MCPToolError, match="another actor"):
+        await mcp_rooms.bulk_create_rooms(factory, "admin-b", items=items, idempotency_key="actor-scoped-key")
+
+    rows = (await db_session.execute(select(Room))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_bulk_create_rooms_rejects_batch_over_limit(db_session):
+    """The MCP surface enforces the same 200-item cap as the REST endpoint (#837 review)."""
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    items = [RoomCreate(venue_id="venue-1", name=f"Room {i}", width_m=10, length_m=10) for i in range(201)]
+
+    with pytest.raises(MCPToolError):
+        await mcp_rooms.bulk_create_rooms(factory, "admin-1", items=items)
+
+    rows = (await db_session.execute(select(Room))).scalars().all()
+    assert rows == []
 
 
 async def test_bulk_create_rooms_stores_idempotency_key_scoped_to_rooms(db_session):
@@ -181,7 +211,7 @@ async def test_bulk_create_table_types_rolls_back_on_partial_failure(db_session)
         TableTypeCreate(venue_id="venue-1", name="Type A", width_m=0.7, length_m=1.8, max_capacity=6),
         TableTypeCreate(venue_id="nonexistent", name="Type B", width_m=0.7, length_m=1.8, max_capacity=6),
     ]
-    with pytest.raises(ValueError, match="not found"):
+    with pytest.raises(MCPToolError, match="not found"):
         await mcp_table_types.bulk_create_table_types(factory, "admin-1", items=items)
 
     rows = (await db_session.execute(select(TableType))).scalars().all()
@@ -236,7 +266,7 @@ async def test_bulk_create_tables_rolls_back_on_partial_failure(db_session):
         TableCreate(name="Table A", capacity=4, table_type_id="ttype-1", layout_id="lay-1"),
         TableCreate(name="Table B", capacity=4, table_type_id="ttype-1", layout_id="nonexistent"),
     ]
-    with pytest.raises(ValueError, match="not found"):
+    with pytest.raises(MCPToolError, match="not found"):
         await mcp_tables.bulk_create_tables(factory, "admin-1", items=items)
 
     rows = (await db_session.execute(select(Table))).scalars().all()
@@ -283,7 +313,7 @@ async def test_bulk_create_layouts_rejects_duplicate_within_batch(db_session):
     await _seed_room(db_session)
 
     items = [LayoutCreate(room_id="room-1", day_id=1), LayoutCreate(room_id="room-1", day_id=1)]
-    with pytest.raises(ValueError, match="Duplicate layout"):
+    with pytest.raises(MCPToolError, match="Duplicate layout"):
         await mcp_layouts.bulk_create_layouts(factory, "admin-1", items=items)
 
     rows = (await db_session.execute(select(Layout))).scalars().all()
@@ -296,7 +326,7 @@ async def test_bulk_create_layouts_rolls_back_on_partial_failure(db_session):
     await _seed_room(db_session)
 
     items = [LayoutCreate(room_id="room-1", day_id=1), LayoutCreate(room_id="nonexistent", day_id=1)]
-    with pytest.raises(ValueError, match="not found"):
+    with pytest.raises(MCPToolError, match="not found"):
         await mcp_layouts.bulk_create_layouts(factory, "admin-1", items=items)
 
     rows = (await db_session.execute(select(Layout))).scalars().all()

--- a/backend/tests/test_mcp_admin_bulk_create.py
+++ b/backend/tests/test_mcp_admin_bulk_create.py
@@ -1,0 +1,317 @@
+"""Tests for the admin (write) bulk-create MCP tools (#837).
+
+Mirrors ``test_bulk_create.py`` (the REST surface) so both surfaces are
+verified against the same atomicity/idempotency contract. Business logic
+lives in ``app.services.*_service.bulk_create_*`` and is shared with REST.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from app.mcp.admin import layouts as mcp_layouts
+from app.mcp.admin import rooms as mcp_rooms
+from app.mcp.admin import table_types as mcp_table_types
+from app.mcp.admin import tables as mcp_tables
+from app.models import IdempotencyKey, Layout, Room, Table, TableType, Venue
+from app.schemas import LayoutCreate, RoomCreate, TableCreate, TableTypeCreate
+from tests.helpers import mcp_session_factory
+
+
+def _normalize(value: Any) -> Any:
+    """Recursively convert datetime/date values to ISO strings.
+
+    A replayed idempotent result comes back with the timestamps it was
+    stored with (already ISO strings, see ``app.services.idempotency``),
+    while a fresh call returns live ``datetime`` objects — normalising both
+    lets the tests assert the results are equivalent regardless of which
+    Python type carries the timestamp (the wire format is identical either
+    way once FastMCP serialises the response to JSON).
+    """
+    if isinstance(value, dict):
+        return {k: _normalize(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_normalize(v) for v in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return value
+
+
+async def _seed_venue(db_session, venue_id: str = "venue-1") -> Venue:
+    venue = Venue(id=venue_id, name="Test Venue")
+    db_session.add(venue)
+    await db_session.commit()
+    return venue
+
+
+async def _seed_room(db_session, venue_id: str = "venue-1", room_id: str = "room-1") -> Room:
+    room = Room(id=room_id, venue_id=venue_id, name="Main Hall", width_m=25.0, length_m=18.0)
+    db_session.add(room)
+    await db_session.commit()
+    return room
+
+
+async def _seed_table_type(db_session, venue_id: str = "venue-1", type_id: str = "ttype-1") -> TableType:
+    tt = TableType(id=type_id, name="Standard", venue_id=venue_id, width_m=0.7, length_m=1.8, max_capacity=6)
+    db_session.add(tt)
+    await db_session.commit()
+    return tt
+
+
+async def _seed_layout(db_session, room_id: str = "room-1", layout_id: str = "lay-1", day_id: int = 1) -> Layout:
+    lay = Layout(id=layout_id, edition_id=None, room_id=room_id, day_id=day_id)
+    db_session.add(lay)
+    await db_session.commit()
+    return lay
+
+
+# ---------------------------------------------------------------------------
+# Rooms
+# ---------------------------------------------------------------------------
+
+
+async def test_bulk_create_rooms_happy_path(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+
+    items = [
+        RoomCreate(venue_id="venue-1", name="Room A", width_m=10, length_m=10),
+        RoomCreate(venue_id="venue-1", name="Room B", width_m=12, length_m=12),
+    ]
+    result = await mcp_rooms.bulk_create_rooms(factory, "admin-1", items=items)
+    assert [r["name"] for r in result["items"]] == ["Room A", "Room B"]
+
+    rows = (await db_session.execute(select(Room))).scalars().all()
+    assert len(rows) == 2
+
+
+async def test_bulk_create_rooms_rolls_back_on_partial_failure(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+
+    items = [
+        RoomCreate(venue_id="venue-1", name="Room A", width_m=10, length_m=10),
+        RoomCreate(venue_id="nonexistent", name="Room B", width_m=10, length_m=10),
+    ]
+    with pytest.raises(ValueError, match="not found"):
+        await mcp_rooms.bulk_create_rooms(factory, "admin-1", items=items)
+
+    rows = (await db_session.execute(select(Room))).scalars().all()
+    assert rows == []
+
+
+async def test_bulk_create_rooms_idempotency_key_replays_result(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    items = [RoomCreate(venue_id="venue-1", name="Room A", width_m=10, length_m=10)]
+
+    first = await mcp_rooms.bulk_create_rooms(factory, "admin-1", items=items, idempotency_key="mcp-retry-key")
+    second = await mcp_rooms.bulk_create_rooms(factory, "admin-1", items=items, idempotency_key="mcp-retry-key")
+    assert _normalize(second) == _normalize(first)
+
+    rows = (await db_session.execute(select(Room))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_bulk_create_rooms_idempotency_key_reused_with_different_payload_conflicts(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+
+    await mcp_rooms.bulk_create_rooms(
+        factory,
+        "admin-1",
+        items=[RoomCreate(venue_id="venue-1", name="Room A", width_m=10, length_m=10)],
+        idempotency_key="shared-key",
+    )
+    with pytest.raises(ValueError, match="different request"):
+        await mcp_rooms.bulk_create_rooms(
+            factory,
+            "admin-1",
+            items=[RoomCreate(venue_id="venue-1", name="Room B", width_m=10, length_m=10)],
+            idempotency_key="shared-key",
+        )
+
+    rows = (await db_session.execute(select(Room))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_bulk_create_rooms_stores_idempotency_key_scoped_to_rooms(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    await mcp_rooms.bulk_create_rooms(
+        factory,
+        "admin-1",
+        items=[RoomCreate(venue_id="venue-1", name="Room A", width_m=10, length_m=10)],
+        idempotency_key="scoped-key",
+    )
+
+    row = (await db_session.execute(select(IdempotencyKey).where(IdempotencyKey.key == "scoped-key"))).scalar_one()
+    assert row.scope == "rooms.bulk_create"
+
+
+# ---------------------------------------------------------------------------
+# Table types
+# ---------------------------------------------------------------------------
+
+
+async def test_bulk_create_table_types_happy_path(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+
+    items = [
+        TableTypeCreate(venue_id="venue-1", name="Type A", width_m=0.7, length_m=1.8, max_capacity=6),
+        TableTypeCreate(venue_id="venue-1", name="Type B", width_m=0.7, length_m=1.8, max_capacity=8),
+    ]
+    result = await mcp_table_types.bulk_create_table_types(factory, "admin-1", items=items)
+    assert [tt["name"] for tt in result["items"]] == ["Type A", "Type B"]
+
+    rows = (await db_session.execute(select(TableType))).scalars().all()
+    assert len(rows) == 2
+
+
+async def test_bulk_create_table_types_rolls_back_on_partial_failure(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+
+    items = [
+        TableTypeCreate(venue_id="venue-1", name="Type A", width_m=0.7, length_m=1.8, max_capacity=6),
+        TableTypeCreate(venue_id="nonexistent", name="Type B", width_m=0.7, length_m=1.8, max_capacity=6),
+    ]
+    with pytest.raises(ValueError, match="not found"):
+        await mcp_table_types.bulk_create_table_types(factory, "admin-1", items=items)
+
+    rows = (await db_session.execute(select(TableType))).scalars().all()
+    assert rows == []
+
+
+async def test_bulk_create_table_types_idempotency_key_replays_result(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    items = [TableTypeCreate(venue_id="venue-1", name="Type A", width_m=0.7, length_m=1.8, max_capacity=6)]
+
+    first = await mcp_table_types.bulk_create_table_types(factory, "admin-1", items=items, idempotency_key="tt-key")
+    second = await mcp_table_types.bulk_create_table_types(factory, "admin-1", items=items, idempotency_key="tt-key")
+    assert _normalize(second) == _normalize(first)
+
+    rows = (await db_session.execute(select(TableType))).scalars().all()
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tables
+# ---------------------------------------------------------------------------
+
+
+async def test_bulk_create_tables_happy_path(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    await _seed_room(db_session)
+    await _seed_table_type(db_session)
+    await _seed_layout(db_session)
+
+    items = [
+        TableCreate(name="Table A", capacity=4, table_type_id="ttype-1", layout_id="lay-1"),
+        TableCreate(name="Table B", capacity=4, table_type_id="ttype-1", layout_id="lay-1"),
+    ]
+    result = await mcp_tables.bulk_create_tables(factory, "admin-1", items=items)
+    assert [t["name"] for t in result["items"]] == ["Table A", "Table B"]
+    assert all(t["registration_ids"] == [] for t in result["items"])
+
+    rows = (await db_session.execute(select(Table))).scalars().all()
+    assert len(rows) == 2
+
+
+async def test_bulk_create_tables_rolls_back_on_partial_failure(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    await _seed_room(db_session)
+    await _seed_table_type(db_session)
+    await _seed_layout(db_session)
+
+    items = [
+        TableCreate(name="Table A", capacity=4, table_type_id="ttype-1", layout_id="lay-1"),
+        TableCreate(name="Table B", capacity=4, table_type_id="ttype-1", layout_id="nonexistent"),
+    ]
+    with pytest.raises(ValueError, match="not found"):
+        await mcp_tables.bulk_create_tables(factory, "admin-1", items=items)
+
+    rows = (await db_session.execute(select(Table))).scalars().all()
+    assert rows == []
+
+
+async def test_bulk_create_tables_idempotency_key_replays_result(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    await _seed_room(db_session)
+    await _seed_table_type(db_session)
+    await _seed_layout(db_session)
+    items = [TableCreate(name="Table A", capacity=4, table_type_id="ttype-1", layout_id="lay-1")]
+
+    first = await mcp_tables.bulk_create_tables(factory, "admin-1", items=items, idempotency_key="table-key")
+    second = await mcp_tables.bulk_create_tables(factory, "admin-1", items=items, idempotency_key="table-key")
+    assert _normalize(second) == _normalize(first)
+
+    rows = (await db_session.execute(select(Table))).scalars().all()
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Layouts
+# ---------------------------------------------------------------------------
+
+
+async def test_bulk_create_layouts_happy_path(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    await _seed_room(db_session)
+
+    items = [LayoutCreate(room_id="room-1", day_id=1), LayoutCreate(room_id="room-1", day_id=2)]
+    result = await mcp_layouts.bulk_create_layouts(factory, "admin-1", items=items)
+    assert [lay["day_id"] for lay in result["items"]] == [1, 2]
+
+    rows = (await db_session.execute(select(Layout))).scalars().all()
+    assert len(rows) == 2
+
+
+async def test_bulk_create_layouts_rejects_duplicate_within_batch(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    await _seed_room(db_session)
+
+    items = [LayoutCreate(room_id="room-1", day_id=1), LayoutCreate(room_id="room-1", day_id=1)]
+    with pytest.raises(ValueError, match="Duplicate layout"):
+        await mcp_layouts.bulk_create_layouts(factory, "admin-1", items=items)
+
+    rows = (await db_session.execute(select(Layout))).scalars().all()
+    assert rows == []
+
+
+async def test_bulk_create_layouts_rolls_back_on_partial_failure(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    await _seed_room(db_session)
+
+    items = [LayoutCreate(room_id="room-1", day_id=1), LayoutCreate(room_id="nonexistent", day_id=1)]
+    with pytest.raises(ValueError, match="not found"):
+        await mcp_layouts.bulk_create_layouts(factory, "admin-1", items=items)
+
+    rows = (await db_session.execute(select(Layout))).scalars().all()
+    assert rows == []
+
+
+async def test_bulk_create_layouts_idempotency_key_replays_result(db_session):
+    factory = mcp_session_factory(db_session)
+    await _seed_venue(db_session)
+    await _seed_room(db_session)
+    items = [LayoutCreate(room_id="room-1", day_id=1)]
+
+    first = await mcp_layouts.bulk_create_layouts(factory, "admin-1", items=items, idempotency_key="layout-key")
+    second = await mcp_layouts.bulk_create_layouts(factory, "admin-1", items=items, idempotency_key="layout-key")
+    assert _normalize(second) == _normalize(first)
+
+    rows = (await db_session.execute(select(Layout))).scalars().all()
+    assert len(rows) == 1


### PR DESCRIPTION
## Summary

Closes #837. Adds bulk/import write operations for the record types most commonly set up in batch — rooms, table types, tables, and floor-plan layouts — with an idempotency-key mechanism, on both REST and MCP:

- `POST /api/rooms/bulk`, `/api/table-types/bulk`, `/api/tables/bulk`, `/api/layouts/bulk`, plus matching `bulk_create_rooms` / `bulk_create_table_types` / `bulk_create_tables` / `bulk_create_layouts` MCP tools.
- Each bulk operation validates every item up front and commits once, atomically: a failure partway through (e.g. an unknown `venue_id` on item 3 of 5) leaves **no** records created, not a partial batch.
- An optional `idempotency_key` on the request lets a retried call (after a timeout or partial failure) replay the original result instead of creating duplicates. Reusing the same key with a *different* request body is rejected as a 409 conflict rather than silently applied or silently replayed. A validation failure never consumes the key, so a corrected retry with the same key still goes through.
- Layouts additionally reject duplicate room+day+edition combinations both against existing rows and *within* the same batch.
- The idempotency mechanism (`app/services/idempotency.py`, backed by a new `idempotency_keys` table) is generic and shared identically across all four bulk operations, and both surfaces delegate to the same `app/services/*_service.py` functions — following the existing REST/MCP thin-adapter-over-a-shared-service pattern from #807.

## Implementation notes

- New model `IdempotencyKey` (`scope`, `key`, `request_hash`, `response_body`), unique on `(scope, key)`, added via migration `013_add_idempotency_keys`.
- New bulk schemas (`RoomBulkCreate`/`Out`, etc.) reuse the existing per-item `*Create`/`*Out` schemas and their validators (e.g. `TableTypeCreate`'s round-shape dimension normalisation) unchanged.
- Batches are capped at 200 items via schema `Field(min_length=1, max_length=200)`.
- A concurrent race on the same idempotency key (two retries landing at once) is caught at commit time and translated into a clean `ConflictError` rather than a raw `IntegrityError`.
- `bulk_create_` was added to the MCP tool-name prefixes that get the non-destructive write annotation, alongside the existing `create_`/`copy_` prefixes.

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check .`
- [x] `uv run alembic upgrade head` / `uv run alembic check` (models match migrations)
- [x] `uv run pytest` — full suite (863 tests) passes
- [x] New `tests/test_bulk_create.py` (REST) and `tests/test_mcp_admin_bulk_create.py` (MCP) cover: happy-path creation, atomic rollback on partial failure, idempotency-key replay, key-reuse-with-different-payload conflict, and (for layouts) in-batch duplicate rejection

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FPbK5MLcpDNWRHSGPbnyC7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPbK5MLcpDNWRHSGPbnyC7)_