### PR TITLE
Extract shared REST/MCP application-service logic across all admin domains

### DIFF
--- a/backend/alembic/versions/014_renormalise_person_identity_fields.py
+++ b/backend/alembic/versions/014_renormalise_person_identity_fields.py
@@ -1,0 +1,85 @@
+"""Renormalise Person.national_register_number/eid_document_number.
+
+`app.services.people_service.normalise_optional_identity` strips separators
+(space/dot/hyphen/slash) and lowercases these two columns before storing them
+and before checking `people`'s unique constraints on them. Until #866,
+`app.services.members_service`/`app.services.volunteers_service` only
+stripped surrounding whitespace before storing — e.g. a member created with
+`"93.05.18-223.61"` and a person created with `"93051822361"` were the same
+real-world identity but compared unequal, so both could exist and the unique
+constraint never caught the collision.
+
+This renormalises every existing row to the stricter form so the constraint
+stays valid once all three call sites agree on it. A row is only rewritten
+when renormalising doesn't collide with another row's *already-normalised*
+value — a genuine pre-existing duplicate identity that only differed by
+formatting is left as-is (both flavours of case predate this migration
+either way) rather than silently merged; see
+`app.services.people_service.merge_people` for resolving those by hand. Scans
+`national_register_number`/`eid_document_number` independently since a
+collision on one column doesn't imply a collision on the other.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "014"
+down_revision: str | None = "013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_COLUMNS = ("national_register_number", "eid_document_number")
+
+
+def _normalise(value: str) -> str:
+    for ch in (" ", ".", "-", "/"):
+        value = value.replace(ch, "")
+    value = value.strip().lower()
+    return value
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    people = sa.table(
+        "people",
+        sa.column("id", sa.String),
+        sa.column("national_register_number", sa.String),
+        sa.column("eid_document_number", sa.String),
+    )
+
+    for column_name in _COLUMNS:
+        column = people.c[column_name]
+        rows = conn.execute(sa.select(people.c.id, column).where(column.isnot(None))).all()
+
+        by_normalised: dict[str, list[tuple[str, str]]] = defaultdict(list)
+        for row_id, raw_value in rows:
+            normalised = _normalise(raw_value)
+            if normalised:
+                by_normalised[normalised].append((row_id, raw_value))
+
+        for normalised_value, entries in by_normalised.items():
+            if len(entries) > 1:
+                # Genuine pre-existing duplicate identity across differently
+                # formatted values — applying the stricter form here would
+                # violate the column's unique constraint. Leave these rows
+                # untouched; they need a manual merge_people call, not a
+                # migration silently picking a winner.
+                continue
+            row_id, raw_value = entries[0]
+            if raw_value == normalised_value:
+                continue
+            conn.execute(people.update().where(people.c.id == row_id).values(**{column_name: normalised_value}))
+
+
+def downgrade() -> None:
+    # Renormalisation discards the original separator/casing, so there's no
+    # recorded prior value to restore. The renormalised form is still a
+    # valid, equivalent identity value, so leaving it in place on downgrade
+    # is safe — there is nothing else for this step to reasonably do.
+    pass

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -2,10 +2,20 @@
 
 from typing import Any, TypeVar
 
-from fastapi import HTTPException, Query, status
+from fastapi import HTTPException, Query, Request, status
 from sqlalchemy.sql import Select
 
 SelectT = TypeVar("SelectT", bound=Select[Any])
+
+
+def get_request_id(request: Request) -> str | None:
+    """The request id set by ``app.observability``'s middleware, or ``None``.
+
+    The ``getattr`` default guards contexts where that middleware didn't run
+    (e.g. some test setups) rather than assuming ``request.state.request_id``
+    always exists.
+    """
+    return getattr(request.state, "request_id", None)
 
 
 class Pagination:

--- a/backend/app/mcp/admin/editions.py
+++ b/backend/app/mcp/admin/editions.py
@@ -19,7 +19,6 @@ from typing import Any
 
 from fastapi import HTTPException
 
-from app.audit import write_audit_entry
 from app.mcp.utils import MCPToolError, as_value_error, validate_with_schema
 from app.schemas import EditionCreate, EditionType, EditionUpdate
 from app.services import editions_service
@@ -123,16 +122,6 @@ async def delete_edition(session_factory: Any, actor: str, edition_id: str) -> d
     async with session_factory() as db:
         try:
             edition = await editions_service.get_edition_or_404(db, edition_id)
+            return await editions_service.delete_edition(db, edition, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-        await db.delete(edition)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="edition_deleted",
-            resource_type="edition",
-            resource_id=edition_id,
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": edition_id}

--- a/backend/app/mcp/admin/editions.py
+++ b/backend/app/mcp/admin/editions.py
@@ -1,9 +1,10 @@
 """Admin (write) MCP tool implementations for edition management.
 
-Mirrors ``app.routers.editions``. The edition response payload is built by
-``_edition_payload`` (venue + exhibitor lookups, dates derived from events),
-so ``get_edition``/``create_edition``/``update_edition`` reuse that helper
-(and ``_get_edition_or_404``) directly rather than re-deriving it.
+Mirrors ``app.routers.editions``. Business logic — the create/update
+transition, payload building, and shared lookup/validation helpers — lives in
+``app.services.editions_service`` and is shared with the REST router; this
+module is responsible only for validating MCP kwargs into a schema instance
+and translating ``HTTPException`` into ``MCPToolError`` at its own boundary.
 
 Partial-update convention differs slightly from strict REST ``model_fields_set``
 semantics for ``exhibitors``: MCP tool kwargs can't distinguish "omitted" from
@@ -17,22 +18,11 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import HTTPException
-from sqlalchemy import select
 
 from app.audit import write_audit_entry
 from app.mcp.utils import MCPToolError, as_value_error, validate_with_schema
-from app.models import Edition
-from app.routers.editions import (
-    _commit_or_conflict,
-    _deactivate_conflicting_editions,
-    _edition_payload,
-    _get_edition_or_404,
-    _load_venue,
-    _validate_co_organizer,
-    _validate_exhibitor_ids,
-    _validate_exhibitors_allowed,
-)
 from app.schemas import EditionCreate, EditionType, EditionUpdate
+from app.services import editions_service
 
 
 async def create_edition(
@@ -62,57 +52,8 @@ async def create_edition(
         active=active,
     )
     async with session_factory() as db:
-        existing = (await db.execute(select(Edition).where(Edition.id == body.id))).scalar_one_or_none()
-        if existing is not None:
-            raise MCPToolError(f"Edition '{body.id}' already exists.")
-
         try:
-            await _load_venue(db, body.venue_id)
-            _validate_exhibitors_allowed(body.edition_type, body.exhibitors)
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-
-        edition = Edition(
-            id=body.id,
-            year=body.year,
-            month=body.month,
-            venue_id=body.venue_id,
-            edition_type=body.edition_type,
-            exhibitors=list(body.exhibitors),
-            co_organizer_exhibitor_id=body.co_organizer_exhibitor_id,
-            active=body.active,
-        )
-        try:
-            await _validate_exhibitor_ids(db, edition.exhibitors)
-            await _validate_co_organizer(db, edition.co_organizer_exhibitor_id)
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-
-        deactivated: list[str] = []
-        if edition.active:
-            deactivated = await _deactivate_conflicting_editions(
-                db, edition_type=edition.edition_type, exclude_id=None, actor=actor, request_id=None
-            )
-
-        db.add(edition)
-        details: dict = {"year": edition.year, "month": edition.month, "edition_type": edition.edition_type}
-        if deactivated:
-            details["deactivated_conflicting_editions"] = deactivated
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="edition_created",
-            resource_type="edition",
-            resource_id=edition.id,
-            details=details,
-        )
-        try:
-            await _commit_or_conflict(db)
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-        try:
-            edition = await _get_edition_or_404(db, edition.id)
-            return await _edition_payload(db, edition, active_only=False)
+            return await editions_service.create_edition(db, body=body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
 
@@ -120,8 +61,8 @@ async def create_edition(
 async def get_edition(session_factory: Any, edition_id: str) -> dict:
     async with session_factory() as db:
         try:
-            edition = await _get_edition_or_404(db, edition_id)
-            return await _edition_payload(db, edition, active_only=False)
+            edition = await editions_service.get_edition_or_404(db, edition_id)
+            return await editions_service.edition_payload(db, edition, active_only=False)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
 
@@ -145,7 +86,7 @@ async def update_edition(
     ``exhibitors=None`` means "leave the lineup unchanged"; pass an explicit list
     (including ``[]``) to replace it. Changing ``edition_type`` away from
     ``"festival"`` without an explicit ``exhibitors`` payload silently clears the
-    now-invalid lineup, matching ``app.routers.editions.update_edition``.
+    now-invalid lineup, matching ``app.services.editions_service.apply_edition_update``.
 
     ``co_organizer_exhibitor_id`` has no natural "clear" sentinel (an unset kwarg
     already means "leave unchanged"), so pass ``clear_co_organizer=True`` to unset
@@ -172,87 +113,8 @@ async def update_edition(
 
     async with session_factory() as db:
         try:
-            edition = await _get_edition_or_404(db, edition_id)
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-
-        if "co_organizer_exhibitor_id" in body.model_fields_set:
-            try:
-                await _validate_co_organizer(db, body.co_organizer_exhibitor_id)
-            except HTTPException as exc:
-                raise as_value_error(exc) from exc
-            edition.co_organizer_exhibitor_id = body.co_organizer_exhibitor_id
-
-        for field in ("year", "month"):
-            if field in body.model_fields_set:
-                setattr(edition, field, getattr(body, field))
-
-        if "venue_id" in body.model_fields_set and body.venue_id is not None:
-            try:
-                await _load_venue(db, body.venue_id)
-            except HTTPException as exc:
-                raise as_value_error(exc) from exc
-            edition.venue_id = body.venue_id
-
-        # `active`/`edition_type` are deliberately not applied to `edition` yet — see the
-        # matching comment in `app.routers.editions.update_edition`, which this mirrors.
-        target_edition_type: str = (
-            body.edition_type if "edition_type" in body.model_fields_set else edition.edition_type
-        )  # ty: ignore[invalid-assignment]
-        target_active: bool = body.active if "active" in body.model_fields_set else edition.active  # ty: ignore[invalid-assignment]
-
-        exhibitors_implicitly_cleared = False
-        if "exhibitors" in body.model_fields_set and body.exhibitors is not None:
-            try:
-                _validate_exhibitors_allowed(target_edition_type, body.exhibitors)  # ty: ignore[invalid-argument-type]
-                await _validate_exhibitor_ids(db, body.exhibitors)
-            except HTTPException as exc:
-                raise as_value_error(exc) from exc
-            edition.exhibitors = list(body.exhibitors)
-        elif target_edition_type != "festival" and edition.exhibitors:
-            # The edition type changed away from festival without an explicit exhibitors
-            # payload — clear the now-invalid associations as part of the same update
-            # instead of rejecting it, mirroring the router.
-            edition.exhibitors = []
-            exhibitors_implicitly_cleared = True
-
-        try:
-            _validate_exhibitors_allowed(target_edition_type, edition.exhibitors)  # ty: ignore[invalid-argument-type]
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-
-        deactivated: list[str] = []
-        if target_active:
-            deactivated = await _deactivate_conflicting_editions(
-                db, edition_type=target_edition_type, exclude_id=edition.id, actor=actor, request_id=None
-            )
-
-        # Safe to apply now: any conflicting active row of `target_edition_type` has
-        # already been deactivated and flushed above.
-        for field in ("active", "edition_type"):
-            if field in body.model_fields_set:
-                setattr(edition, field, getattr(body, field))
-
-        details: dict = {"fields_changed": sorted(body.model_fields_set)}
-        if exhibitors_implicitly_cleared:
-            details["exhibitors_cleared"] = True
-        if deactivated:
-            details["deactivated_conflicting_editions"] = deactivated
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="edition_updated",
-            resource_type="edition",
-            resource_id=edition.id,
-            details=details,
-        )
-        try:
-            await _commit_or_conflict(db)
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-        try:
-            edition = await _get_edition_or_404(db, edition.id)
-            return await _edition_payload(db, edition, active_only=False)
+            edition = await editions_service.get_edition_or_404(db, edition_id)
+            return await editions_service.apply_edition_update(db, edition, body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
 
@@ -260,7 +122,7 @@ async def update_edition(
 async def delete_edition(session_factory: Any, actor: str, edition_id: str) -> dict:
     async with session_factory() as db:
         try:
-            edition = await _get_edition_or_404(db, edition_id)
+            edition = await editions_service.get_edition_or_404(db, edition_id)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
         await db.delete(edition)

--- a/backend/app/mcp/admin/events.py
+++ b/backend/app/mcp/admin/events.py
@@ -1,13 +1,10 @@
 """Admin (write) MCP tool implementations for event management.
 
-Mirrors ``app.routers.events``. The event response payload is built by
-``event_to_summary_dict(event, include_edition=True)`` (the same serializer the
-REST ``get_event`` endpoint returns), so ``get_event``/``create_event``/
-``update_event`` reuse it directly. Off-festival edition date cardinality and
-registration-settings validation are also reused from the router
-(``_validate_standalone_event_date``, ``_validate_registration_settings``)
-rather than re-derived, with their ``HTTPException``s converted via
-``as_value_error``.
+Mirrors ``app.routers.events``. Business logic — the create/update
+transition, delete guard, and shared lookup/validation helpers — lives in
+``app.services.events_service`` and is shared with the REST router; this
+module is responsible only for validating MCP kwargs into a schema instance
+and translating ``HTTPException`` into ``MCPToolError`` at its own boundary.
 
 A read-only ``list_events``/``get_event_schedule`` tool already covers
 per-edition event listing elsewhere, so this module intentionally does not
@@ -22,18 +19,10 @@ from typing import Any
 
 from fastapi import HTTPException
 
-from app.audit import write_audit_entry
 from app.mcp.utils import as_value_error, validate_with_schema
-from app.models import Event
-from app.routers.events import (
-    _ensure_edition_exists,
-    _get_event_or_404,
-    _reject_if_registrations_exist,
-    _validate_registration_settings,
-    _validate_standalone_event_date,
-)
 from app.schemas import EventCreate, EventUpdate
-from app.utils import event_to_summary_dict, make_id
+from app.services import events_service
+from app.utils import event_to_summary_dict
 
 
 async def create_event(
@@ -68,51 +57,15 @@ async def create_event(
     )
     async with session_factory() as db:
         try:
-            edition = await _ensure_edition_exists(db, body.edition_id)
-            await _validate_standalone_event_date(db, edition, body.date)
-            _validate_registration_settings(
-                registration_required=body.registration_required,
-                registrations_open_from=body.registrations_open_from,
-                max_capacity=body.max_capacity,
-            )
+            return await events_service.create_event(db, body=body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        event = Event(
-            id=make_id("evt"),
-            edition_id=body.edition_id,
-            title=body.title,
-            description=body.description,
-            date=body.date,
-            start_time=body.start_time,
-            end_time=body.end_time,
-            category=body.category,
-            registration_required=body.registration_required,
-            registrations_open_from=body.registrations_open_from,
-            max_capacity=body.max_capacity,
-            active=body.active,
-        )
-        db.add(event)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="event_created",
-            resource_type="event",
-            resource_id=event.id,
-            details={"title": event.title, "edition_id": event.edition_id},
-        )
-        await db.commit()
-        try:
-            event = await _get_event_or_404(db, event.id)
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-        return event_to_summary_dict(event, include_edition=True)
 
 
 async def get_event(session_factory: Any, event_id: str) -> dict:
     async with session_factory() as db:
         try:
-            event = await _get_event_or_404(db, event_id)
+            event = await events_service.get_event_or_404(db, event_id)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
         return event_to_summary_dict(event, include_edition=True)
@@ -174,88 +127,16 @@ async def update_event(
 
     async with session_factory() as db:
         try:
-            event = await _get_event_or_404(db, event_id)
+            event = await events_service.get_event_or_404(db, event_id)
+            return await events_service.apply_event_update(db, event, body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-        edition = event.edition
-
-        if body.edition_id is not None:
-            try:
-                edition = await _ensure_edition_exists(db, body.edition_id)
-            except HTTPException as exc:
-                raise as_value_error(exc) from exc
-            event.edition_id = body.edition_id
-
-        fields_set = body.model_fields_set
-        # `body.date`/`body.registration_required` are typed `X | None`, so narrow
-        # each via its own `is not None` check (not just fields_set membership) —
-        # ty can't narrow across a fields_set lookup, only a same-branch None check.
-        candidate_date = body.date if "date" in fields_set and body.date is not None else event.date
-        candidate_registration_required = (
-            body.registration_required
-            if "registration_required" in fields_set and body.registration_required is not None
-            else event.registration_required
-        )
-        candidate_registrations_open_from = (
-            body.registrations_open_from if "registrations_open_from" in fields_set else event.registrations_open_from
-        )
-        candidate_max_capacity = body.max_capacity if "max_capacity" in fields_set else event.max_capacity
-        try:
-            await _validate_standalone_event_date(db, edition, candidate_date, exclude_event_id=event.id)
-            _validate_registration_settings(
-                registration_required=candidate_registration_required,
-                registrations_open_from=candidate_registrations_open_from,
-                max_capacity=candidate_max_capacity,
-            )
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-
-        for field in (
-            "title",
-            "description",
-            "date",
-            "start_time",
-            "end_time",
-            "category",
-            "registration_required",
-            "registrations_open_from",
-            "max_capacity",
-            "active",
-        ):
-            if field in fields_set:
-                setattr(event, field, getattr(body, field))
-
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="event_updated",
-            resource_type="event",
-            resource_id=event.id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        await db.commit()
-        try:
-            event = await _get_event_or_404(db, event.id)
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-        return event_to_summary_dict(event, include_edition=True)
 
 
 async def delete_event(session_factory: Any, actor: str, event_id: str) -> dict:
     async with session_factory() as db:
         try:
-            event = await _get_event_or_404(db, event_id)
-            await _reject_if_registrations_exist(db, event_id)
+            event = await events_service.get_event_or_404(db, event_id)
+            return await events_service.delete_event(db, event, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-        await db.delete(event)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="event_deleted",
-            resource_type="event",
-            resource_id=event_id,
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": event_id}

--- a/backend/app/mcp/admin/exhibitors.py
+++ b/backend/app/mcp/admin/exhibitors.py
@@ -1,6 +1,7 @@
 """Admin (write) MCP tool implementations for exhibitor management.
 
-Mirrors ``app.routers.exhibitors``.
+Mirrors ``app.routers.exhibitors``. Business logic lives in
+``app.services.exhibitors_service`` and is shared with the REST router.
 """
 
 from __future__ import annotations
@@ -8,28 +9,13 @@ from __future__ import annotations
 from typing import Any
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.mcp.utils import MCPToolError, get_or_error, validate_with_schema
-from app.models import Edition, Exhibitor, Person
-from app.routers.exhibitors import _editions_linking
+from app.models import Exhibitor
 from app.schemas import ExhibitorCreate, ExhibitorUpdate
+from app.services import exhibitors_service
+from app.services.errors import ServiceError
 from app.utils import exhibitor_to_dict
-
-
-async def _load_contact(db: AsyncSession, person_id: str | None) -> Person | None:
-    if not person_id:
-        return None
-    result = await db.execute(select(Person).where(Person.id == person_id))
-    return result.scalar_one_or_none()
-
-
-async def _load_contacts_by_ids(db: AsyncSession, ids: list[str]) -> dict[str, Person]:
-    if not ids:
-        return {}
-    result = await db.execute(select(Person).where(Person.id.in_(ids)))
-    return {p.id: p for p in result.scalars().all()}
 
 
 async def create_exhibitor(
@@ -53,36 +39,16 @@ async def create_exhibitor(
         contact_person_id=contact_person_id,
     )
     async with session_factory() as db:
-        contact = await _load_contact(db, body.contact_person_id)
-        if body.contact_person_id and contact is None:
-            raise MCPToolError("Person not found.")
-        e = Exhibitor(
-            name=body.name,
-            image=body.image,
-            website=body.website,
-            active=body.active,
-            type=body.type,
-            contact_person_id=body.contact_person_id,
-        )
-        db.add(e)
-        await db.flush()
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="exhibitor_created",
-            resource_type="exhibitor",
-            resource_id=str(e.id),
-            details={"name": e.name, "type": e.type},
-        )
-        await db.commit()
-        await db.refresh(e)
-        return exhibitor_to_dict(e, contact)
+        try:
+            return await exhibitors_service.create_exhibitor(db, body=body, actor=actor)
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
 
 
 async def get_exhibitor(session_factory: Any, exhibitor_id: int) -> dict:
     async with session_factory() as db:
         e = await get_or_error(db, Exhibitor, exhibitor_id, f"Exhibitor '{exhibitor_id}' not found.")
-        contact = await _load_contact(db, e.contact_person_id)
+        contact = await exhibitors_service.load_contact(db, e.contact_person_id)
         return exhibitor_to_dict(e, contact)
 
 
@@ -94,7 +60,7 @@ async def list_exhibitors(session_factory: Any, exhibitor_type: str | None = Non
         result = await db.execute(stmt)
         exhibitors = result.scalars().all()
         person_ids = [e.contact_person_id for e in exhibitors if e.contact_person_id]
-        contacts = await _load_contacts_by_ids(db, person_ids)
+        contacts = await exhibitors_service.load_contacts_by_ids(db, person_ids)
         return {
             "exhibitors": [
                 exhibitor_to_dict(e, contacts.get(e.contact_person_id) if e.contact_person_id else None)
@@ -131,68 +97,15 @@ async def update_exhibitor(
     body = validate_with_schema(ExhibitorUpdate, **provided)
     async with session_factory() as db:
         e = await get_or_error(db, Exhibitor, exhibitor_id, f"Exhibitor '{exhibitor_id}' not found.")
-        if body.name is not None:
-            e.name = body.name
-        if body.image is not None:
-            e.image = body.image
-        if body.website is not None:
-            e.website = body.website
-        if body.active is not None:
-            e.active = body.active
-        if body.type is not None:
-            if body.type == "vendor" and e.type != "vendor":
-                # Lock this exhibitor row so a concurrent edition update that's
-                # about to link it to a lineup can't interleave with this
-                # retype and leave a vendor exhibitor linked to an edition.
-                await db.execute(select(Exhibitor.id).where(Exhibitor.id == exhibitor_id).with_for_update())
-                linked = await _editions_linking(db, exhibitor_id)
-                if linked:
-                    raise MCPToolError(
-                        "Cannot change this exhibitor to a vendor while editions still link to it: "
-                        f"{', '.join(linked)}. Remove it from those editions first."
-                    )
-            e.type = body.type
-
-        fields_changed = set(body.model_fields_set)
-        if clear_contact_person:
-            e.contact_person_id = None
-            fields_changed.add("contact_person_id")
-        elif "contact_person_id" in body.model_fields_set:
-            if body.contact_person_id is not None:
-                contact_check = await _load_contact(db, body.contact_person_id)
-                if contact_check is None:
-                    raise MCPToolError("Person not found.")
-            e.contact_person_id = body.contact_person_id
-
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="exhibitor_updated",
-            resource_type="exhibitor",
-            resource_id=str(e.id),
-            details={"fields_changed": sorted(fields_changed)},
-        )
-        await db.commit()
-        await db.refresh(e)
-        contact = await _load_contact(db, e.contact_person_id)
-        return exhibitor_to_dict(e, contact)
+        try:
+            return await exhibitors_service.apply_exhibitor_update(
+                db, e, body, actor=actor, clear_contact_person=clear_contact_person
+            )
+        except ServiceError as exc:
+            raise MCPToolError(str(exc)) from exc
 
 
 async def delete_exhibitor(session_factory: Any, actor: str, exhibitor_id: int) -> dict:
     async with session_factory() as db:
         e = await get_or_error(db, Exhibitor, exhibitor_id, f"Exhibitor '{exhibitor_id}' not found.")
-        editions_result = await db.execute(select(Edition))
-        for edition in editions_result.scalars().all():
-            if exhibitor_id in edition.exhibitors:
-                edition.exhibitors = [eid for eid in edition.exhibitors if eid != exhibitor_id]
-        await db.delete(e)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="exhibitor_deleted",
-            resource_type="exhibitor",
-            resource_id=str(exhibitor_id),
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": exhibitor_id}
+        return await exhibitors_service.delete_exhibitor(db, e, actor=actor)

--- a/backend/app/mcp/admin/members.py
+++ b/backend/app/mcp/admin/members.py
@@ -13,9 +13,8 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import HTTPException
-from sqlalchemy.exc import IntegrityError
 
-from app.mcp.utils import MCPToolError, as_value_error, validate_with_schema
+from app.mcp.utils import as_value_error, validate_with_schema
 from app.schemas import PersonCreate, PersonUpdate
 from app.services import members_service
 from app.utils import person_to_dict
@@ -56,11 +55,6 @@ async def create_member(
             return await members_service.create_member(db, body=body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-        except IntegrityError as exc:
-            await db.rollback()
-            raise MCPToolError(
-                "Person with this national register number or eID document number already exists."
-            ) from exc
 
 
 async def get_member(session_factory: Any, person_id: str) -> dict:
@@ -122,11 +116,6 @@ async def update_member(
             return await members_service.apply_member_update(db, person, body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-        except IntegrityError as exc:
-            await db.rollback()
-            raise MCPToolError(
-                "Person with this national register number or eID document number already exists."
-            ) from exc
 
 
 async def delete_member(session_factory: Any, actor: str, person_id: str) -> dict:

--- a/backend/app/mcp/admin/members.py
+++ b/backend/app/mcp/admin/members.py
@@ -1,35 +1,24 @@
 """Admin (write) MCP tool implementations for member management.
 
-Mirrors ``app.routers.members``. Members are ``Person`` rows tagged with the
-``member`` role — see ``app.mcp.admin.people`` for the general-purpose
-``Person`` CRUD tools and ``app.mcp.admin.volunteers`` for the volunteer
-counterpart, which each have their own REST router and rules.
+Mirrors ``app.routers.members``. Business logic lives in
+``app.services.members_service`` and is shared with the REST router. Members
+are ``Person`` rows tagged with the ``member`` role — see
+``app.mcp.admin.people`` for the general-purpose ``Person`` CRUD tools and
+``app.mcp.admin.volunteers`` for the volunteer counterpart, which each have
+their own REST router and rules.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastapi import HTTPException
-from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import selectinload
 
-from app.audit import write_audit_entry
-from app.live import live_bus
-from app.live import mapping as live_mapping
 from app.mcp.utils import MCPToolError, as_value_error, validate_with_schema
-from app.models import Person, Registration
-from app.routers.members import _ensure_member_role, _get_member_or_404
-from app.routers.members import _ensure_unique_fields as _member_ensure_unique_fields
-from app.routers.members import _normalise_optional_identity as _member_normalise_optional_identity
-from app.routers.members import _normalise_roles as _member_normalise_roles
-from app.routers.people import parse_phone
 from app.schemas import PersonCreate, PersonUpdate
-from app.utils import make_id, person_to_dict, roles_contains
-
-logger = logging.getLogger(__name__)
+from app.services import members_service
+from app.utils import person_to_dict
 
 
 async def create_member(
@@ -62,56 +51,22 @@ async def create_member(
         notes=notes,
         active=active,
     )
-    nrr = _member_normalise_optional_identity(body.national_register_number)
-    eid = _member_normalise_optional_identity(body.eid_document_number)
-
     async with session_factory() as db:
         try:
-            await _member_ensure_unique_fields(db, national_register_number=nrr, eid_document_number=eid)
-            phone_value = parse_phone(body.phone)
+            return await members_service.create_member(db, body=body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        person = Person(
-            id=make_id("per"),
-            name=body.name,
-            email=str(body.email).lower().strip() if body.email else "",
-            phone=phone_value,
-            address=body.address,
-            national_register_number=nrr,
-            eid_document_number=eid,
-            visits_per_month=body.visits_per_month,
-            club_name=body.club_name,
-            notes=body.notes,
-            active=body.active,
-        )
-        person.roles = _member_normalise_roles(body.roles)
-        _ensure_member_role(person)
-
-        db.add(person)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="member_created",
-            resource_type="person",
-            resource_id=person.id,
-            details={"roles": person.roles},
-        )
-        try:
-            await db.commit()
         except IntegrityError as exc:
             await db.rollback()
             raise MCPToolError(
                 "Person with this national register number or eID document number already exists."
             ) from exc
-        await db.refresh(person)
-        return person_to_dict(person)
 
 
 async def get_member(session_factory: Any, person_id: str) -> dict:
     async with session_factory() as db:
         try:
-            person = await _get_member_or_404(db, person_id)
+            person = await members_service.get_member_or_404(db, person_id)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
         return person_to_dict(person)
@@ -119,26 +74,7 @@ async def get_member(session_factory: Any, person_id: str) -> dict:
 
 async def list_members(session_factory: Any, q: str | None = None, active: bool | None = None) -> dict:
     async with session_factory() as db:
-        stmt = select(Person).where(roles_contains("member"))
-
-        if active is not None:
-            stmt = stmt.where(Person.active == active)
-
-        if q:
-            q_escaped = q.strip().replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-            q_like = f"%{q_escaped}%"
-            stmt = stmt.where(
-                or_(
-                    Person.name.ilike(q_like, escape="\\"),
-                    Person.email.ilike(q_like, escape="\\"),
-                    Person.phone.ilike(q_like, escape="\\"),
-                    Person.address.ilike(q_like, escape="\\"),
-                    Person.club_name.ilike(q_like, escape="\\"),
-                    Person.notes.ilike(q_like, escape="\\"),
-                )
-            )
-
-        stmt = stmt.order_by(Person.created_at.desc(), Person.id.desc())
+        stmt = members_service.search_members_stmt(q=q, active=active)
         result = await db.execute(stmt)
         rows = result.scalars().all()
         return {"members": [person_to_dict(p) for p in rows]}
@@ -182,106 +118,21 @@ async def update_member(
 
     async with session_factory() as db:
         try:
-            person = await _get_member_or_404(db, person_id)
+            person = await members_service.get_member_or_404(db, person_id)
+            return await members_service.apply_member_update(db, person, body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        if body.name is not None:
-            person.name = body.name
-        if body.phone is not None:
-            try:
-                person.phone = parse_phone(body.phone)
-            except HTTPException as exc:
-                raise as_value_error(exc) from exc
-        if body.address is not None:
-            person.address = body.address
-        if body.visits_per_month is not None:
-            person.visits_per_month = body.visits_per_month
-        if body.club_name is not None:
-            person.club_name = body.club_name
-        if body.notes is not None:
-            person.notes = body.notes
-        if body.active is not None:
-            person.active = body.active
-
-        if body.email is not None:
-            person.email = str(body.email).lower().strip() if body.email else ""
-
-        nrr = _member_normalise_optional_identity(body.national_register_number)
-        eid = _member_normalise_optional_identity(body.eid_document_number)
-
-        try:
-            if body.national_register_number is not None and nrr is not None:
-                await _member_ensure_unique_fields(db, national_register_number=nrr, exclude_id=person.id)
-            if body.eid_document_number is not None and eid is not None:
-                await _member_ensure_unique_fields(db, eid_document_number=eid, exclude_id=person.id)
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-
-        if body.national_register_number is not None:
-            person.national_register_number = nrr
-        if body.eid_document_number is not None:
-            person.eid_document_number = eid
-
-        if body.roles is not None:
-            person.roles = _member_normalise_roles(body.roles)
-        _ensure_member_role(person)
-
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="member_updated",
-            resource_type="person",
-            resource_id=person.id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        try:
-            await db.commit()
         except IntegrityError as exc:
             await db.rollback()
             raise MCPToolError(
                 "Person with this national register number or eID document number already exists."
             ) from exc
-        await db.refresh(person)
-        return person_to_dict(person)
 
 
 async def delete_member(session_factory: Any, actor: str, person_id: str) -> dict:
     async with session_factory() as db:
         try:
-            person = await _get_member_or_404(db, person_id)
+            person = await members_service.get_member_or_404(db, person_id)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        result = await db.execute(
-            select(Registration).options(selectinload(Registration.event)).where(Registration.person_id == person_id)
-        )
-        registrations = result.scalars().all()
-        registration_scopes = [
-            {
-                "registration_id": registration.id,
-                "event_id": registration.event_id,
-                "edition_id": registration.event.edition_id,
-            }
-            for registration in registrations
-        ]
-        for registration in registrations:
-            await db.delete(registration)
-        await db.delete(person)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="member_deleted",
-            resource_type="person",
-            resource_id=person_id,
-            details={"deleted_registration_count": len(registrations)},
-        )
-        await db.commit()
-        for scope in registration_scopes:
-            try:
-                await live_bus.publish(live_mapping.registration_changed(action="deleted", **scope))
-            except Exception:
-                logger.warning(
-                    "live_bus.publish failed for deleted registration %s", scope["registration_id"], exc_info=True
-                )
-        return {"deleted": True, "id": person_id}
+        return await members_service.delete_member(db, person, actor=actor)

--- a/backend/app/mcp/admin/people.py
+++ b/backend/app/mcp/admin/people.py
@@ -1,37 +1,24 @@
 """Admin (write) MCP tool implementations for people management.
 
-Mirrors ``app.routers.people``. Members and volunteers are also ``Person``
-rows (see ``app.mcp.admin.members`` / ``app.mcp.admin.volunteers``) but each
-has its own REST router with its own rules, so they get their own MCP module
-too rather than being folded into this one.
+Mirrors ``app.routers.people``. Business logic lives in
+``app.services.people_service`` and is shared with the REST router. Members
+and volunteers are also ``Person`` rows (see ``app.mcp.admin.members`` /
+``app.mcp.admin.volunteers``) but each has its own REST router with its own
+rules, so they get their own MCP module too rather than being folded into
+this one.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastapi import HTTPException
-from sqlalchemy import select, update
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import selectinload
 
-from app.audit import write_audit_entry
-from app.live import live_bus
-from app.live import mapping as live_mapping
 from app.mcp.utils import MCPToolError, as_value_error, get_or_error, validate_with_schema
-from app.models import Exhibitor, Person, Registration, VolunteerPeriod
-from app.routers.people import (
-    _ensure_unique_identity_fields,
-    _normalise_optional_identity,
-    _normalise_roles,
-    _raise_identity_conflict,
-    parse_phone,
-)
+from app.models import Person
 from app.schemas import PersonCreate, PersonUpdate
-from app.utils import make_id, person_to_dict
-
-logger = logging.getLogger(__name__)
+from app.services import people_service
+from app.utils import person_to_dict
 
 
 async def create_person(
@@ -64,54 +51,11 @@ async def create_person(
         notes=notes,
         active=active,
     )
-    national_register_number = _normalise_optional_identity(body.national_register_number)
-    eid_document_number = _normalise_optional_identity(body.eid_document_number)
-
     async with session_factory() as db:
         try:
-            await _ensure_unique_identity_fields(
-                db,
-                national_register_number=national_register_number,
-                eid_document_number=eid_document_number,
-            )
-            phone_value = parse_phone(body.phone)
+            return await people_service.create_person(db, body=body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        person = Person(
-            id=make_id("per"),
-            name=body.name,
-            email=str(body.email).lower().strip() if body.email else "",
-            phone=phone_value,
-            address=body.address,
-            national_register_number=national_register_number,
-            eid_document_number=eid_document_number,
-            visits_per_month=body.visits_per_month,
-            club_name=body.club_name,
-            notes=body.notes,
-            active=body.active,
-        )
-        person.roles = _normalise_roles(body.roles)
-
-        db.add(person)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="person_created",
-            resource_type="person",
-            resource_id=person.id,
-            details={"roles": person.roles},
-        )
-        try:
-            await db.commit()
-        except IntegrityError:
-            await db.rollback()
-            try:
-                _raise_identity_conflict()
-            except HTTPException as exc:
-                raise as_value_error(exc) from exc
-        await db.refresh(person)
-        return person_to_dict(person)
 
 
 async def get_person(session_factory: Any, person_id: str) -> dict:
@@ -158,108 +102,23 @@ async def update_person(
 
     async with session_factory() as db:
         person = await get_or_error(db, Person, person_id, f"Person '{person_id}' not found.")
-
-        for field in ("name", "address", "visits_per_month", "club_name", "notes", "active"):
-            if field in body.model_fields_set:
-                setattr(person, field, getattr(body, field))
-
-        if "phone" in body.model_fields_set:
-            try:
-                person.phone = parse_phone(body.phone)
-            except HTTPException as exc:
-                raise as_value_error(exc) from exc
-
-        if "email" in body.model_fields_set:
-            person.email = str(body.email).lower().strip() if body.email else ""
-
-        nrr_in_set = "national_register_number" in body.model_fields_set
-        eid_in_set = "eid_document_number" in body.model_fields_set
-        nrr = _normalise_optional_identity(body.national_register_number) if nrr_in_set else None
-        eid = _normalise_optional_identity(body.eid_document_number) if eid_in_set else None
-
         try:
-            if nrr_in_set and nrr is not None:
-                await _ensure_unique_identity_fields(db, national_register_number=nrr, exclude_id=person.id)
-            if eid_in_set and eid is not None:
-                await _ensure_unique_identity_fields(db, eid_document_number=eid, exclude_id=person.id)
+            return await people_service.apply_person_update(db, person, body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        if nrr_in_set:
-            person.national_register_number = nrr
-        if eid_in_set:
-            person.eid_document_number = eid
-
-        if body.roles is not None:
-            person.roles = _normalise_roles(body.roles)
-
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="person_updated",
-            resource_type="person",
-            resource_id=person.id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        try:
-            await db.commit()
-        except IntegrityError:
-            await db.rollback()
-            try:
-                _raise_identity_conflict()
-            except HTTPException as exc:
-                raise as_value_error(exc) from exc
-        await db.refresh(person)
-        return person_to_dict(person)
 
 
 async def delete_person(session_factory: Any, actor: str, person_id: str) -> dict:
     async with session_factory() as db:
         person = await get_or_error(db, Person, person_id, f"Person '{person_id}' not found.")
-        result = await db.execute(
-            select(Registration).options(selectinload(Registration.event)).where(Registration.person_id == person_id)
-        )
-        registrations = result.scalars().all()
-        registration_scopes = [
-            {
-                "registration_id": registration.id,
-                "event_id": registration.event_id,
-                "edition_id": registration.event.edition_id,
-            }
-            for registration in registrations
-        ]
-        for registration in registrations:
-            await db.delete(registration)
-        await db.delete(person)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="person_deleted",
-            resource_type="person",
-            resource_id=person_id,
-            details={"deleted_registration_count": len(registrations)},
-        )
-        await db.commit()
-        for scope in registration_scopes:
-            try:
-                await live_bus.publish(live_mapping.registration_changed(action="deleted", **scope))
-            except Exception:
-                logger.warning(
-                    "live_bus.publish failed for deleted registration %s", scope["registration_id"], exc_info=True
-                )
-        return {"deleted": True, "id": person_id}
+        return await people_service.delete_person(db, person, actor=actor)
 
 
 async def merge_people(session_factory: Any, actor: str, person_id: str, duplicate_id: str) -> dict:
     """Merge duplicate_id into person_id.
 
-    See ``app.routers.people.merge_people`` for the exact semantics this
-    mirrors: reservations/exhibitor contacts/volunteer periods linked to the
-    duplicate are re-pointed to the canonical person, blank fields on the
-    canonical are filled from the duplicate, roles are unioned, and unique
-    identity fields are adopted from the duplicate only if the canonical
-    lacks them (a conflict on both being set to different values is an
-    error). The duplicate person record is deleted.
+    See ``app.services.people_service.merge_people`` for the exact semantics
+    this mirrors.
     """
     if person_id == duplicate_id:
         raise MCPToolError("Cannot merge a person with themselves.")
@@ -267,76 +126,7 @@ async def merge_people(session_factory: Any, actor: str, person_id: str, duplica
     async with session_factory() as db:
         canonical = await get_or_error(db, Person, person_id, f"Person '{person_id}' not found.")
         duplicate = await get_or_error(db, Person, duplicate_id, f"Person '{duplicate_id}' not found.")
-
-        field_labels = {
-            "national_register_number": "national register number",
-            "eid_document_number": "eID document number",
-        }
-        for field in ("national_register_number", "eid_document_number"):
-            canon_val = _normalise_optional_identity(getattr(canonical, field))
-            dup_val = _normalise_optional_identity(getattr(duplicate, field))
-            if canon_val and dup_val and canon_val != dup_val:
-                label = field_labels[field]
-                raise MCPToolError(f"Both persons have a different {label}; resolve manually before merging.")
-
-        # Normalise canonical's own existing identity fields in-place so the
-        # surviving record is always in canonical form, consistent with
-        # create/update_person.
-        for field in ("national_register_number", "eid_document_number"):
-            existing = getattr(canonical, field)
-            normalised = _normalise_optional_identity(existing)
-            if normalised != existing:
-                setattr(canonical, field, normalised or None)
-
-        # Fill blank string fields on canonical from duplicate.
-        for field in ("email", "phone", "address", "club_name", "notes"):
-            if not getattr(canonical, field) and getattr(duplicate, field):
-                setattr(canonical, field, getattr(duplicate, field))
-
-        # Fill blank nullable fields on canonical from duplicate.
-        for field in ("visits_per_month",):
-            if getattr(canonical, field) is None and getattr(duplicate, field) is not None:
-                setattr(canonical, field, getattr(duplicate, field))
-
-        # Merge roles (union).
-        canonical.roles = sorted(set(canonical.roles) | set(duplicate.roles))
-
-        # Adopt unique identity fields from duplicate if canonical lacks them.
-        adopted = {
-            field: _normalise_optional_identity(getattr(duplicate, field))
-            for field in ("national_register_number", "eid_document_number")
-            if not getattr(canonical, field) and getattr(duplicate, field)
-        }
-        if adopted:
-            # These columns are UNIQUE, so the duplicate has to release its
-            # value before the canonical can take it. Clear and flush
-            # separately so the two writes cannot race for the same value.
-            for field in adopted:
-                setattr(duplicate, field, None)
-            await db.flush()
-            for field, value in adopted.items():
-                setattr(canonical, field, value)
-
-        await db.flush()
-
-        # Re-point everything that references the duplicate.
-        await db.execute(update(Registration).where(Registration.person_id == duplicate_id).values(person_id=person_id))
-        await db.execute(
-            update(Exhibitor).where(Exhibitor.contact_person_id == duplicate_id).values(contact_person_id=person_id)
-        )
-        await db.execute(
-            update(VolunteerPeriod).where(VolunteerPeriod.volunteer_id == duplicate_id).values(volunteer_id=person_id)
-        )
-
-        await db.delete(duplicate)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="person_merged",
-            resource_type="person",
-            resource_id=canonical.id,
-            details={"duplicate_id": duplicate_id},
-        )
-        await db.commit()
-        await db.refresh(canonical)
-        return person_to_dict(canonical)
+        try:
+            return await people_service.merge_people(db, canonical, duplicate, actor=actor)
+        except HTTPException as exc:
+            raise as_value_error(exc) from exc

--- a/backend/app/mcp/admin/registrations.py
+++ b/backend/app/mcp/admin/registrations.py
@@ -2,42 +2,27 @@
 
 Mirrors the admin-only endpoints of ``app.routers.registrations``
 (``list_registrations``, ``admin_create_registration``, ``update_registration``,
-``delete_registration``). The public self-service endpoints (guest-facing
-creation with spam/rate-limit checks, the email-token "my registrations"
-lookup flow) have no MCP equivalent — those are unauthenticated flows already
-reachable via the web app, not admin management surface.
+``delete_registration``). Business logic lives in
+``app.services.registrations_service`` and is shared with the REST router.
+The public self-service endpoints (guest-facing creation with spam/rate-limit
+checks, the email-token "my registrations" lookup flow) have no MCP
+equivalent — those are unauthenticated flows already reachable via the web
+app, not admin management surface.
 """
 
 from __future__ import annotations
 
-import logging
-import secrets
-from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
-from app.audit import write_audit_entry
-from app.live import live_bus
-from app.live import mapping as live_mapping
 from app.mcp.utils import MCPToolError, as_value_error, registration_base_dict, validate_with_schema
 from app.models import Event, Registration
-from app.routers.registrations import (
-    _assert_table_matches_edition,
-    _fetch_person_map,
-    _get_event_or_404,
-    _get_person_or_404,
-    _get_registration_or_404,
-    _resolve_order_items,
-    _sum_delivered,
-)
 from app.schemas import RegistrationAdminCreate, RegistrationUpdate
+from app.services import registrations_service
 from app.services.operational_search import person_search_predicate
-from app.utils import make_id, registration_to_dict
-
-logger = logging.getLogger(__name__)
 
 DEFAULT_LIST_LIMIT = 50
 MAX_LIST_LIMIT = 200
@@ -97,7 +82,7 @@ async def list_registrations(
         rows = list((await db.execute(stmt)).scalars().all())
         has_more = len(rows) > effective_limit
         rows = rows[:effective_limit]
-        person_map = await _fetch_person_map(db, rows)
+        person_map = await registrations_service.fetch_person_map(db, rows)
 
         registrations = []
         for row in rows:
@@ -128,7 +113,8 @@ async def create_registration(
 
     ``order_items`` is a list of ``{"product_id": ..., "quantity": ...}``; quantities are
     resolved against the event's real active products server-side, so a caller can never
-    set an arbitrary price or order a nonexistent product — see ``_resolve_order_items``.
+    set an arbitrary price or order a nonexistent product — see
+    ``app.services.registrations_service.resolve_order_items``.
     """
     body = validate_with_schema(
         RegistrationAdminCreate,
@@ -142,47 +128,9 @@ async def create_registration(
     )
     async with session_factory() as db:
         try:
-            person = await _get_person_or_404(db, body.person_id)
-            event = await _get_event_or_404(db, body.event_id)
-            resolved_order_items = _resolve_order_items(event, body.order_items, body.guest_count)
+            return await registrations_service.admin_create_registration(db, body=body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        registration = Registration(
-            id=make_id("reg"),
-            event_id=event.id,
-            guest_count=body.guest_count,
-            notes=body.notes,
-            accessibility_note=body.accessibility_note,
-            status=body.status,
-            person_id=person.id,
-            check_in_token=secrets.token_urlsafe(32),
-        )
-        registration.order_items = resolved_order_items
-        db.add(registration)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="registration_created",
-            resource_type="registration",
-            resource_id=registration.id,
-            details={"event_id": event.id, "person_id": person.id},
-        )
-        await db.commit()
-
-        registration = await _get_registration_or_404(db, registration.id)
-        try:
-            await live_bus.publish(
-                live_mapping.registration_changed(
-                    action="created",
-                    registration_id=registration.id,
-                    event_id=registration.event_id,
-                    edition_id=registration.event.edition_id,
-                )
-            )
-        except Exception:
-            logger.warning("live_bus.publish failed for registration %s", registration.id, exc_info=True)
-        return registration_to_dict(registration, person, event)
 
 
 async def update_registration(
@@ -234,184 +182,23 @@ async def update_registration(
 
     async with session_factory() as db:
         try:
-            registration = await _get_registration_or_404(db, registration_id)
+            registration = await registrations_service.get_registration_or_404(db, registration_id)
+            return await registrations_service.apply_registration_update(
+                db,
+                registration,
+                body,
+                actor=actor,
+                clear_amount_due=clear_amount_due,
+                clear_table=clear_table,
+            )
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        _pre_table_id = registration.table_id
-        _pre_order_items = list(registration.order_items) if registration.order_items else []
-        _pre_delivery_sum = _sum_delivered(registration.order_items)
-        _pre_checked_in = registration.checked_in
-        _pre_strap_issued = registration.strap_issued
-        _pre_status = registration.status
-        _pre_payment_status = registration.payment_status
-        _pre_amount_due = registration.amount_due
-        _event_id = registration.event_id
-        _edition_id = registration.event.edition_id
-
-        # `provided` only ever carries non-None values (see the dict comprehension
-        # above), so `body.<field> is not None` is exactly "the caller passed this
-        # kwarg" — using `is not None` here (instead of `model_fields_set`) also lets
-        # the type checker narrow `body.<field>` from `X | None` to `X` in each block.
-        order_items_changed = False
-        checked_in_changed = False
-        strap_issued_changed = False
-        table_id_changed = False
-
-        if body.status is not None:
-            registration.status = body.status
-        if body.payment_status is not None:
-            registration.payment_status = body.payment_status
-        if clear_amount_due:
-            registration.amount_due = None
-        elif body.amount_due is not None:
-            registration.amount_due = body.amount_due
-        if clear_table:
-            registration.table_id = None
-            table_id_changed = True
-        elif body.table_id is not None:
-            try:
-                await _assert_table_matches_edition(db, body.table_id, _edition_id)
-            except HTTPException as exc:
-                raise as_value_error(exc) from exc
-            registration.table_id = body.table_id
-            table_id_changed = True
-        if body.notes is not None:
-            registration.notes = body.notes
-        if body.accessibility_note is not None:
-            registration.accessibility_note = body.accessibility_note
-        if body.person_id is not None:
-            try:
-                await _get_person_or_404(db, body.person_id)
-            except HTTPException as exc:
-                raise as_value_error(exc) from exc
-            registration.person_id = body.person_id
-        if body.order_items is not None:
-            registration.order_items = [item.model_dump() for item in body.order_items]
-            order_items_changed = True
-        if body.checked_in is not None:
-            if body.checked_in and not registration.checked_in:
-                registration.checked_in_at = datetime.now(UTC)
-            if not body.checked_in:
-                registration.checked_in_at = None
-            registration.checked_in = body.checked_in
-            checked_in_changed = True
-        if body.strap_issued is not None:
-            registration.strap_issued = body.strap_issued
-            strap_issued_changed = True
-
-        _audit_base = {"resource_type": "registration", "resource_id": registration.id}
-        if table_id_changed and registration.table_id != _pre_table_id:
-            action = "table_unassigned" if registration.table_id is None else "table_assigned"
-            await write_audit_entry(
-                db,
-                actor=actor,
-                action=action,
-                details={"table_id": registration.table_id, "previous_table_id": _pre_table_id},
-                **_audit_base,
-            )
-        if order_items_changed and registration.order_items != _pre_order_items:
-            action = (
-                "delivery_updated" if _sum_delivered(registration.order_items) != _pre_delivery_sum else "order_updated"
-            )
-            await write_audit_entry(db, actor=actor, action=action, details={}, **_audit_base)
-        if checked_in_changed and registration.checked_in != _pre_checked_in:
-            await write_audit_entry(
-                db,
-                actor=actor,
-                action="check_in",
-                details={"checked_in": registration.checked_in},
-                **_audit_base,
-            )
-        if strap_issued_changed and registration.strap_issued != _pre_strap_issued:
-            await write_audit_entry(
-                db,
-                actor=actor,
-                action="strap_issued",
-                details={"strap_issued": registration.strap_issued},
-                **_audit_base,
-            )
-        if registration.status != _pre_status or registration.payment_status != _pre_payment_status:
-            await write_audit_entry(
-                db,
-                actor=actor,
-                action="registration_status_changed",
-                details={"status": registration.status, "payment_status": registration.payment_status},
-                **_audit_base,
-            )
-        if registration.amount_due != _pre_amount_due:
-            await write_audit_entry(
-                db,
-                actor=actor,
-                action="amount_due_updated",
-                details={
-                    "amount_due": float(registration.amount_due) if registration.amount_due is not None else None,
-                    "previous_amount_due": float(_pre_amount_due) if _pre_amount_due is not None else None,
-                },
-                **_audit_base,
-            )
-
-        await db.commit()
-        registration = await _get_registration_or_404(db, registration.id)
-        person_map = await _fetch_person_map(db, [registration])
-
-        try:
-            _scope = {"registration_id": registration.id, "event_id": _event_id, "edition_id": _edition_id}
-            if registration.table_id != _pre_table_id:
-                await live_bus.publish(live_mapping.seating_changed(table_id=registration.table_id, **_scope))
-            if order_items_changed and registration.order_items != _pre_order_items:
-                if _sum_delivered(registration.order_items) != _pre_delivery_sum:
-                    await live_bus.publish(live_mapping.delivery_changed(**_scope))
-                else:
-                    await live_bus.publish(live_mapping.order_changed(**_scope))
-            if registration.checked_in != _pre_checked_in or registration.strap_issued != _pre_strap_issued:
-                await live_bus.publish(live_mapping.check_in_changed(**_scope))
-            metadata_provided = any(
-                [
-                    status is not None,
-                    payment_status is not None,
-                    amount_due is not None or clear_amount_due,
-                    notes is not None,
-                    accessibility_note is not None,
-                    person_id is not None,
-                ]
-            )
-            if metadata_provided:
-                await live_bus.publish(live_mapping.registration_changed(action="updated", **_scope))
-        except Exception:
-            logger.warning("live_bus.publish failed for registration %s", registration.id, exc_info=True)
-
-        return registration_to_dict(registration, person_map[registration.person_id], registration.event)
 
 
 async def delete_registration(session_factory: Any, actor: str, registration_id: str) -> dict:
     async with session_factory() as db:
         try:
-            registration = await _get_registration_or_404(db, registration_id)
+            registration = await registrations_service.get_registration_or_404(db, registration_id)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-        _reg_id = registration.id
-        _event_id = registration.event_id
-        _edition_id = registration.event.edition_id
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="registration_deleted",
-            resource_type="registration",
-            resource_id=_reg_id,
-            details={"event_id": _event_id},
-        )
-        await db.delete(registration)
-        await db.commit()
-        try:
-            await live_bus.publish(
-                live_mapping.registration_changed(
-                    action="deleted",
-                    registration_id=_reg_id,
-                    event_id=_event_id,
-                    edition_id=_edition_id,
-                )
-            )
-        except Exception:
-            logger.warning("live_bus.publish failed for deleted registration %s", _reg_id, exc_info=True)
-        return {"deleted": True, "id": _reg_id}
+        return await registrations_service.delete_registration(db, registration, actor=actor)

--- a/backend/app/mcp/admin/registrations.py
+++ b/backend/app/mcp/admin/registrations.py
@@ -199,6 +199,6 @@ async def delete_registration(session_factory: Any, actor: str, registration_id:
     async with session_factory() as db:
         try:
             registration = await registrations_service.get_registration_or_404(db, registration_id)
+            return await registrations_service.delete_registration(db, registration, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-        return await registrations_service.delete_registration(db, registration, actor=actor)

--- a/backend/app/mcp/admin/settings.py
+++ b/backend/app/mcp/admin/settings.py
@@ -1,70 +1,24 @@
 """Admin (write) MCP tool implementation for site-wide settings.
 
-Mirrors ``app.routers.settings``. Currently just the maintenance-mode toggle.
+Mirrors ``app.routers.settings``. Business logic lives in
+``app.services.settings_service`` and is shared with the REST router.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.audit import write_audit_entry
-from app.models import AppSettings
-from app.utils import app_settings_to_dict
-
-_SETTINGS_ID = "app_settings"
-
-
-async def _get_or_create_settings(db: AsyncSession) -> AppSettings:
-    settings = await db.get(AppSettings, _SETTINGS_ID)
-    if settings is not None:
-        return settings
-
-    # Two concurrent first calls can both see no row and both try to insert the
-    # fixed id; the loser's flush raises IntegrityError rather than a second row.
-    # Roll back and re-fetch instead of erroring out — either call landing on the
-    # same row is a correct outcome here.
-    #
-    # Flushes rather than commits, so the caller controls the transaction
-    # boundary — set_maintenance_mode folds the row creation, the mutation, and
-    # the audit entry into one atomic commit instead of two separate ones.
-    settings = AppSettings(id=_SETTINGS_ID)
-    db.add(settings)
-    try:
-        await db.flush()
-    except IntegrityError:
-        await db.rollback()
-        settings = await db.get(AppSettings, _SETTINGS_ID)
-        if settings is None:
-            # The conflicting insert guarantees a row now — assert would do here,
-            # but assertions are stripped under `-O`, silently returning None and
-            # turning this into an AttributeError deep in the caller instead.
-            raise RuntimeError("Application settings row could not be created or reloaded.") from None
-        return settings
-    return settings
+from app.mcp.utils import validate_with_schema
+from app.schemas import AppSettingsUpdate
+from app.services import settings_service
 
 
 async def get_settings(session_factory: Any) -> dict:
     async with session_factory() as db:
-        settings = await _get_or_create_settings(db)
-        await db.commit()  # persist a freshly-created default row; a no-op otherwise
-        return app_settings_to_dict(settings)
+        return await settings_service.get_settings(db)
 
 
 async def set_maintenance_mode(session_factory: Any, actor: str, *, maintenance_mode: bool) -> dict:
+    body = validate_with_schema(AppSettingsUpdate, maintenance_mode=maintenance_mode)
     async with session_factory() as db:
-        settings = await _get_or_create_settings(db)
-        settings.maintenance_mode = maintenance_mode
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="settings_updated",
-            resource_type="app_settings",
-            resource_id=_SETTINGS_ID,
-            details={"fields_changed": ["maintenance_mode"]},
-        )
-        await db.commit()
-        await db.refresh(settings)
-        return app_settings_to_dict(settings)
+        return await settings_service.update_settings(db, actor=actor, body=body)

--- a/backend/app/mcp/admin/volunteers.py
+++ b/backend/app/mcp/admin/volunteers.py
@@ -10,9 +10,8 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import HTTPException
-from sqlalchemy.exc import IntegrityError
 
-from app.mcp.utils import MCPToolError, as_value_error, validate_with_schema
+from app.mcp.utils import as_value_error, validate_with_schema
 from app.schemas import VolunteerCreate, VolunteerUpdate
 from app.services import volunteers_service
 
@@ -42,11 +41,6 @@ async def create_volunteer(
             return await volunteers_service.create_volunteer(db, body=body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-        except IntegrityError as exc:
-            await db.rollback()
-            raise MCPToolError(
-                "Person with this national register number or eID document number already exists."
-            ) from exc
 
 
 async def get_volunteer(session_factory: Any, volunteer_id: str) -> dict:
@@ -99,11 +93,6 @@ async def update_volunteer(
             return await volunteers_service.apply_volunteer_update(db, volunteer, body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-        except IntegrityError as exc:
-            await db.rollback()
-            raise MCPToolError(
-                "Person with this national register number or eID document number already exists."
-            ) from exc
 
 
 async def delete_volunteer(session_factory: Any, actor: str, volunteer_id: str) -> dict:

--- a/backend/app/mcp/admin/volunteers.py
+++ b/backend/app/mcp/admin/volunteers.py
@@ -1,10 +1,8 @@
 """Admin (write) MCP tool implementations for volunteer management.
 
 Mirrors ``app.routers.volunteers`` (except ``export_volunteers_csv``, which is
-out of scope for MCP tools). Volunteers are ``Person`` rows tagged with the
-``volunteer`` role, with help periods stored separately in
-``VolunteerPeriod`` — see ``app.mcp.admin.people`` / ``app.mcp.admin.members``
-for the other ``Person``-backed MCP modules.
+out of scope for MCP tools). Business logic lives in
+``app.services.volunteers_service`` and is shared with the REST router.
 """
 
 from __future__ import annotations
@@ -12,23 +10,11 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import HTTPException
-from sqlalchemy import delete, or_, select
 from sqlalchemy.exc import IntegrityError
 
-from app.audit import write_audit_entry
 from app.mcp.utils import MCPToolError, as_value_error, validate_with_schema
-from app.models import Person, VolunteerPeriod
-from app.routers.volunteers import _ensure_unique_fields as _volunteer_ensure_unique_fields
-from app.routers.volunteers import (
-    _ensure_volunteer_role,
-    _get_volunteer_or_404,
-    _load_periods_map,
-    _remove_volunteer_role,
-    _replace_help_periods,
-    _to_volunteer_out,
-)
 from app.schemas import VolunteerCreate, VolunteerUpdate
-from app.utils import make_id, roles_contains
+from app.services import volunteers_service
 
 
 async def create_volunteer(
@@ -53,80 +39,32 @@ async def create_volunteer(
     )
     async with session_factory() as db:
         try:
-            await _volunteer_ensure_unique_fields(
-                db,
-                national_register_number=body.national_register_number,
-                eid_document_number=body.eid_document_number,
-            )
+            return await volunteers_service.create_volunteer(db, body=body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        person = Person(
-            id=make_id("per"),
-            name=body.name,
-            address=body.address,
-            national_register_number=body.national_register_number,
-            eid_document_number=body.eid_document_number,
-            active=body.active,
-        )
-        _ensure_volunteer_role(person)
-
-        db.add(person)
-        await db.flush()
-        await _replace_help_periods(db, person.id, body.help_periods)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="volunteer_created",
-            resource_type="person",
-            resource_id=person.id,
-            details={"help_period_count": len(body.help_periods)},
-        )
-        try:
-            await db.commit()
         except IntegrityError as exc:
             await db.rollback()
             raise MCPToolError(
                 "Person with this national register number or eID document number already exists."
             ) from exc
-        await db.refresh(person)
-        periods_map = await _load_periods_map(db, [person.id])
-        return _to_volunteer_out(person, periods_map.get(person.id, []))
 
 
 async def get_volunteer(session_factory: Any, volunteer_id: str) -> dict:
     async with session_factory() as db:
         try:
-            volunteer = await _get_volunteer_or_404(db, volunteer_id)
+            volunteer = await volunteers_service.get_volunteer_or_404(db, volunteer_id)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-        periods_map = await _load_periods_map(db, [volunteer.id])
-        return _to_volunteer_out(volunteer, periods_map.get(volunteer.id, []))
+        periods_map = await volunteers_service.load_periods_map(db, [volunteer.id])
+        return volunteers_service.to_volunteer_out(volunteer, periods_map.get(volunteer.id, []))
 
 
 async def list_volunteers(session_factory: Any, q: str | None = None, active: bool | None = None) -> dict:
     async with session_factory() as db:
-        stmt = select(Person).where(roles_contains("volunteer"))
-
-        if active is not None:
-            stmt = stmt.where(Person.active == active)
-
-        if q:
-            q_escaped = q.strip().replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-            q_like = f"%{q_escaped}%"
-            stmt = stmt.where(
-                or_(
-                    Person.name.ilike(q_like, escape="\\"),
-                    Person.address.ilike(q_like, escape="\\"),
-                    Person.national_register_number.ilike(q_like, escape="\\"),
-                    Person.eid_document_number.ilike(q_like, escape="\\"),
-                )
-            )
-
-        stmt = stmt.order_by(Person.created_at.desc(), Person.id.desc())
+        stmt = volunteers_service.search_volunteers_stmt(q=q, active=active)
         rows = (await db.execute(stmt)).scalars().all()
-        periods_map = await _load_periods_map(db, [row.id for row in rows])
-        return {"volunteers": [_to_volunteer_out(v, periods_map.get(v.id, [])) for v in rows]}
+        periods_map = await volunteers_service.load_periods_map(db, [row.id for row in rows])
+        return {"volunteers": [volunteers_service.to_volunteer_out(v, periods_map.get(v.id, [])) for v in rows]}
 
 
 async def update_volunteer(
@@ -157,85 +95,26 @@ async def update_volunteer(
 
     async with session_factory() as db:
         try:
-            volunteer = await _get_volunteer_or_404(db, volunteer_id)
+            volunteer = await volunteers_service.get_volunteer_or_404(db, volunteer_id)
+            return await volunteers_service.apply_volunteer_update(db, volunteer, body, actor=actor)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        try:
-            if body.national_register_number is not None:
-                await _volunteer_ensure_unique_fields(
-                    db,
-                    national_register_number=body.national_register_number,
-                    exclude_id=volunteer_id,
-                )
-            if body.eid_document_number is not None:
-                await _volunteer_ensure_unique_fields(
-                    db,
-                    eid_document_number=body.eid_document_number,
-                    exclude_id=volunteer_id,
-                )
-        except HTTPException as exc:
-            raise as_value_error(exc) from exc
-
-        if body.name is not None:
-            volunteer.name = body.name
-        if body.address is not None:
-            volunteer.address = body.address
-        if body.national_register_number is not None:
-            volunteer.national_register_number = body.national_register_number
-        if body.eid_document_number is not None:
-            volunteer.eid_document_number = body.eid_document_number
-        if body.active is not None:
-            volunteer.active = body.active
-
-        if body.help_periods is not None:
-            await _replace_help_periods(db, volunteer_id, body.help_periods)
-
-        _ensure_volunteer_role(volunteer)
-
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="volunteer_updated",
-            resource_type="person",
-            resource_id=volunteer.id,
-            details={"fields_changed": sorted(body.model_fields_set)},
-        )
-        try:
-            await db.commit()
         except IntegrityError as exc:
             await db.rollback()
             raise MCPToolError(
                 "Person with this national register number or eID document number already exists."
             ) from exc
-        await db.refresh(volunteer)
-        periods_map = await _load_periods_map(db, [volunteer.id])
-        return _to_volunteer_out(volunteer, periods_map.get(volunteer.id, []))
 
 
 async def delete_volunteer(session_factory: Any, actor: str, volunteer_id: str) -> dict:
     """Remove the volunteer role from a person (soft archive).
 
-    Mirrors ``app.routers.volunteers.delete_volunteer``: the underlying
-    ``Person`` record and its non-volunteer data (membership, reservations,
-    audit history) are kept intact. Only the ``volunteer`` role and its
-    associated help periods are removed.
+    See ``app.services.volunteers_service.delete_volunteer`` for the exact
+    semantics.
     """
     async with session_factory() as db:
         try:
-            volunteer = await _get_volunteer_or_404(db, volunteer_id)
+            volunteer = await volunteers_service.get_volunteer_or_404(db, volunteer_id)
         except HTTPException as exc:
             raise as_value_error(exc) from exc
-
-        await db.execute(delete(VolunteerPeriod).where(VolunteerPeriod.volunteer_id == volunteer_id))
-        _remove_volunteer_role(volunteer)
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="volunteer_role_removed",
-            resource_type="person",
-            resource_id=volunteer_id,
-            details={},
-        )
-        await db.commit()
-        return {"deleted": True, "id": volunteer_id}
+        return await volunteers_service.delete_volunteer(db, volunteer, actor=actor)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -446,7 +446,8 @@ class Product(Base):
     required: Mapped[bool] = mapped_column(Boolean, default=False)
     """A prerequisite product for this event (e.g. an entry ticket). An order
     that includes any non-required product for an event with required products
-    must also include at least one required one — see _resolve_order_items."""
+    must also include at least one required one — see
+    app.services.registrations_service.resolve_order_items."""
     included_product_id: Mapped[str | None] = mapped_column(
         String(64), ForeignKey("products.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -378,7 +378,7 @@ class Edition(Base):
     active: Mapped[bool] = mapped_column(Boolean, default=True)
     """At most one edition per `edition_type` may be active at a time — enforced by the
     `uq_editions_active_type` partial unique index (migration 009) and, on the normal
-    single-request path, by `app.routers.editions._deactivate_conflicting_editions`
+    single-request path, by `app.services.editions_service.deactivate_conflicting_editions`
     transactionally deactivating the previous active edition of the same type. See #832."""
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)

--- a/backend/app/routers/editions.py
+++ b/backend/app/routers/editions.py
@@ -1,4 +1,11 @@
-"""Edition management endpoints."""
+"""Edition management endpoints.
+
+Business logic — the create/update transition, payload building, and shared
+lookup/validation helpers — lives in ``app.services.editions_service`` and is
+shared with ``app.mcp.admin.editions``; see that module's docstring for why
+editions use ``HTTPException`` directly rather than the ``ServiceError``
+convention other services follow.
+"""
 
 from __future__ import annotations
 
@@ -7,16 +14,14 @@ from datetime import UTC, date, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import func, select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.models import Edition, Event, Exhibitor, Registration, Venue
+from app.models import Event, Registration
 from app.schemas import EditionAttendanceStats, EditionCreate, EditionOut, EditionType, EditionUpdate
-from app.utils import edition_to_dict, event_to_summary_dict, get_or_404, venue_to_dict
+from app.services import editions_service
 
 router = APIRouter(prefix="/api/editions", tags=["editions"])
 logger = logging.getLogger(__name__)
@@ -33,23 +38,24 @@ async def get_active_edition(
     event neither keeps an otherwise-finished edition classified as upcoming, nor
     appears in the response.
     """
-    editions = await _load_editions(db, include_inactive=False, edition_type=edition_type)
+    editions = await editions_service.load_editions(db, include_inactive=False, edition_type=edition_type)
     if not editions:
         raise HTTPException(status_code=404, detail="No active editions found.")
 
     today = datetime.now(UTC).date()
-    dated = _sorted_editions(editions, active_only=True)
+    dated = editions_service.sorted_editions(editions, active_only=True)
     active = next(
         (
             edition
             for edition in dated
-            if (edition_end_date := _edition_end_date(_active_events(edition))) and edition_end_date >= today
+            if (edition_end_date := editions_service.edition_end_date(editions_service.active_events(edition)))
+            and edition_end_date >= today
         ),
         None,
     )
     if active is None:
         raise HTTPException(status_code=404, detail="No active or upcoming editions found.")
-    return await _edition_payload(db, active, active_only=True)
+    return await editions_service.edition_payload(db, active, active_only=True)
 
 
 @router.get("/upcoming", response_model=list[EditionOut])
@@ -63,9 +69,15 @@ async def list_upcoming_editions(
     active events are serialized in the response; see `get_active_edition`.
     """
     today = datetime.now(UTC).date()
-    editions = await _load_editions(db, include_inactive=False, edition_type=edition_type)
-    upcoming = [edition for edition in editions if (_edition_end_date(_active_events(edition)) or date.min) >= today]
-    return await _edition_payloads(db, _sorted_editions(upcoming, active_only=True), active_only=True)
+    editions = await editions_service.load_editions(db, include_inactive=False, edition_type=edition_type)
+    upcoming = [
+        edition
+        for edition in editions
+        if (editions_service.edition_end_date(editions_service.active_events(edition)) or date.min) >= today
+    ]
+    return await editions_service.edition_payloads(
+        db, editions_service.sorted_editions(upcoming, active_only=True), active_only=True
+    )
 
 
 @router.get("", response_model=list[EditionOut], dependencies=[Depends(require_admin)])
@@ -74,8 +86,10 @@ async def list_editions(
     include_inactive: bool = Query(False),
 ) -> list[dict]:
     """Admin listing: exposes every event (active or not) for management purposes."""
-    editions = await _load_editions(db, include_inactive=include_inactive)
-    return await _edition_payloads(db, _sorted_editions(editions, active_only=False), active_only=False)
+    editions = await editions_service.load_editions(db, include_inactive=include_inactive)
+    return await editions_service.edition_payloads(
+        db, editions_service.sorted_editions(editions, active_only=False), active_only=False
+    )
 
 
 @router.get("/stats", response_model=list[EditionAttendanceStats], dependencies=[Depends(require_admin)])
@@ -88,8 +102,8 @@ async def list_edition_attendance_stats(
     Includes inactive (past) editions since the point is historical comparison.
     Registered but cancelled bookings are excluded from every count.
     """
-    editions = await _load_editions(db, include_inactive=True, edition_type=edition_type)
-    editions = _sorted_editions(editions, active_only=False)
+    editions = await editions_service.load_editions(db, include_inactive=True, edition_type=edition_type)
+    editions = editions_service.sorted_editions(editions, active_only=False)
 
     stmt = (
         select(
@@ -115,7 +129,7 @@ async def list_edition_attendance_stats(
                 "year": edition.year,
                 "month": edition.month,
                 "edition_type": edition.edition_type,
-                "start_date": _edition_start_date(edition.events),
+                "start_date": editions_service.edition_start_date(edition.events),
                 "events_count": len(edition.events),
                 "total_registrations": stats.total_registrations if stats else 0,
                 "total_guests": stats.total_guests if stats else 0,
@@ -127,8 +141,8 @@ async def list_edition_attendance_stats(
 
 @router.get("/{edition_id}", response_model=EditionOut, dependencies=[Depends(require_admin)])
 async def get_edition(edition_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    edition = await _get_edition_or_404(db, edition_id)
-    return await _edition_payload(db, edition, active_only=False)
+    edition = await editions_service.get_edition_or_404(db, edition_id)
+    return await editions_service.edition_payload(db, edition, active_only=False)
 
 
 @router.post(
@@ -143,50 +157,9 @@ async def create_edition(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    if (await db.execute(select(Edition).where(Edition.id == body.id))).scalar_one_or_none():
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"Edition '{body.id}' already exists.",
-        )
-    await _load_venue(db, body.venue_id)
-    _validate_exhibitors_allowed(body.edition_type, body.exhibitors)
-
-    edition = Edition(
-        id=body.id,
-        year=body.year,
-        month=body.month,
-        venue_id=body.venue_id,
-        edition_type=body.edition_type,
-        exhibitors=list(body.exhibitors),
-        co_organizer_exhibitor_id=body.co_organizer_exhibitor_id,
-        active=body.active,
+    return await editions_service.create_edition(
+        db, body=body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    await _validate_exhibitor_ids(db, edition.exhibitors)
-    await _validate_co_organizer(db, edition.co_organizer_exhibitor_id)
-
-    request_id = getattr(request.state, "request_id", None)
-    deactivated: list[str] = []
-    if edition.active:
-        deactivated = await _deactivate_conflicting_editions(
-            db, edition_type=edition.edition_type, exclude_id=None, actor=actor, request_id=request_id
-        )
-
-    db.add(edition)
-    details: dict = {"year": edition.year, "month": edition.month, "edition_type": edition.edition_type}
-    if deactivated:
-        details["deactivated_conflicting_editions"] = deactivated
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="edition_created",
-        resource_type="edition",
-        resource_id=edition.id,
-        request_id=request_id,
-        details=details,
-    )
-    await _commit_or_conflict(db)
-    edition = await _get_edition_or_404(db, edition.id)
-    return await _edition_payload(db, edition, active_only=False)
 
 
 @router.put("/{edition_id}", response_model=EditionOut, dependencies=[Depends(require_admin)])
@@ -197,75 +170,10 @@ async def update_edition(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    edition = await _get_edition_or_404(db, edition_id)
-
-    if "co_organizer_exhibitor_id" in body.model_fields_set:
-        await _validate_co_organizer(db, body.co_organizer_exhibitor_id)
-        edition.co_organizer_exhibitor_id = body.co_organizer_exhibitor_id
-
-    for field in ["year", "month"]:
-        if field in body.model_fields_set:
-            setattr(edition, field, getattr(body, field))
-
-    if "venue_id" in body.model_fields_set and body.venue_id is not None:
-        await _load_venue(db, body.venue_id)
-        edition.venue_id = body.venue_id
-
-    # `active`/`edition_type` are deliberately not applied to `edition` yet: doing so
-    # here would dirty the object before `_deactivate_conflicting_editions` runs below,
-    # and any autoflush in between (the exhibitor/co-organizer validations above already
-    # ran, but `_validate_exhibitor_ids` below issues one too) could flush this row into
-    # an (edition_type, active) state that collides with the still-active conflicting
-    # row — the exact violation the deactivation step exists to avoid causing.
-    target_edition_type: str = body.edition_type if "edition_type" in body.model_fields_set else edition.edition_type  # ty: ignore[invalid-assignment]
-    target_active: bool = body.active if "active" in body.model_fields_set else edition.active  # ty: ignore[invalid-assignment]
-
-    exhibitors_implicitly_cleared = False
-    if "exhibitors" in body.model_fields_set and body.exhibitors is not None:
-        _validate_exhibitors_allowed(target_edition_type, body.exhibitors)  # ty: ignore[invalid-argument-type]
-        await _validate_exhibitor_ids(db, body.exhibitors)
-        edition.exhibitors = list(body.exhibitors)
-    elif target_edition_type != "festival" and edition.exhibitors:
-        # The edition type changed away from festival without an explicit exhibitors
-        # payload — either just now (edition_type in this update) or on an edition
-        # already non-festival before this update. Off-festival editions can't carry
-        # exhibitors, so clear the now-invalid associations as part of the same atomic
-        # transition instead of rejecting the update.
-        edition.exhibitors = []
-        exhibitors_implicitly_cleared = True
-
-    _validate_exhibitors_allowed(target_edition_type, edition.exhibitors)  # ty: ignore[invalid-argument-type]
-
-    request_id = getattr(request.state, "request_id", None)
-    deactivated: list[str] = []
-    if target_active:
-        deactivated = await _deactivate_conflicting_editions(
-            db, edition_type=target_edition_type, exclude_id=edition.id, actor=actor, request_id=request_id
-        )
-
-    # Safe to apply now: any conflicting active row of `target_edition_type` has
-    # already been deactivated and flushed above.
-    for field in ("active", "edition_type"):
-        if field in body.model_fields_set:
-            setattr(edition, field, getattr(body, field))
-
-    details: dict = {"fields_changed": sorted(body.model_fields_set)}
-    if exhibitors_implicitly_cleared:
-        details["exhibitors_cleared"] = True
-    if deactivated:
-        details["deactivated_conflicting_editions"] = deactivated
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="edition_updated",
-        resource_type="edition",
-        resource_id=edition.id,
-        request_id=request_id,
-        details=details,
+    edition = await editions_service.get_edition_or_404(db, edition_id)
+    return await editions_service.apply_edition_update(
+        db, edition, body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    await _commit_or_conflict(db)
-    edition = await _get_edition_or_404(db, edition.id)
-    return await _edition_payload(db, edition, active_only=False)
 
 
 @router.delete(
@@ -279,7 +187,7 @@ async def delete_edition(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    edition = await _get_edition_or_404(db, edition_id)
+    edition = await editions_service.get_edition_or_404(db, edition_id)
     await db.delete(edition)
     await write_audit_entry(
         db,
@@ -291,267 +199,3 @@ async def delete_edition(
         details={},
     )
     await db.commit()
-
-
-async def _load_editions(
-    db: AsyncSession,
-    include_inactive: bool,
-    edition_type: EditionType | None = None,
-) -> list[Edition]:
-    stmt = select(Edition).options(selectinload(Edition.events).selectinload(Event.products))
-    if not include_inactive:
-        stmt = stmt.where(Edition.active.is_(True))
-    if edition_type is not None:
-        stmt = stmt.where(Edition.edition_type == edition_type)
-    return list((await db.execute(stmt)).scalars().all())
-
-
-async def _get_edition_or_404(db: AsyncSession, edition_id: str) -> Edition:
-    return await get_or_404(
-        db,
-        Edition,
-        edition_id,
-        "Edition not found.",
-        options=[selectinload(Edition.events).selectinload(Event.products)],
-    )
-
-
-async def _deactivate_conflicting_editions(
-    db: AsyncSession,
-    *,
-    edition_type: str,
-    exclude_id: str | None,
-    actor: str,
-    request_id: str | None,
-) -> list[str]:
-    """Deactivate any other active edition of the same type in the same transaction.
-
-    Backs the "at most one active edition per type" invariant (#832) on the normal
-    single-request path: activating an edition transparently supersedes whichever
-    edition of that type was active before, rather than requiring the caller to
-    deactivate it first. Rows are locked with ``FOR UPDATE`` before being flipped so a
-    concurrent activation targeting one of them can't interleave. That still leaves one
-    race unresolved — two brand-new editions of the same type activated at once, with no
-    existing active row for either to lock — which is why this alone isn't the
-    invariant's backstop: the ``uq_editions_active_type`` partial unique index
-    (migration 009) is, and ``_commit_or_conflict`` turns its violation into a 409.
-    """
-    stmt = select(Edition).where(Edition.edition_type == edition_type, Edition.active.is_(True))
-    if exclude_id is not None:
-        stmt = stmt.where(Edition.id != exclude_id)
-    conflicting = list((await db.execute(stmt.with_for_update())).scalars().all())
-    for other in conflicting:
-        other.active = False
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="edition_deactivated",
-            resource_type="edition",
-            resource_id=other.id,
-            request_id=request_id,
-            details={"reason": "superseded_by_activation", "edition_type": edition_type},
-        )
-    if conflicting:
-        await db.flush()
-    return [other.id for other in conflicting]
-
-
-async def _commit_or_conflict(db: AsyncSession) -> None:
-    """Commit, translating a ``uq_editions_active_type`` violation into a 409.
-
-    A concurrent activation of two editions of the same type can race past
-    `_deactivate_conflicting_editions` with nothing to lock; see that function's
-    docstring. Other integrity violations reaching this commit — a duplicate id
-    slipping past `create_edition`'s existence check, or a venue/co-organizer
-    deleted concurrently with this request — are re-raised as-is for
-    ``app.main.integrity_error_handler`` to report accurately instead of being
-    misreported as this specific conflict.
-    """
-    try:
-        await db.commit()
-    except IntegrityError as exc:
-        await db.rollback()
-        # SQLAlchemy's asyncpg dialect wraps the driver error in a fresh exception
-        # that only copies pgcode/sqlstate, not asyncpg's richer diagnostics — but
-        # it chains the original via `raise ... from error`, so the real
-        # `asyncpg.exceptions.UniqueViolationError` (with `constraint_name`) is
-        # reachable through `__cause__`.
-        constraint = getattr(getattr(exc.orig, "__cause__", None), "constraint_name", None)
-        if constraint != "uq_editions_active_type":
-            raise
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Another edition of this type was activated concurrently. Please retry.",
-        ) from exc
-
-
-async def _load_venue(db: AsyncSession, venue_id: str) -> dict:
-    result = await db.execute(select(Venue).where(Venue.id == venue_id))
-    venue = result.scalar_one_or_none()
-    if venue is None:
-        raise HTTPException(status_code=404, detail=f"Venue '{venue_id}' not found.")
-    return venue_to_dict(venue)
-
-
-async def _load_venues_by_ids(db: AsyncSession, ids: set[str]) -> dict[str, dict]:
-    if not ids:
-        return {}
-    result = await db.execute(select(Venue).where(Venue.id.in_(ids)))
-    return {venue.id: venue_to_dict(venue) for venue in result.scalars().all()}
-
-
-async def _load_exhibitors_by_ids(db: AsyncSession, ids: set[int]) -> dict[int, dict]:
-    if not ids:
-        return {}
-    result = await db.execute(select(Exhibitor).where(Exhibitor.id.in_(ids), Exhibitor.active.is_(True)))
-    return {
-        exhibitor.id: {
-            "id": exhibitor.id,
-            "name": exhibitor.name,
-            "image": exhibitor.image,
-            "website": exhibitor.website,
-            "type": exhibitor.type,
-        }
-        for exhibitor in result.scalars().all()
-    }
-
-
-async def _validate_exhibitor_ids(db: AsyncSession, exhibitor_ids: list[int]) -> None:
-    if not exhibitor_ids:
-        return
-    # Lock the referenced exhibitor rows so a concurrent retype-to-vendor (see
-    # exhibitors.update_exhibitor, which locks the same rows) can't interleave
-    # with this check and leave a vendor exhibitor linked to an edition lineup.
-    await db.execute(select(Exhibitor.id).where(Exhibitor.id.in_(exhibitor_ids)).with_for_update())
-    exhibitor_map = await _load_exhibitors_by_ids(db, set(exhibitor_ids))
-    invalid = [eid for eid in exhibitor_ids if eid not in exhibitor_map]
-    if invalid:
-        raise HTTPException(status_code=400, detail=f"Invalid or inactive exhibitor IDs: {invalid}")
-    vendor_ids = [eid for eid in exhibitor_ids if exhibitor_map[eid]["type"] == "vendor"]
-    if vendor_ids:
-        raise HTTPException(
-            status_code=400, detail=f"Vendor-type exhibitors may not be linked to editions: {vendor_ids}"
-        )
-
-
-async def _edition_payloads(db: AsyncSession, editions: list[Edition], *, active_only: bool) -> list[dict]:
-    """Build edition response payloads.
-
-    `active_only` controls whether inactive events are dropped from the serialized
-    `events`/`dates` fields. Public endpoints (`/active`, `/upcoming`) pass `True` so
-    inactive (draft/cancelled) events never appear in unauthenticated responses;
-    admin endpoints pass `False` so event management keeps seeing everything.
-    """
-    venues = await _load_venues_by_ids(db, {edition.venue_id for edition in editions})
-    exhibitor_map = await _load_exhibitors_by_ids(
-        db,
-        {eid for edition in editions for eid in edition.exhibitors}
-        | {edition.co_organizer_exhibitor_id for edition in editions if edition.co_organizer_exhibitor_id},
-    )
-    payloads = []
-    for edition in editions:
-        if edition.venue_id not in venues:
-            logger.warning(
-                "Skipping edition payload because venue is missing. edition_id=%s venue_id=%s",
-                edition.id,
-                edition.venue_id,
-            )
-            continue
-        producers, sponsors, vendors = _resolve_exhibitors(edition, exhibitor_map)
-        # `Edition.events` is loaded pre-ordered by (date, start_time, created_at); filtering
-        # to active events preserves that order, so no re-sort is needed here.
-        events = _active_events(edition) if active_only else edition.events
-        payloads.append(
-            edition_to_dict(
-                edition,
-                venue=venues[edition.venue_id],
-                dates=_edition_dates(events),
-                events=[event_to_summary_dict(event) for event in events],
-                producers=producers,
-                sponsors=sponsors,
-                vendors=vendors,
-                co_organizer=exhibitor_map.get(edition.co_organizer_exhibitor_id)
-                if edition.co_organizer_exhibitor_id
-                else None,
-            )
-        )
-    return payloads
-
-
-async def _edition_payload(db: AsyncSession, edition: Edition, *, active_only: bool) -> dict:
-    payloads = await _edition_payloads(db, [edition], active_only=active_only)
-    if not payloads:
-        raise HTTPException(status_code=404, detail="Edition not found.")
-    return payloads[0]
-
-
-def _resolve_exhibitors(edition: Edition, exhibitor_map: dict[int, dict]) -> tuple[list[dict], list[dict], list[dict]]:
-    producers: list[dict] = []
-    sponsors: list[dict] = []
-    vendors: list[dict] = []
-    for exhibitor_id in edition.exhibitors:
-        item = exhibitor_map.get(exhibitor_id)
-        if item is None:
-            continue
-        if item["type"] == "producer":
-            producers.append(item)
-        elif item["type"] == "sponsor":
-            sponsors.append(item)
-        elif item["type"] == "vendor":
-            vendors.append(item)
-    return producers, sponsors, vendors
-
-
-def _active_events(edition: Edition) -> list[Event]:
-    return [event for event in edition.events if event.active]
-
-
-def _edition_dates(events: list[Event]) -> list[date]:
-    """Unique event dates in chronological order (relies on `events` being pre-sorted by date)."""
-    return list(dict.fromkeys(event.date for event in events))
-
-
-def _edition_start_date(events: list[Event]) -> date | None:
-    return events[0].date if events else None
-
-
-def _edition_end_date(events: list[Event]) -> date | None:
-    return events[-1].date if events else None
-
-
-def _sorted_editions(editions: list[Edition], *, active_only: bool) -> list[Edition]:
-    def sort_key(edition: Edition) -> tuple:
-        events = _active_events(edition) if active_only else edition.events
-        return (
-            _edition_start_date(events) or date.max,
-            _edition_end_date(events) or date.max,
-            edition.year,
-            edition.month,
-            edition.created_at,
-        )
-
-    return sorted(editions, key=sort_key)
-
-
-async def _validate_co_organizer(db: AsyncSession, exhibitor_id: int | None) -> None:
-    """A co-organizer must be an existing, active exhibitor.
-
-    Unlike the lineup, any exhibitor type is acceptable and any edition type may
-    have one — co-organizing says who ran the event with the vzw, not who was
-    programmed at it.
-    """
-    if exhibitor_id is None:
-        return
-    exhibitor = (
-        await db.execute(select(Exhibitor).where(Exhibitor.id == exhibitor_id, Exhibitor.active.is_(True)))
-    ).scalar_one_or_none()
-    if exhibitor is None:
-        raise HTTPException(status_code=400, detail=f"Invalid or inactive co-organizer exhibitor id: {exhibitor_id}")
-
-
-def _validate_exhibitors_allowed(edition_type: EditionType, exhibitors: list[int]) -> None:
-    if edition_type != "festival" and exhibitors:
-        raise HTTPException(
-            status_code=400,
-            detail="Exhibitors are only supported on festival editions.",
-        )

--- a/backend/app/routers/editions.py
+++ b/backend/app/routers/editions.py
@@ -16,7 +16,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
 from app.models import Event, Registration
@@ -188,14 +187,6 @@ async def delete_edition(
     actor: str = Depends(get_actor_id),
 ) -> None:
     edition = await editions_service.get_edition_or_404(db, edition_id)
-    await db.delete(edition)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="edition_deleted",
-        resource_type="edition",
-        resource_id=edition_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={},
+    await editions_service.delete_edition(
+        db, edition, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    await db.commit()

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1,20 +1,27 @@
-"""Event management endpoints."""
+"""Event management endpoints.
+
+Business logic — the create/update transition, delete guard, and shared
+lookup/validation helpers — lives in ``app.services.events_service`` and is
+shared with ``app.mcp.admin.events``; see that module's docstring for why
+events use ``HTTPException`` directly rather than the ``ServiceError``
+convention other services follow.
+"""
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin, require_volunteer
 from app.database import get_db
-from app.models import Edition, Event, Registration
+from app.models import Event, Registration
 from app.schemas import EventCheckInStats, EventCreate, EventOut, EventUpdate
-from app.utils import event_to_summary_dict, get_or_404, make_id
+from app.services import events_service
+from app.utils import event_to_summary_dict
 
 router = APIRouter(prefix="/api/events", tags=["events"])
 
@@ -87,7 +94,7 @@ async def get_checkin_stats(
 
 @router.get("/{event_id}", response_model=EventOut, dependencies=[Depends(require_admin)])
 async def get_event(event_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    event = await _get_event_or_404(db, event_id)
+    event = await events_service.get_event_or_404(db, event_id)
     return event_to_summary_dict(event, include_edition=True)
 
 
@@ -103,40 +110,9 @@ async def create_event(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    edition = await _ensure_edition_exists(db, body.edition_id)
-    await _validate_standalone_event_date(db, edition, body.date)
-    _validate_registration_settings(
-        registration_required=body.registration_required,
-        registrations_open_from=body.registrations_open_from,
-        max_capacity=body.max_capacity,
+    return await events_service.create_event(
+        db, body=body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    event = Event(
-        id=make_id("evt"),
-        edition_id=body.edition_id,
-        title=body.title,
-        description=body.description,
-        date=body.date,
-        start_time=body.start_time,
-        end_time=body.end_time,
-        category=body.category,
-        registration_required=body.registration_required,
-        registrations_open_from=body.registrations_open_from,
-        max_capacity=body.max_capacity,
-        active=body.active,
-    )
-    db.add(event)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="event_created",
-        resource_type="event",
-        resource_id=event.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"title": event.title, "edition_id": event.edition_id},
-    )
-    await db.commit()
-    event = await _get_event_or_404(db, event.id)
-    return event_to_summary_dict(event, include_edition=True)
 
 
 @router.put("/{event_id}", response_model=EventOut, dependencies=[Depends(require_admin)])
@@ -147,56 +123,10 @@ async def update_event(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    event = await _get_event_or_404(db, event_id)
-    edition = event.edition
-
-    if "edition_id" in body.model_fields_set and body.edition_id is not None:
-        edition = await _ensure_edition_exists(db, body.edition_id)
-        event.edition_id = body.edition_id
-
-    candidate_date = body.date if "date" in body.model_fields_set and body.date is not None else event.date
-    await _validate_standalone_event_date(db, edition, candidate_date, exclude_event_id=event.id)
-    _validate_registration_settings(
-        registration_required=(
-            body.registration_required
-            if "registration_required" in body.model_fields_set and body.registration_required is not None
-            else event.registration_required
-        ),
-        registrations_open_from=(
-            body.registrations_open_from
-            if "registrations_open_from" in body.model_fields_set
-            else event.registrations_open_from
-        ),
-        max_capacity=(body.max_capacity if "max_capacity" in body.model_fields_set else event.max_capacity),
+    event = await events_service.get_event_or_404(db, event_id)
+    return await events_service.apply_event_update(
+        db, event, body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-
-    for field in [
-        "title",
-        "description",
-        "date",
-        "start_time",
-        "end_time",
-        "category",
-        "registration_required",
-        "registrations_open_from",
-        "max_capacity",
-        "active",
-    ]:
-        if field in body.model_fields_set:
-            setattr(event, field, getattr(body, field))
-
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="event_updated",
-        resource_type="event",
-        resource_id=event.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
-    )
-    await db.commit()
-    event = await _get_event_or_404(db, event.id)
-    return event_to_summary_dict(event, include_edition=True)
 
 
 @router.delete("/{event_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_admin)])
@@ -206,99 +136,7 @@ async def delete_event(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    event = await _get_event_or_404(db, event_id)
-    await _reject_if_registrations_exist(db, event_id)
-    await db.delete(event)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="event_deleted",
-        resource_type="event",
-        resource_id=event_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={},
+    event = await events_service.get_event_or_404(db, event_id)
+    await events_service.delete_event(
+        db, event, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    await db.commit()
-
-
-async def _reject_if_registrations_exist(db: AsyncSession, event_id: str) -> None:
-    """Block event deletion while registrations still reference it.
-
-    ``registrations.event_id`` is non-nullable and the ORM relationship has no
-    delete cascade configured (registrations carry payment/attendance/order
-    history, so silently orphaning or cascading them is unsafe). Without this
-    check, ``db.delete(event)`` reaches the database, which raises a raw
-    ``NotNullViolationError`` that would otherwise surface driver/SQL details
-    and registration row contents to the caller.
-    """
-    count = (
-        await db.execute(select(func.count()).select_from(Registration).where(Registration.event_id == event_id))
-    ).scalar_one()
-    if count:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                f"Cannot delete event: {count} registration(s) are still linked to it. Delete or reassign them first."
-            ),
-        )
-
-
-async def _get_event_or_404(db: AsyncSession, event_id: str) -> Event:
-    return await get_or_404(
-        db,
-        Event,
-        event_id,
-        "Event not found.",
-        options=[selectinload(Event.edition), selectinload(Event.products)],
-    )
-
-
-async def _ensure_edition_exists(db: AsyncSession, edition_id: str) -> Edition:
-    result = await db.execute(select(Edition).where(Edition.id == edition_id))
-    edition = result.scalar_one_or_none()
-    if edition is None:
-        raise HTTPException(status_code=404, detail=f"Edition '{edition_id}' not found.")
-    return edition
-
-
-async def _validate_standalone_event_date(
-    db: AsyncSession,
-    edition: Edition,
-    event_date: date,
-    exclude_event_id: str | None = None,
-) -> None:
-    """Enforce the off-festival edition event cardinality contract.
-
-    Off-festival editions (`bourse`, `capsule_exchange`) may contain any number of events
-    (e.g. separate opening, tasting, and auction entries), but every event on such an
-    edition must share the same calendar date. Festival editions are unrestricted since
-    they legitimately span multiple days. The public UI and admin UI both render every
-    active event for an edition, so this is the only cardinality constraint enforced.
-    """
-    if edition.edition_type == "festival":
-        return
-    stmt = select(Event.date).where(Event.edition_id == edition.id)
-    if exclude_event_id is not None:
-        stmt = stmt.where(Event.id != exclude_event_id)
-    existing_dates = {row[0] for row in (await db.execute(stmt)).all()}
-    resulting_dates = existing_dates | {event_date}
-    if len(resulting_dates) > 1:
-        raise HTTPException(
-            status_code=400,
-            detail="Standalone editions may only contain events on a single date.",
-        )
-
-
-def _validate_registration_settings(
-    *,
-    registration_required: bool,
-    registrations_open_from: datetime | None,
-    max_capacity: int | None,
-) -> None:
-    if registration_required:
-        return
-    if registrations_open_from is not None or max_capacity is not None:
-        raise HTTPException(
-            status_code=400,
-            detail=("registrations_open_from and max_capacity may only be set when registration_required is true."),
-        )

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -137,6 +137,4 @@ async def delete_event(
     actor: str = Depends(get_actor_id),
 ) -> None:
     event = await events_service.get_event_or_404(db, event_id)
-    await events_service.delete_event(
-        db, event, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    await events_service.delete_event(db, event, actor=actor, request_id=getattr(request.state, "request_id", None))

--- a/backend/app/routers/exhibitors.py
+++ b/backend/app/routers/exhibitors.py
@@ -113,12 +113,12 @@ async def update_exhibitor(
     if body.type is not None:
         if body.type == "vendor" and e.type != "vendor":
             # Lock this exhibitor row so a concurrent edition update that's about
-            # to link it to a lineup (see _validate_exhibitor_ids in the editions
-            # router, which locks the same row) can't interleave with this retype
-            # and leave a vendor exhibitor linked to an edition.
+            # to link it to a lineup (see validate_exhibitor_ids in
+            # editions_service, which locks the same row) can't interleave with
+            # this retype and leave a vendor exhibitor linked to an edition.
             await db.execute(select(Exhibitor.id).where(Exhibitor.id == exhibitor_id).with_for_update())
-            # Editions reject vendor ids (see _validate_exhibitor_ids in the
-            # editions router), so retyping an exhibitor that editions still link
+            # Editions reject vendor ids (see validate_exhibitor_ids in
+            # editions_service), so retyping an exhibitor that editions still link
             # to would strand them in a state their own update endpoint refuses.
             linked = await _editions_linking(db, exhibitor_id)
             if linked:

--- a/backend/app/routers/exhibitors.py
+++ b/backend/app/routers/exhibitors.py
@@ -1,38 +1,24 @@
-"""Exhibitor management endpoints."""
+"""Exhibitor management endpoints.
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+Business logic lives in ``app.services.exhibitors_service`` and is shared
+with ``app.mcp.admin.exhibitors`` — this router is a thin adapter that
+translates ``ServiceError`` into ``HTTPException`` (see #807, #860).
+"""
+
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
 from app.dependencies import Pagination, apply_pagination
-from app.models import Edition, Exhibitor, Person
+from app.models import Exhibitor
 from app.schemas import ExhibitorCreate, ExhibitorOut, ExhibitorUpdate
+from app.services import exhibitors_service
+from app.services.errors import ServiceError, to_http_exception
 from app.utils import exhibitor_to_dict, get_or_404
 
 router = APIRouter(prefix="/api/exhibitors", tags=["exhibitors"])
-
-
-async def _editions_linking(db: AsyncSession, exhibitor_id: int) -> list[str]:
-    """Ids of editions whose exhibitor list still contains this exhibitor."""
-    result = await db.execute(select(Edition))
-    return sorted(edition.id for edition in result.scalars().all() if exhibitor_id in edition.exhibitors)
-
-
-async def _load_contact(db: AsyncSession, person_id: str | None) -> Person | None:
-    if not person_id:
-        return None
-    result = await db.execute(select(Person).where(Person.id == person_id))
-    return result.scalar_one_or_none()
-
-
-async def _load_contacts_by_ids(db: AsyncSession, ids: list[str]) -> dict[str, Person]:
-    if not ids:
-        return {}
-    result = await db.execute(select(Person).where(Person.id.in_(ids)))
-    return {p.id: p for p in result.scalars().all()}
 
 
 @router.get("", response_model=list[ExhibitorOut], dependencies=[Depends(require_admin)])
@@ -48,7 +34,7 @@ async def list_exhibitors(
     result = await db.execute(stmt)
     exhibitors = result.scalars().all()
     person_ids = [e.contact_person_id for e in exhibitors if e.contact_person_id]
-    contacts = await _load_contacts_by_ids(db, person_ids)
+    contacts = await exhibitors_service.load_contacts_by_ids(db, person_ids)
     return [
         exhibitor_to_dict(e, contacts.get(e.contact_person_id) if e.contact_person_id else None) for e in exhibitors
     ]
@@ -66,31 +52,12 @@ async def create_exhibitor(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    contact = await _load_contact(db, body.contact_person_id)
-    if body.contact_person_id and contact is None:
-        raise HTTPException(status_code=404, detail="Person not found.")
-    e = Exhibitor(
-        name=body.name,
-        image=body.image,
-        website=body.website,
-        active=body.active,
-        type=body.type,
-        contact_person_id=body.contact_person_id,
-    )
-    db.add(e)
-    await db.flush()
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="exhibitor_created",
-        resource_type="exhibitor",
-        resource_id=str(e.id),
-        request_id=getattr(request.state, "request_id", None),
-        details={"name": e.name, "type": e.type},
-    )
-    await db.commit()
-    await db.refresh(e)
-    return exhibitor_to_dict(e, contact)
+    try:
+        return await exhibitors_service.create_exhibitor(
+            db, body=body, actor=actor, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.put("/{exhibitor_id}", response_model=ExhibitorOut, dependencies=[Depends(require_admin)])
@@ -102,53 +69,12 @@ async def update_exhibitor(
     actor: str = Depends(get_actor_id),
 ) -> dict:
     e = await get_or_404(db, Exhibitor, exhibitor_id, "Exhibitor not found.")
-    if body.name is not None:
-        e.name = body.name
-    if body.image is not None:
-        e.image = body.image
-    if body.website is not None:
-        e.website = body.website
-    if body.active is not None:
-        e.active = body.active
-    if body.type is not None:
-        if body.type == "vendor" and e.type != "vendor":
-            # Lock this exhibitor row so a concurrent edition update that's about
-            # to link it to a lineup (see validate_exhibitor_ids in
-            # editions_service, which locks the same row) can't interleave with
-            # this retype and leave a vendor exhibitor linked to an edition.
-            await db.execute(select(Exhibitor.id).where(Exhibitor.id == exhibitor_id).with_for_update())
-            # Editions reject vendor ids (see validate_exhibitor_ids in
-            # editions_service), so retyping an exhibitor that editions still link
-            # to would strand them in a state their own update endpoint refuses.
-            linked = await _editions_linking(db, exhibitor_id)
-            if linked:
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        "Cannot change this exhibitor to a vendor while editions still link to it: "
-                        f"{', '.join(linked)}. Remove it from those editions first."
-                    ),
-                )
-        e.type = body.type
-    if "contact_person_id" in body.model_fields_set:
-        if body.contact_person_id is not None:
-            contact_check = await _load_contact(db, body.contact_person_id)
-            if contact_check is None:
-                raise HTTPException(status_code=404, detail="Person not found.")
-        e.contact_person_id = body.contact_person_id
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="exhibitor_updated",
-        resource_type="exhibitor",
-        resource_id=str(e.id),
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
-    )
-    await db.commit()
-    await db.refresh(e)
-    contact = await _load_contact(db, e.contact_person_id)
-    return exhibitor_to_dict(e, contact)
+    try:
+        return await exhibitors_service.apply_exhibitor_update(
+            db, e, body, actor=actor, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc
 
 
 @router.delete(
@@ -163,18 +89,9 @@ async def delete_exhibitor(
     actor: str = Depends(get_actor_id),
 ) -> None:
     e = await get_or_404(db, Exhibitor, exhibitor_id, "Exhibitor not found.")
-    editions_result = await db.execute(select(Edition))
-    for edition in editions_result.scalars().all():
-        if exhibitor_id in edition.exhibitors:
-            edition.exhibitors = [eid for eid in edition.exhibitors if eid != exhibitor_id]
-    await db.delete(e)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="exhibitor_deleted",
-        resource_type="exhibitor",
-        resource_id=str(exhibitor_id),
-        request_id=getattr(request.state, "request_id", None),
-        details={},
-    )
-    await db.commit()
+    try:
+        await exhibitors_service.delete_exhibitor(
+            db, e, actor=actor, request_id=getattr(request.state, "request_id", None)
+        )
+    except ServiceError as exc:
+        raise to_http_exception(exc) from exc

--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -5,12 +5,12 @@ Business logic lives in ``app.services.members_service`` and is shared with
 ``app.mcp.admin.members``.
 """
 
-from fastapi import APIRouter, Depends, Query, Request, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.dependencies import Pagination, apply_pagination
+from app.dependencies import Pagination, apply_pagination, get_request_id
 from app.schemas import PersonCreate, PersonOut, PersonUpdate
 from app.services import members_service
 from app.utils import person_to_dict
@@ -25,13 +25,11 @@ router = APIRouter(
 @router.post("", response_model=PersonOut, status_code=status.HTTP_201_CREATED)
 async def create_member(
     body: PersonCreate,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
+    request_id: str | None = Depends(get_request_id),
 ) -> dict:
-    return await members_service.create_member(
-        db, body=body, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    return await members_service.create_member(db, body=body, actor=actor, request_id=request_id)
 
 
 @router.get("", response_model=list[PersonOut])
@@ -58,22 +56,20 @@ async def get_member(person_id: str, db: AsyncSession = Depends(get_db)) -> dict
 async def update_member(
     person_id: str,
     body: PersonUpdate,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
+    request_id: str | None = Depends(get_request_id),
 ) -> dict:
     person = await members_service.get_member_or_404(db, person_id)
-    return await members_service.apply_member_update(
-        db, person, body, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    return await members_service.apply_member_update(db, person, body, actor=actor, request_id=request_id)
 
 
 @router.delete("/{person_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_member(
     person_id: str,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
+    request_id: str | None = Depends(get_request_id),
 ) -> None:
     person = await members_service.get_member_or_404(db, person_id)
-    await members_service.delete_member(db, person, actor=actor, request_id=getattr(request.state, "request_id", None))
+    await members_service.delete_member(db, person, actor=actor, request_id=request_id)

--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -1,82 +1,25 @@
 """Member CRUD endpoints (admin-only).
 
 Members are stored in the people table as a subset with role='member'.
+Business logic lives in ``app.services.members_service`` and is shared with
+``app.mcp.admin.members``.
 """
 
-import logging
-
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import or_, select
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
 from app.dependencies import Pagination, apply_pagination
-from app.live import live_bus
-from app.live import mapping as live_mapping
-from app.models import Person, Registration
-from app.routers.people import parse_phone
 from app.schemas import PersonCreate, PersonOut, PersonUpdate
-from app.utils import get_or_404, make_id, person_to_dict, roles_contains
+from app.services import members_service
+from app.utils import person_to_dict
 
 router = APIRouter(
     prefix="/api/members",
     tags=["members"],
     dependencies=[Depends(require_admin)],
 )
-logger = logging.getLogger(__name__)
-
-
-def _normalise_roles(roles: list[str]) -> list[str]:
-    return sorted({r.strip().lower() for r in roles if r and r.strip()})
-
-
-def _normalise_optional_identity(value: str | None) -> str | None:
-    if value is None:
-        return None
-    value = value.strip()
-    return value or None
-
-
-def _ensure_member_role(person: Person) -> None:
-    roles = set(person.roles or [])
-    roles.add("member")
-    person.roles = sorted(roles)
-
-
-def _has_member_role(person: Person) -> bool:
-    return "member" in (person.roles or [])
-
-
-async def _ensure_unique_fields(
-    db: AsyncSession,
-    national_register_number: str | None = None,
-    eid_document_number: str | None = None,
-    exclude_id: str | None = None,
-) -> None:
-    if national_register_number is not None:
-        stmt = select(Person).where(Person.national_register_number == national_register_number)
-        if exclude_id:
-            stmt = stmt.where(Person.id != exclude_id)
-        existing = (await db.execute(stmt)).scalar_one_or_none()
-        if existing is not None:
-            raise HTTPException(
-                status_code=409,
-                detail="Person with this national register number already exists.",
-            )
-
-    if eid_document_number is not None:
-        stmt = select(Person).where(Person.eid_document_number == eid_document_number)
-        if exclude_id:
-            stmt = stmt.where(Person.id != exclude_id)
-        existing = (await db.execute(stmt)).scalar_one_or_none()
-        if existing is not None:
-            raise HTTPException(
-                status_code=409,
-                detail="Person with this eID document number already exists.",
-            )
 
 
 @router.post("", response_model=PersonOut, status_code=status.HTTP_201_CREATED)
@@ -86,43 +29,9 @@ async def create_member(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    nrr = _normalise_optional_identity(body.national_register_number)
-    eid = _normalise_optional_identity(body.eid_document_number)
-    await _ensure_unique_fields(
-        db,
-        national_register_number=nrr,
-        eid_document_number=eid,
+    return await members_service.create_member(
+        db, body=body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-
-    person = Person(
-        id=make_id("per"),
-        name=body.name,
-        email=str(body.email).lower().strip() if body.email else "",
-        phone=parse_phone(body.phone),
-        address=body.address,
-        national_register_number=nrr,
-        eid_document_number=eid,
-        visits_per_month=body.visits_per_month,
-        club_name=body.club_name,
-        notes=body.notes,
-        active=body.active,
-    )
-    person.roles = _normalise_roles(body.roles)
-    _ensure_member_role(person)
-
-    db.add(person)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="member_created",
-        resource_type="person",
-        resource_id=person.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"roles": person.roles},
-    )
-    await db.commit()
-    await db.refresh(person)
-    return person_to_dict(person)
 
 
 @router.get("", response_model=list[PersonOut])
@@ -132,28 +41,8 @@ async def list_members(
     active: bool | None = Query(default=None),
     pagination: Pagination = Depends(),
 ) -> list[dict]:
-    stmt = select(Person).where(roles_contains("member"))
-
-    if active is not None:
-        stmt = stmt.where(Person.active == active)
-
-    if q:
-        q_escaped = q.strip().replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-        q_like = f"%{q_escaped}%"
-        stmt = stmt.where(
-            or_(
-                Person.name.ilike(q_like, escape="\\"),
-                Person.email.ilike(q_like, escape="\\"),
-                Person.phone.ilike(q_like, escape="\\"),
-                Person.address.ilike(q_like, escape="\\"),
-                Person.club_name.ilike(q_like, escape="\\"),
-                Person.notes.ilike(q_like, escape="\\"),
-            )
-        )
-
-    stmt = stmt.order_by(Person.created_at.desc(), Person.id.desc())
+    stmt = members_service.search_members_stmt(q=q, active=active)
     stmt = apply_pagination(stmt, pagination)
-
     result = await db.execute(stmt)
     rows = result.scalars().all()
     return [person_to_dict(p) for p in rows]
@@ -161,7 +50,7 @@ async def list_members(
 
 @router.get("/{person_id}", response_model=PersonOut)
 async def get_member(person_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    person = await _get_member_or_404(db, person_id)
+    person = await members_service.get_member_or_404(db, person_id)
     return person_to_dict(person)
 
 
@@ -173,64 +62,10 @@ async def update_member(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    person = await _get_member_or_404(db, person_id)
-
-    for field in (
-        "name",
-        "address",
-        "visits_per_month",
-        "club_name",
-        "notes",
-        "active",
-    ):
-        if field in body.model_fields_set:
-            setattr(person, field, getattr(body, field))
-
-    if "phone" in body.model_fields_set:
-        person.phone = parse_phone(body.phone)
-
-    if "email" in body.model_fields_set:
-        person.email = str(body.email).lower().strip() if body.email else ""
-
-    nrr_in_set = "national_register_number" in body.model_fields_set
-    eid_in_set = "eid_document_number" in body.model_fields_set
-    nrr = _normalise_optional_identity(body.national_register_number) if nrr_in_set else None
-    eid = _normalise_optional_identity(body.eid_document_number) if eid_in_set else None
-
-    if nrr_in_set and nrr is not None:
-        await _ensure_unique_fields(
-            db,
-            national_register_number=nrr,
-            exclude_id=person.id,
-        )
-    if eid_in_set and eid is not None:
-        await _ensure_unique_fields(
-            db,
-            eid_document_number=eid,
-            exclude_id=person.id,
-        )
-
-    if nrr_in_set:
-        person.national_register_number = nrr
-    if eid_in_set:
-        person.eid_document_number = eid
-
-    if body.roles is not None:
-        person.roles = _normalise_roles(body.roles)
-    _ensure_member_role(person)
-
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="member_updated",
-        resource_type="person",
-        resource_id=person.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
+    person = await members_service.get_member_or_404(db, person_id)
+    return await members_service.apply_member_update(
+        db, person, body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    await db.commit()
-    await db.refresh(person)
-    return person_to_dict(person)
 
 
 @router.delete("/{person_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -240,43 +75,7 @@ async def delete_member(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    person = await _get_member_or_404(db, person_id)
-    result = await db.execute(
-        select(Registration).options(selectinload(Registration.event)).where(Registration.person_id == person_id)
+    person = await members_service.get_member_or_404(db, person_id)
+    await members_service.delete_member(
+        db, person, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    registrations = result.scalars().all()
-    registration_scopes = [
-        {
-            "registration_id": registration.id,
-            "event_id": registration.event_id,
-            "edition_id": registration.event.edition_id,
-        }
-        for registration in registrations
-    ]
-    for registration in registrations:
-        await db.delete(registration)
-    await db.delete(person)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="member_deleted",
-        resource_type="person",
-        resource_id=person_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"deleted_registration_count": len(registrations)},
-    )
-    await db.commit()
-    for scope in registration_scopes:
-        try:
-            await live_bus.publish(live_mapping.registration_changed(action="deleted", **scope))
-        except Exception:
-            logger.warning(
-                "live_bus.publish failed for deleted registration %s", scope["registration_id"], exc_info=True
-            )
-
-
-async def _get_member_or_404(db: AsyncSession, person_id: str) -> Person:
-    person = await get_or_404(db, Person, person_id, "Member not found.")
-    if not _has_member_role(person):
-        raise HTTPException(status_code=404, detail="Member not found.")
-    return person

--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -76,6 +76,4 @@ async def delete_member(
     actor: str = Depends(get_actor_id),
 ) -> None:
     person = await members_service.get_member_or_404(db, person_id)
-    await members_service.delete_member(
-        db, person, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    await members_service.delete_member(db, person, actor=actor, request_id=getattr(request.state, "request_id", None))

--- a/backend/app/routers/people.py
+++ b/backend/app/routers/people.py
@@ -154,6 +154,4 @@ async def delete_person(
     actor: str = Depends(get_actor_id),
 ) -> None:
     person = await people_service.get_person_or_404(db, person_id)
-    await people_service.delete_person(
-        db, person, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    await people_service.delete_person(db, person, actor=actor, request_id=getattr(request.state, "request_id", None))

--- a/backend/app/routers/people.py
+++ b/backend/app/routers/people.py
@@ -5,14 +5,14 @@ create/update/delete/merge transitions — lives in
 ``app.services.people_service`` and is shared with ``app.mcp.admin.people``.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import Text, cast, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.dependencies import Pagination, apply_pagination
+from app.dependencies import Pagination, apply_pagination, get_request_id
 from app.models import Event, Person, Registration
 from app.schemas import PersonCreate, PersonOut, PersonUpdate
 from app.services import people_service
@@ -34,13 +34,11 @@ router = APIRouter(
 @router.post("", response_model=PersonOut, status_code=status.HTTP_201_CREATED)
 async def create_person(
     body: PersonCreate,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
+    request_id: str | None = Depends(get_request_id),
 ) -> dict:
-    return await people_service.create_person(
-        db, body=body, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    return await people_service.create_person(db, body=body, actor=actor, request_id=request_id)
 
 
 @router.get("", response_model=list[PersonOut])
@@ -96,14 +94,12 @@ async def get_person(person_id: str, db: AsyncSession = Depends(get_db)) -> dict
 async def update_person(
     person_id: str,
     body: PersonUpdate,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
+    request_id: str | None = Depends(get_request_id),
 ) -> dict:
     person = await people_service.get_person_or_404(db, person_id)
-    return await people_service.apply_person_update(
-        db, person, body, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    return await people_service.apply_person_update(db, person, body, actor=actor, request_id=request_id)
 
 
 @router.get("/{person_id}/registrations")
@@ -130,9 +126,9 @@ async def list_person_registrations(
 async def merge_people(
     person_id: str,
     duplicate_id: str,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
+    request_id: str | None = Depends(get_request_id),
 ) -> dict:
     """Merge duplicate_id into person_id (admin-only). See
     ``app.services.people_service.merge_people`` for the exact semantics."""
@@ -141,17 +137,15 @@ async def merge_people(
 
     canonical = await people_service.get_person_or_404(db, person_id)
     duplicate = await people_service.get_person_or_404(db, duplicate_id)
-    return await people_service.merge_people(
-        db, canonical, duplicate, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    return await people_service.merge_people(db, canonical, duplicate, actor=actor, request_id=request_id)
 
 
 @router.delete("/{person_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_person(
     person_id: str,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
+    request_id: str | None = Depends(get_request_id),
 ) -> None:
     person = await people_service.get_person_or_404(db, person_id)
-    await people_service.delete_person(db, person, actor=actor, request_id=getattr(request.state, "request_id", None))
+    await people_service.delete_person(db, person, actor=actor, request_id=request_id)

--- a/backend/app/routers/people.py
+++ b/backend/app/routers/people.py
@@ -1,115 +1,34 @@
-"""People CRUD endpoints (admin-only)."""
+"""People CRUD endpoints (admin-only).
 
-import logging
+Business logic — identity normalisation, phone parsing, and the
+create/update/delete/merge transitions — lives in
+``app.services.people_service`` and is shared with ``app.mcp.admin.people``.
+"""
 
-import phonenumbers
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import Text, cast, or_, select, update
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy import Text, cast, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
 from app.dependencies import Pagination, apply_pagination
-from app.live import live_bus
-from app.live import mapping as live_mapping
-from app.models import Event, Exhibitor, Person, Registration, VolunteerPeriod
+from app.models import Event, Person, Registration
 from app.schemas import PersonCreate, PersonOut, PersonUpdate
+from app.services import people_service
 from app.services.operational_search import (
     DEFAULT_RESULT_LIMIT,
     bounded_limit,
     person_search_order_by,
     person_search_predicate,
 )
-from app.utils import get_or_404, make_id, person_to_dict, registration_to_list_dict, roles_contains
+from app.utils import person_to_dict, registration_to_list_dict, roles_contains
 
 router = APIRouter(
     prefix="/api/people",
     tags=["people"],
     dependencies=[Depends(require_admin)],
 )
-logger = logging.getLogger(__name__)
-
-
-def _normalise_roles(roles: list[str]) -> list[str]:
-    normalised: set[str] = set()
-    for role in roles:
-        if not role or not role.strip():
-            continue
-        r = role.strip().lower()
-        normalised.add(r)
-    return sorted(normalised)
-
-
-def _normalise_optional_identity(value: str | None) -> str | None:
-    """Strip separators and normalise case so that e.g. '93.05.18-223.61' and
-    '93051822361' are treated as the same value for uniqueness checks."""
-    if value is None:
-        return None
-    for ch in (" ", ".", "-", "/"):
-        value = value.replace(ch, "")
-    value = value.strip().lower()
-    return value or None
-
-
-def parse_phone(raw: str | None) -> str:
-    """Parse and normalise a phone number to E.164 format.
-
-    Uses the ``phonenumbers`` library (Google libphonenumber binding) with
-    ``"BE"`` as the default region for numbers that lack a country code prefix.
-    Numbers that already carry a ``+`` or ``00`` IDD prefix are parsed
-    regardless of the default region.
-
-    Returns ``""`` for empty/None input.
-    Raises :class:`fastapi.HTTPException` (422) for unparseable or invalid input.
-    """
-    if not raw or not raw.strip():
-        return ""
-    try:
-        parsed = phonenumbers.parse(raw, "BE")
-    except phonenumbers.NumberParseException as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=f"Invalid phone number: {exc}",
-        ) from exc
-    if not phonenumbers.is_valid_number(parsed):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="Invalid phone number.",
-        )
-    return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
-
-
-def _raise_identity_conflict() -> None:
-    raise HTTPException(
-        status_code=409,
-        detail="Person with this national register number or eID document number already exists.",
-    )
-
-
-async def _ensure_unique_identity_fields(
-    db: AsyncSession,
-    national_register_number: str | None = None,
-    eid_document_number: str | None = None,
-    exclude_id: str | None = None,
-) -> None:
-    if national_register_number is not None:
-        stmt = select(Person).where(Person.national_register_number == national_register_number)
-        if exclude_id:
-            stmt = stmt.where(Person.id != exclude_id)
-        existing = (await db.execute(stmt)).scalar_one_or_none()
-        if existing is not None:
-            _raise_identity_conflict()
-
-    if eid_document_number is not None:
-        stmt = select(Person).where(Person.eid_document_number == eid_document_number)
-        if exclude_id:
-            stmt = stmt.where(Person.id != exclude_id)
-        existing = (await db.execute(stmt)).scalar_one_or_none()
-        if existing is not None:
-            _raise_identity_conflict()
 
 
 @router.post("", response_model=PersonOut, status_code=status.HTTP_201_CREATED)
@@ -119,46 +38,9 @@ async def create_person(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    national_register_number = _normalise_optional_identity(body.national_register_number)
-    eid_document_number = _normalise_optional_identity(body.eid_document_number)
-    await _ensure_unique_identity_fields(
-        db,
-        national_register_number=national_register_number,
-        eid_document_number=eid_document_number,
+    return await people_service.create_person(
+        db, body=body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-
-    person = Person(
-        id=make_id("per"),
-        name=body.name,
-        email=str(body.email).lower().strip() if body.email else "",
-        phone=parse_phone(body.phone),
-        address=body.address,
-        national_register_number=national_register_number,
-        eid_document_number=eid_document_number,
-        visits_per_month=body.visits_per_month,
-        club_name=body.club_name,
-        notes=body.notes,
-        active=body.active,
-    )
-    person.roles = _normalise_roles(body.roles)
-
-    db.add(person)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="person_created",
-        resource_type="person",
-        resource_id=person.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"roles": person.roles},
-    )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        _raise_identity_conflict()
-    await db.refresh(person)
-    return person_to_dict(person)
 
 
 @router.get("", response_model=list[PersonOut])
@@ -206,7 +88,7 @@ async def list_people(
 
 @router.get("/{person_id}", response_model=PersonOut)
 async def get_person(person_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    person = await _get_person_or_404(db, person_id)
+    person = await people_service.get_person_or_404(db, person_id)
     return person_to_dict(person)
 
 
@@ -218,67 +100,10 @@ async def update_person(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    person = await _get_person_or_404(db, person_id)
-
-    for field in (
-        "name",
-        "address",
-        "visits_per_month",
-        "club_name",
-        "notes",
-        "active",
-    ):
-        if field in body.model_fields_set:
-            setattr(person, field, getattr(body, field))
-
-    if "phone" in body.model_fields_set:
-        person.phone = parse_phone(body.phone)
-
-    if "email" in body.model_fields_set:
-        person.email = str(body.email).lower().strip() if body.email else ""
-
-    nrr_in_set = "national_register_number" in body.model_fields_set
-    eid_in_set = "eid_document_number" in body.model_fields_set
-    nrr = _normalise_optional_identity(body.national_register_number) if nrr_in_set else None
-    eid = _normalise_optional_identity(body.eid_document_number) if eid_in_set else None
-
-    if nrr_in_set and nrr is not None:
-        await _ensure_unique_identity_fields(
-            db,
-            national_register_number=nrr,
-            exclude_id=person.id,
-        )
-    if eid_in_set and eid is not None:
-        await _ensure_unique_identity_fields(
-            db,
-            eid_document_number=eid,
-            exclude_id=person.id,
-        )
-
-    if nrr_in_set:
-        person.national_register_number = nrr
-    if eid_in_set:
-        person.eid_document_number = eid
-
-    if body.roles is not None:
-        person.roles = _normalise_roles(body.roles)
-
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="person_updated",
-        resource_type="person",
-        resource_id=person.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
+    person = await people_service.get_person_or_404(db, person_id)
+    return await people_service.apply_person_update(
+        db, person, body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    try:
-        await db.commit()
-    except IntegrityError:
-        await db.rollback()
-        _raise_identity_conflict()
-    await db.refresh(person)
-    return person_to_dict(person)
 
 
 @router.get("/{person_id}/registrations")
@@ -286,7 +111,7 @@ async def list_person_registrations(
     person_id: str,
     db: AsyncSession = Depends(get_db),
 ) -> list[dict]:
-    person = await _get_person_or_404(db, person_id)
+    person = await people_service.get_person_or_404(db, person_id)
 
     result = await db.execute(
         select(Registration)
@@ -309,109 +134,16 @@ async def merge_people(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    """Merge duplicate_id into person_id (admin-only).
-
-    - All reservations and exhibitor contacts linked to the duplicate are
-      re-pointed to the canonical person.
-    - Blank string fields on the canonical person are filled from the duplicate.
-    - Roles are merged (union).
-    - Unique identity fields (national_register_number, eid_document_number)
-      are adopted from the duplicate only if the canonical person lacks them;
-      if both carry conflicting values a 409 is returned.
-    - The duplicate person record is deleted.
-    """
+    """Merge duplicate_id into person_id (admin-only). See
+    ``app.services.people_service.merge_people`` for the exact semantics."""
     if person_id == duplicate_id:
         raise HTTPException(status_code=400, detail="Cannot merge a person with themselves.")
 
-    canonical = await _get_person_or_404(db, person_id)
-    duplicate = await _get_person_or_404(db, duplicate_id)
-
-    # Guard unique identity fields before making any changes.
-    # Normalise values with the same routine used by create/update so that
-    # equivalent but differently-formatted IDs are not treated as conflicts.
-    field_labels = {
-        "national_register_number": "national register number",
-        "eid_document_number": "eID document number",
-    }
-    for field in ("national_register_number", "eid_document_number"):
-        canon_val = _normalise_optional_identity(getattr(canonical, field))
-        dup_val = _normalise_optional_identity(getattr(duplicate, field))
-        if canon_val and dup_val and canon_val != dup_val:
-            label = field_labels[field]
-            raise HTTPException(
-                status_code=409,
-                detail=f"Both persons have a different {label}; resolve manually before merging.",
-            )
-
-    # Normalise canonical's own existing identity fields in-place so the
-    # surviving record is always in canonical form, consistent with
-    # create/update_person.
-    for field in ("national_register_number", "eid_document_number"):
-        existing = getattr(canonical, field)
-        normalised = _normalise_optional_identity(existing)
-        if normalised != existing:
-            setattr(canonical, field, normalised or None)
-
-    # Fill blank string fields on canonical from duplicate.
-    for field in ("email", "phone", "address", "club_name", "notes"):
-        if not getattr(canonical, field) and getattr(duplicate, field):
-            setattr(canonical, field, getattr(duplicate, field))
-
-    # Fill blank nullable fields on canonical from duplicate.
-    for field in ("visits_per_month",):
-        if getattr(canonical, field) is None and getattr(duplicate, field) is not None:
-            setattr(canonical, field, getattr(duplicate, field))
-
-    # Merge roles (union).
-    canonical.roles = sorted(set(canonical.roles) | set(duplicate.roles))
-
-    # Adopt unique identity fields from duplicate if canonical lacks them.
-    # Normalise the value from the duplicate before storing so the canonical
-    # ends up with the same canonical form used by create/update_person.
-    adopted = {
-        field: _normalise_optional_identity(getattr(duplicate, field))
-        for field in ("national_register_number", "eid_document_number")
-        if not getattr(canonical, field) and getattr(duplicate, field)
-    }
-    if adopted:
-        # These columns are UNIQUE, so the duplicate has to release its value
-        # before the canonical can take it. A single flush does not guarantee
-        # that order — SQLAlchemy batches same-mapper UPDATEs by primary key, so
-        # whenever the canonical's id sorts first it would write the value while
-        # the duplicate still holds it. Clear and flush separately.
-        for field in adopted:
-            setattr(duplicate, field, None)
-        await db.flush()
-        for field, value in adopted.items():
-            setattr(canonical, field, value)
-
-    await db.flush()
-
-    # Re-point everything that references the duplicate. VolunteerPeriod matters
-    # most: its FK cascades on delete, so a period left pointing at the duplicate
-    # is destroyed below rather than transferred, leaving a person carrying the
-    # volunteer role with no help periods.
-    await db.execute(update(Registration).where(Registration.person_id == duplicate_id).values(person_id=person_id))
-    await db.execute(
-        update(Exhibitor).where(Exhibitor.contact_person_id == duplicate_id).values(contact_person_id=person_id)
+    canonical = await people_service.get_person_or_404(db, person_id)
+    duplicate = await people_service.get_person_or_404(db, duplicate_id)
+    return await people_service.merge_people(
+        db, canonical, duplicate, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    await db.execute(
-        update(VolunteerPeriod).where(VolunteerPeriod.volunteer_id == duplicate_id).values(volunteer_id=person_id)
-    )
-
-    await db.delete(duplicate)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="person_merged",
-        resource_type="person",
-        resource_id=canonical.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"duplicate_id": duplicate_id},
-    )
-    await db.commit()
-    await db.refresh(canonical)
-    return person_to_dict(canonical)
 
 
 @router.delete("/{person_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -421,40 +153,7 @@ async def delete_person(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    person = await _get_person_or_404(db, person_id)
-    result = await db.execute(
-        select(Registration).options(selectinload(Registration.event)).where(Registration.person_id == person_id)
+    person = await people_service.get_person_or_404(db, person_id)
+    await people_service.delete_person(
+        db, person, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    registrations = result.scalars().all()
-    registration_scopes = [
-        {
-            "registration_id": registration.id,
-            "event_id": registration.event_id,
-            "edition_id": registration.event.edition_id,
-        }
-        for registration in registrations
-    ]
-    for registration in registrations:
-        await db.delete(registration)
-    await db.delete(person)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="person_deleted",
-        resource_type="person",
-        resource_id=person_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"deleted_registration_count": len(registrations)},
-    )
-    await db.commit()
-    for scope in registration_scopes:
-        try:
-            await live_bus.publish(live_mapping.registration_changed(action="deleted", **scope))
-        except Exception:
-            logger.warning(
-                "live_bus.publish failed for deleted registration %s", scope["registration_id"], exc_info=True
-            )
-
-
-async def _get_person_or_404(db: AsyncSession, person_id: str) -> Person:
-    return await get_or_404(db, Person, person_id, "Person not found.")

--- a/backend/app/routers/registrations.py
+++ b/backend/app/routers/registrations.py
@@ -1,4 +1,12 @@
-"""Registration CRUD endpoints."""
+"""Registration CRUD endpoints.
+
+Admin-only mutation logic — order-item resolution, the table/edition guard,
+and the admin create/update/delete transitions — lives in
+``app.services.registrations_service`` and is shared with
+``app.mcp.admin.registrations``. The public self-service endpoints below
+(guest-facing creation, CSV export, the email-token "my registrations"
+lookup flow) have no MCP equivalent and stay here.
+"""
 
 from __future__ import annotations
 
@@ -9,7 +17,6 @@ import logging
 import re
 import secrets
 from datetime import UTC, datetime, timedelta
-from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import delete, func, select
@@ -18,7 +25,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from starlette.responses import StreamingResponse
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.config import settings
 from app.database import get_db
@@ -26,12 +32,9 @@ from app.dependencies import Pagination, apply_pagination
 from app.email import send_guest_access_email
 from app.live import live_bus
 from app.live import mapping as live_mapping
-from app.models import Edition, Event, Layout, Person, Product, Registration, ReservationAccessToken, Table
+from app.models import Edition, Event, Person, Registration, ReservationAccessToken, Table
 from app.ratelimit import check_rate_limit, get_client_ip
 from app.schemas import (
-    OrderItemBase,
-    OrderItemCategory,
-    OrderItemRequest,
     RegistrationAccessLookupRequest,
     RegistrationAdminCreate,
     RegistrationCreate,
@@ -43,6 +46,7 @@ from app.schemas import (
     RegistrationOutWithToken,
     RegistrationUpdate,
 )
+from app.services import events_service, registrations_service
 from app.services.operational_search import (
     DEFAULT_RESULT_LIMIT,
     bounded_limit,
@@ -78,9 +82,9 @@ async def create_registration(
     check_honeypot(body.honeypot)
     check_form_timing(body.form_start_time)
 
-    event = await _get_event_or_404(db, body.event_id)
+    event = await events_service.get_event_or_404(db, body.event_id)
     await _ensure_public_registration_allowed(db, event, body.guest_count)
-    resolved_order_items = _resolve_order_items(event, body.order_items, body.guest_count)
+    resolved_order_items = registrations_service.resolve_order_items(event, body.order_items, body.guest_count)
 
     email_norm = str(body.email).lower().strip()
     name_norm = " ".join(body.name.lower().split())
@@ -115,7 +119,7 @@ async def create_registration(
     db.add(registration)
     await db.commit()
 
-    registration = await _get_registration_or_404(db, registration.id)
+    registration = await registrations_service.get_registration_or_404(db, registration.id)
     try:
         await live_bus.publish(
             live_mapping.registration_changed(
@@ -142,46 +146,9 @@ async def admin_create_registration(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    person = await _get_person_or_404(db, body.person_id)
-    event = await _get_event_or_404(db, body.event_id)
-    resolved_order_items = _resolve_order_items(event, body.order_items, body.guest_count)
-
-    registration = Registration(
-        id=make_id("reg"),
-        event_id=event.id,
-        guest_count=body.guest_count,
-        notes=body.notes,
-        accessibility_note=body.accessibility_note,
-        status=body.status,
-        person_id=person.id,
-        check_in_token=secrets.token_urlsafe(32),
+    return await registrations_service.admin_create_registration(
+        db, body=body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    registration.order_items = resolved_order_items
-    db.add(registration)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="registration_created",
-        resource_type="registration",
-        resource_id=registration.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"event_id": event.id, "person_id": person.id},
-    )
-    await db.commit()
-
-    registration = await _get_registration_or_404(db, registration.id)
-    try:
-        await live_bus.publish(
-            live_mapping.registration_changed(
-                action="created",
-                registration_id=registration.id,
-                event_id=registration.event_id,
-                edition_id=registration.event.edition_id,
-            )
-        )
-    except Exception:
-        logger.warning("live_bus.publish failed for registration %s", registration.id, exc_info=True)
-    return registration_to_dict(registration, person, event)
 
 
 @router.get(
@@ -231,7 +198,7 @@ async def list_registrations(
         stmt = apply_pagination(stmt, pagination)
 
     rows = (await db.execute(stmt)).scalars().all()
-    person_map = await _fetch_person_map(db, list(rows))
+    person_map = await registrations_service.fetch_person_map(db, list(rows))
     return [registration_to_list_dict(row, person_map[row.person_id], row.event) for row in rows]
 
 
@@ -241,7 +208,7 @@ async def export_registrations_csv(
     db: AsyncSession = Depends(get_db),
 ) -> StreamingResponse:
     """Export the guest list for one event as CSV (name, table, party size, status)."""
-    event = await _get_event_or_404(db, event_id)
+    event = await events_service.get_event_or_404(db, event_id)
 
     stmt = (
         select(Registration)
@@ -249,7 +216,7 @@ async def export_registrations_csv(
         .order_by(Registration.created_at)
     )
     rows = (await db.execute(stmt)).scalars().all()
-    person_map = await _fetch_person_map(db, list(rows))
+    person_map = await registrations_service.fetch_person_map(db, list(rows))
 
     table_ids = {row.table_id for row in rows if row.table_id}
     table_map: dict[str, str] = {}
@@ -396,34 +363,9 @@ async def get_registration(
     registration_id: str,
     db: AsyncSession = Depends(get_db),
 ) -> dict:
-    registration = await _get_registration_or_404(db, registration_id)
-    person_map = await _fetch_person_map(db, [registration])
+    registration = await registrations_service.get_registration_or_404(db, registration_id)
+    person_map = await registrations_service.fetch_person_map(db, [registration])
     return registration_to_dict_with_token(registration, person_map[registration.person_id], registration.event)
-
-
-async def _assert_table_matches_edition(db: AsyncSession, table_id: str, edition_id: str | None) -> None:
-    """Reject seating a registration at a table belonging to another edition.
-
-    Layouts are per-edition, so a table only makes sense for registrations of the
-    edition its layout was drawn for. Layouts predating the edition link carry a
-    null edition_id and are left alone.
-    """
-    row = (
-        await db.execute(
-            select(Layout.edition_id).join(Table, Table.layout_id == Layout.id).where(Table.id == table_id)
-        )
-    ).first()
-    if row is None:
-        raise HTTPException(status_code=404, detail=f"Table '{table_id}' not found.")
-    table_edition_id = row[0]
-    if table_edition_id is not None and edition_id is not None and table_edition_id != edition_id:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Table '{table_id}' belongs to edition '{table_edition_id}', "
-                f"but this registration is for edition '{edition_id}'."
-            ),
-        )
 
 
 @router.put(
@@ -438,130 +380,10 @@ async def update_registration(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    registration = await _get_registration_or_404(db, registration_id)
-
-    # Capture pre-state for live-update topic detection.
-    _pre_table_id = registration.table_id
-    _pre_order_items = list(registration.order_items) if registration.order_items else []
-    _pre_delivery_sum = _sum_delivered(registration.order_items)
-    _pre_checked_in = registration.checked_in
-    _pre_strap_issued = registration.strap_issued
-    _pre_status = registration.status
-    _pre_payment_status = registration.payment_status
-    _pre_amount_due = registration.amount_due
-    _event_id = registration.event_id
-    _edition_id = registration.event.edition_id
-
-    if body.status is not None:
-        registration.status = body.status
-    if body.payment_status is not None:
-        registration.payment_status = body.payment_status
-    if "amount_due" in body.model_fields_set:
-        registration.amount_due = body.amount_due
-    if "table_id" in body.model_fields_set:
-        if body.table_id is not None:
-            await _assert_table_matches_edition(db, body.table_id, _edition_id)
-        registration.table_id = body.table_id
-    if body.notes is not None:
-        registration.notes = body.notes
-    if body.accessibility_note is not None:
-        registration.accessibility_note = body.accessibility_note
-    if "person_id" in body.model_fields_set:
-        if body.person_id is None:
-            raise HTTPException(
-                status_code=400, detail="person_id cannot be removed; every registration requires a person."
-            )
-        await _get_person_or_404(db, body.person_id)
-        registration.person_id = body.person_id
-    if body.order_items is not None:
-        registration.order_items = [item.model_dump() for item in body.order_items]
-    if body.checked_in is not None:
-        if body.checked_in and not registration.checked_in:
-            registration.checked_in_at = datetime.now(UTC)
-        if not body.checked_in:
-            registration.checked_in_at = None
-        registration.checked_in = body.checked_in
-    if body.strap_issued is not None:
-        registration.strap_issued = body.strap_issued
-
-    _request_id = getattr(request.state, "request_id", None)
-    _audit_base = {"resource_type": "registration", "resource_id": registration.id, "request_id": _request_id}
-    if "table_id" in body.model_fields_set and body.table_id != _pre_table_id:
-        action = "table_unassigned" if body.table_id is None else "table_assigned"
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action=action,
-            details={"table_id": body.table_id, "previous_table_id": _pre_table_id},
-            **_audit_base,
-        )
-    if body.order_items is not None and registration.order_items != _pre_order_items:
-        action = (
-            "delivery_updated" if _sum_delivered(registration.order_items) != _pre_delivery_sum else "order_updated"
-        )
-        await write_audit_entry(db, actor=actor, action=action, details={}, **_audit_base)
-    if body.checked_in is not None and registration.checked_in != _pre_checked_in:
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="check_in",
-            details={"checked_in": registration.checked_in},
-            **_audit_base,
-        )
-    if body.strap_issued is not None and registration.strap_issued != _pre_strap_issued:
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="strap_issued",
-            details={"strap_issued": registration.strap_issued},
-            **_audit_base,
-        )
-    if registration.status != _pre_status or registration.payment_status != _pre_payment_status:
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="registration_status_changed",
-            details={
-                "status": registration.status,
-                "payment_status": registration.payment_status,
-            },
-            **_audit_base,
-        )
-    if registration.amount_due != _pre_amount_due:
-        await write_audit_entry(
-            db,
-            actor=actor,
-            action="amount_due_updated",
-            details={
-                "amount_due": float(registration.amount_due) if registration.amount_due is not None else None,
-                "previous_amount_due": float(_pre_amount_due) if _pre_amount_due is not None else None,
-            },
-            **_audit_base,
-        )
-
-    await db.commit()
-    registration = await _get_registration_or_404(db, registration.id)
-    person_map = await _fetch_person_map(db, [registration])
-
-    # Publish live-update events; bus errors must never break write responses.
-    try:
-        _scope = {"registration_id": registration.id, "event_id": _event_id, "edition_id": _edition_id}
-        if registration.table_id != _pre_table_id:
-            await live_bus.publish(live_mapping.seating_changed(table_id=registration.table_id, **_scope))
-        if body.order_items is not None and registration.order_items != _pre_order_items:
-            if _sum_delivered(registration.order_items) != _pre_delivery_sum:
-                await live_bus.publish(live_mapping.delivery_changed(**_scope))
-            else:
-                await live_bus.publish(live_mapping.order_changed(**_scope))
-        if registration.checked_in != _pre_checked_in or registration.strap_issued != _pre_strap_issued:
-            await live_bus.publish(live_mapping.check_in_changed(**_scope))
-        _metadata = {"status", "payment_status", "amount_due", "notes", "accessibility_note", "person_id"}
-        if any(f in body.model_fields_set for f in _metadata):
-            await live_bus.publish(live_mapping.registration_changed(action="updated", **_scope))
-    except Exception:
-        logger.warning("live_bus.publish failed for registration %s", registration.id, exc_info=True)
-
-    return registration_to_dict(registration, person_map[registration.person_id], registration.event)
+    registration = await registrations_service.get_registration_or_404(db, registration_id)
+    return await registrations_service.apply_registration_update(
+        db, registration, body, actor=actor, request_id=getattr(request.state, "request_id", None)
+    )
 
 
 @router.delete(
@@ -575,38 +397,10 @@ async def delete_registration(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> None:
-    registration = await _get_registration_or_404(db, registration_id)
-    _reg_id = registration.id
-    _event_id = registration.event_id
-    _edition_id = registration.event.edition_id
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="registration_deleted",
-        resource_type="registration",
-        resource_id=_reg_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"event_id": _event_id},
+    registration = await registrations_service.get_registration_or_404(db, registration_id)
+    await registrations_service.delete_registration(
+        db, registration, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    await db.delete(registration)
-    await db.commit()
-    try:
-        await live_bus.publish(
-            live_mapping.registration_changed(
-                action="deleted",
-                registration_id=_reg_id,
-                event_id=_event_id,
-                edition_id=_edition_id,
-            )
-        )
-    except Exception:
-        logger.warning("live_bus.publish failed for deleted registration %s", _reg_id, exc_info=True)
-
-
-def _sum_delivered(order_items: list[dict] | None) -> int:
-    if not order_items:
-        return 0
-    return sum(int(item.get("delivered_quantity") or 0) for item in order_items)
 
 
 def _hash_guest_access_token(token: str) -> str:
@@ -663,104 +457,6 @@ async def _load_guest_registrations_by_email(
     return [(row, person_map[row.person_id], row.event) for row in rows]
 
 
-async def _get_registration_or_404(db: AsyncSession, registration_id: str) -> Registration:
-    result = await db.execute(
-        select(Registration)
-        .options(
-            selectinload(Registration.event).selectinload(Event.edition),
-            selectinload(Registration.event).selectinload(Event.products),
-        )
-        .where(Registration.id == registration_id)
-    )
-    registration = result.scalar_one_or_none()
-    if registration is None:
-        raise HTTPException(status_code=404, detail="Registration not found.")
-    return registration
-
-
-async def _get_person_or_404(db: AsyncSession, person_id: str) -> Person:
-    result = await db.execute(select(Person).where(Person.id == person_id))
-    person = result.scalar_one_or_none()
-    if person is None:
-        raise HTTPException(status_code=404, detail="Person not found.")
-    return person
-
-
-async def _get_event_or_404(db: AsyncSession, event_id: str) -> Event:
-    result = await db.execute(
-        select(Event).options(selectinload(Event.edition), selectinload(Event.products)).where(Event.id == event_id)
-    )
-    event = result.scalar_one_or_none()
-    if event is None:
-        raise HTTPException(status_code=404, detail="Event not found.")
-    return event
-
-
-def _resolve_order_items(event: Event, requests: list[OrderItemRequest], guest_count: int) -> list[dict]:
-    """Resolve client-supplied product_id/quantity pairs against the event's real,
-    active products, snapshotting name/price/category server-side (see Product's
-    docstring). Rejects any product_id that isn't an active product on this event,
-    so a client can never set an arbitrary price or order a nonexistent product.
-
-    Also enforces that a required product (e.g. an entry ticket) is present
-    whenever an optional one is ordered — an event with required products
-    configured rejects an order for optional add-ons alone — and applies each
-    ordered product's bundle (Product.included_product_id/included_per_guests):
-    a free quantity of the bundled product, scaled to guest_count, is merged
-    into that product's line item on top of anything explicitly requested.
-    """
-    products_by_id: dict[str, Product] = {p.id: p for p in event.products if p.active}
-
-    # product_id -> (quantity, included_quantity)
-    line_items: dict[str, tuple[int, int]] = {}
-    ordered_ids: set[str] = set()
-    for req in requests:
-        product = products_by_id.get(req.product_id)
-        if product is None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Product '{req.product_id}' is not available for this event.",
-            )
-        ordered_ids.add(product.id)
-        quantity, included_quantity = line_items.get(product.id, (0, 0))
-        line_items[product.id] = (quantity + req.quantity, included_quantity)
-
-    required_ids = {p.id for p in products_by_id.values() if p.required}
-    if required_ids and (ordered_ids - required_ids) and not (ordered_ids & required_ids):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="This event requires a required product (e.g. an entry ticket) before any optional products can be ordered.",
-        )
-
-    for product_id in list(ordered_ids):
-        product = products_by_id[product_id]
-        if product.included_product_id is None or product.included_per_guests is None:
-            continue
-        target = products_by_id.get(product.included_product_id)
-        if target is None:
-            continue  # bundled product archived since — inclusion silently no longer applies
-        included_qty = guest_count // product.included_per_guests
-        if included_qty <= 0:
-            continue
-        quantity, included_quantity = line_items.get(target.id, (0, 0))
-        line_items[target.id] = (quantity + included_qty, included_quantity + included_qty)
-
-    resolved: list[dict] = []
-    for product_id, (quantity, included_quantity) in line_items.items():
-        product = products_by_id[product_id]
-        resolved.append(
-            OrderItemBase(
-                product_id=product.id,
-                name=product.name,
-                quantity=quantity,
-                price=float(product.price),
-                category=cast(OrderItemCategory, product.category),
-                included_quantity=included_quantity,
-            ).model_dump()
-        )
-    return resolved
-
-
 async def _ensure_public_registration_allowed(
     db: AsyncSession,
     event: Event,
@@ -813,11 +509,3 @@ async def _ensure_public_registration_allowed(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="This event is fully booked.",
         )
-
-
-async def _fetch_person_map(db: AsyncSession, rows: list[Registration]) -> dict[str, Person]:
-    if not rows:
-        return {}
-    person_ids = {row.person_id for row in rows}
-    people = (await db.execute(select(Person).where(Person.id.in_(person_ids)))).scalars().all()
-    return {person.id: person for person in people}

--- a/backend/app/routers/registrations.py
+++ b/backend/app/routers/registrations.py
@@ -28,7 +28,6 @@ from app.live import live_bus
 from app.live import mapping as live_mapping
 from app.models import Edition, Event, Layout, Person, Product, Registration, ReservationAccessToken, Table
 from app.ratelimit import check_rate_limit, get_client_ip
-from app.routers.people import parse_phone
 from app.schemas import (
     OrderItemBase,
     OrderItemCategory,
@@ -50,6 +49,7 @@ from app.services.operational_search import (
     person_search_order_by,
     person_search_predicate,
 )
+from app.services.people_service import parse_phone
 from app.spam import check_form_timing, check_honeypot
 from app.utils import (
     make_id,

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -1,58 +1,26 @@
-"""Site-wide settings — currently just the maintenance-mode toggle."""
+"""Site-wide settings — currently just the maintenance-mode toggle.
+
+Business logic lives in ``app.services.settings_service`` and is shared with
+``app.mcp.admin.settings``.
+"""
 
 from fastapi import APIRouter, Depends, Request
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.models import AppSettings
 from app.schemas import AppSettingsOut, AppSettingsUpdate
-from app.utils import app_settings_to_dict
+from app.services import settings_service
 
 router = APIRouter(
     prefix="/api/settings",
     tags=["settings"],
 )
 
-_SETTINGS_ID = "app_settings"
-
-
-async def _get_or_create_settings(db: AsyncSession) -> AppSettings:
-    settings = await db.get(AppSettings, _SETTINGS_ID)
-    if settings is not None:
-        return settings
-
-    # Two concurrent first requests can both see no row and both try to insert
-    # the fixed id; the loser's flush raises IntegrityError rather than a
-    # second row. Roll back and re-fetch instead of erroring out — either
-    # request landing on the same row is a correct outcome here.
-    #
-    # Flushes rather than commits, so the caller controls the transaction
-    # boundary — update_settings folds the row creation, the mutation, and the
-    # audit entry into one atomic commit instead of two separate ones.
-    settings = AppSettings(id=_SETTINGS_ID)
-    db.add(settings)
-    try:
-        await db.flush()
-    except IntegrityError:
-        await db.rollback()
-        settings = await db.get(AppSettings, _SETTINGS_ID)
-        if settings is None:
-            # The conflicting insert guarantees a row now — assert would do here,
-            # but assertions are stripped under `-O`, silently returning None and
-            # turning this into an AttributeError deep in the caller instead.
-            raise RuntimeError("Application settings row could not be created or reloaded.") from None
-        return settings
-    return settings
-
 
 @router.get("", response_model=AppSettingsOut)
 async def get_settings(db: AsyncSession = Depends(get_db)) -> dict:
-    settings = await _get_or_create_settings(db)
-    await db.commit()  # persist a freshly-created default row; a no-op otherwise
-    return app_settings_to_dict(settings)
+    return await settings_service.get_settings(db)
 
 
 @router.put("", response_model=AppSettingsOut)
@@ -63,18 +31,6 @@ async def update_settings(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    settings = await _get_or_create_settings(db)
-    if body.maintenance_mode is not None:
-        settings.maintenance_mode = body.maintenance_mode
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="settings_updated",
-        resource_type="app_settings",
-        resource_id=_SETTINGS_ID,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
+    return await settings_service.update_settings(
+        db, actor=actor, body=body, request_id=getattr(request.state, "request_id", None)
     )
-    await db.commit()
-    await db.refresh(settings)
-    return app_settings_to_dict(settings)

--- a/backend/app/routers/volunteers.py
+++ b/backend/app/routers/volunteers.py
@@ -10,14 +10,14 @@ multiple non-contiguous festival dates. Business logic lives in
 import csv
 import io
 
-from fastapi import APIRouter, Depends, Query, Request, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import StreamingResponse
 
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
-from app.dependencies import Pagination, apply_pagination
+from app.dependencies import Pagination, apply_pagination, get_request_id
 from app.models import Person
 from app.schemas import VolunteerCreate, VolunteerOut, VolunteerUpdate
 from app.services import volunteers_service
@@ -33,13 +33,11 @@ router = APIRouter(
 @router.post("", response_model=VolunteerOut, status_code=status.HTTP_201_CREATED)
 async def create_volunteer(
     body: VolunteerCreate,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
+    request_id: str | None = Depends(get_request_id),
 ) -> dict:
-    return await volunteers_service.create_volunteer(
-        db, body=body, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    return await volunteers_service.create_volunteer(db, body=body, actor=actor, request_id=request_id)
 
 
 @router.get("", response_model=list[VolunteerOut])
@@ -107,22 +105,20 @@ async def get_volunteer(volunteer_id: str, db: AsyncSession = Depends(get_db)) -
 async def update_volunteer(
     volunteer_id: str,
     body: VolunteerUpdate,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
+    request_id: str | None = Depends(get_request_id),
 ) -> dict:
     volunteer = await volunteers_service.get_volunteer_or_404(db, volunteer_id)
-    return await volunteers_service.apply_volunteer_update(
-        db, volunteer, body, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    return await volunteers_service.apply_volunteer_update(db, volunteer, body, actor=actor, request_id=request_id)
 
 
 @router.delete("/{volunteer_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_volunteer(
     volunteer_id: str,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
+    request_id: str | None = Depends(get_request_id),
 ) -> None:
     """Remove the volunteer role from a person (soft archive).
 
@@ -130,6 +126,4 @@ async def delete_volunteer(
     semantics.
     """
     volunteer = await volunteers_service.get_volunteer_or_404(db, volunteer_id)
-    await volunteers_service.delete_volunteer(
-        db, volunteer, actor=actor, request_id=getattr(request.state, "request_id", None)
-    )
+    await volunteers_service.delete_volunteer(db, volunteer, actor=actor, request_id=request_id)

--- a/backend/app/routers/volunteers.py
+++ b/backend/app/routers/volunteers.py
@@ -2,120 +2,32 @@
 
 Volunteers are stored in the people table as a subset with role='volunteer'.
 Volunteer help periods are stored separately so a person can help across
-multiple non-contiguous festival dates.
+multiple non-contiguous festival dates. Business logic lives in
+``app.services.volunteers_service`` and is shared with
+``app.mcp.admin.volunteers``.
 """
 
 import csv
 import io
-from collections import defaultdict
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import delete, or_, select
+from fastapi import APIRouter, Depends, Query, Request, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import StreamingResponse
 
-from app.audit import write_audit_entry
 from app.auth import get_actor_id, require_admin
 from app.database import get_db
 from app.dependencies import Pagination, apply_pagination
-from app.models import Person, VolunteerPeriod
-from app.schemas import (
-    VolunteerCreate,
-    VolunteerHelpPeriodIn,
-    VolunteerOut,
-    VolunteerUpdate,
-)
-from app.utils import get_or_404, make_id, person_to_dict, roles_contains
+from app.models import Person
+from app.schemas import VolunteerCreate, VolunteerOut, VolunteerUpdate
+from app.services import volunteers_service
+from app.utils import roles_contains
 
 router = APIRouter(
     prefix="/api/volunteers",
     tags=["volunteers"],
     dependencies=[Depends(require_admin)],
 )
-
-
-def _ensure_volunteer_role(person: Person) -> None:
-    roles = set(person.roles or [])
-    roles.add("volunteer")
-    person.roles = sorted(roles)
-
-
-def _remove_volunteer_role(person: Person) -> None:
-    person.roles = sorted(role for role in (person.roles or []) if role != "volunteer")
-
-
-async def _ensure_unique_fields(
-    db: AsyncSession,
-    national_register_number: str | None = None,
-    eid_document_number: str | None = None,
-    exclude_id: str | None = None,
-) -> None:
-    if national_register_number is not None:
-        national_register_number = national_register_number.strip() or None
-    if eid_document_number is not None:
-        eid_document_number = eid_document_number.strip() or None
-
-    if national_register_number is not None:
-        stmt = select(Person).where(Person.national_register_number == national_register_number)
-        if exclude_id:
-            stmt = stmt.where(Person.id != exclude_id)
-        existing = (await db.execute(stmt)).scalar_one_or_none()
-        if existing is not None:
-            raise HTTPException(
-                status_code=409,
-                detail="Person with this national register number already exists.",
-            )
-
-    if eid_document_number is not None:
-        stmt = select(Person).where(Person.eid_document_number == eid_document_number)
-        if exclude_id:
-            stmt = stmt.where(Person.id != exclude_id)
-        existing = (await db.execute(stmt)).scalar_one_or_none()
-        if existing is not None:
-            raise HTTPException(
-                status_code=409,
-                detail="Person with this eID document number already exists.",
-            )
-
-
-async def _replace_help_periods(
-    db: AsyncSession,
-    volunteer_id: str,
-    help_periods: list[VolunteerHelpPeriodIn],
-) -> None:
-    await db.execute(delete(VolunteerPeriod).where(VolunteerPeriod.volunteer_id == volunteer_id))
-    for period in help_periods:
-        db.add(
-            VolunteerPeriod(
-                volunteer_id=volunteer_id,
-                first_help_day=period.first_help_day,
-                last_help_day=period.last_help_day,
-            )
-        )
-
-
-async def _load_periods_map(db: AsyncSession, volunteer_ids: list[str]) -> dict[str, list[VolunteerPeriod]]:
-    if not volunteer_ids:
-        return {}
-    rows = (
-        (
-            await db.execute(
-                select(VolunteerPeriod)
-                .where(VolunteerPeriod.volunteer_id.in_(volunteer_ids))
-                .order_by(
-                    VolunteerPeriod.volunteer_id,
-                    VolunteerPeriod.first_help_day,
-                    VolunteerPeriod.id,
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-    grouped: dict[str, list[VolunteerPeriod]] = defaultdict(list)
-    for row in rows:
-        grouped[row.volunteer_id].append(row)
-    return grouped
 
 
 @router.post("", response_model=VolunteerOut, status_code=status.HTTP_201_CREATED)
@@ -125,38 +37,9 @@ async def create_volunteer(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    await _ensure_unique_fields(
-        db,
-        national_register_number=body.national_register_number,
-        eid_document_number=body.eid_document_number,
+    return await volunteers_service.create_volunteer(
+        db, body=body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-
-    person = Person(
-        id=make_id("per"),
-        name=body.name,
-        address=body.address,
-        national_register_number=body.national_register_number,
-        eid_document_number=body.eid_document_number,
-        active=body.active,
-    )
-    _ensure_volunteer_role(person)
-
-    db.add(person)
-    await db.flush()
-    await _replace_help_periods(db, person.id, body.help_periods)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="volunteer_created",
-        resource_type="person",
-        resource_id=person.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"help_period_count": len(body.help_periods)},
-    )
-    await db.commit()
-    await db.refresh(person)
-    periods_map = await _load_periods_map(db, [person.id])
-    return _to_volunteer_out(person, periods_map.get(person.id, []))
 
 
 @router.get("", response_model=list[VolunteerOut])
@@ -166,29 +49,12 @@ async def list_volunteers(
     active: bool | None = Query(default=None),
     pagination: Pagination = Depends(),
 ) -> list[dict]:
-    stmt = select(Person).where(roles_contains("volunteer"))
-
-    if active is not None:
-        stmt = stmt.where(Person.active == active)
-
-    if q:
-        q_escaped = q.strip().replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-        q_like = f"%{q_escaped}%"
-        stmt = stmt.where(
-            or_(
-                Person.name.ilike(q_like, escape="\\"),
-                Person.address.ilike(q_like, escape="\\"),
-                Person.national_register_number.ilike(q_like, escape="\\"),
-                Person.eid_document_number.ilike(q_like, escape="\\"),
-            )
-        )
-
-    stmt = stmt.order_by(Person.created_at.desc(), Person.id.desc())
+    stmt = volunteers_service.search_volunteers_stmt(q=q, active=active)
     stmt = apply_pagination(stmt, pagination)
 
     rows = (await db.execute(stmt)).scalars().all()
-    periods_map = await _load_periods_map(db, [row.id for row in rows])
-    return [_to_volunteer_out(v, periods_map.get(v.id, [])) for v in rows]
+    periods_map = await volunteers_service.load_periods_map(db, [row.id for row in rows])
+    return [volunteers_service.to_volunteer_out(v, periods_map.get(v.id, [])) for v in rows]
 
 
 @router.get("/export")
@@ -201,7 +67,7 @@ async def export_volunteers_csv(db: AsyncSession = Depends(get_db)) -> Streaming
     """
     stmt = select(Person).where(roles_contains("volunteer"), Person.active.is_(True)).order_by(Person.name)
     volunteers = (await db.execute(stmt)).scalars().all()
-    periods_map = await _load_periods_map(db, [v.id for v in volunteers])
+    periods_map = await volunteers_service.load_periods_map(db, [v.id for v in volunteers])
 
     buffer = io.StringIO()
     writer = csv.writer(buffer)
@@ -232,9 +98,9 @@ async def export_volunteers_csv(db: AsyncSession = Depends(get_db)) -> Streaming
 
 @router.get("/{volunteer_id}", response_model=VolunteerOut)
 async def get_volunteer(volunteer_id: str, db: AsyncSession = Depends(get_db)) -> dict:
-    volunteer = await _get_volunteer_or_404(db, volunteer_id)
-    periods_map = await _load_periods_map(db, [volunteer.id])
-    return _to_volunteer_out(volunteer, periods_map.get(volunteer.id, []))
+    volunteer = await volunteers_service.get_volunteer_or_404(db, volunteer_id)
+    periods_map = await volunteers_service.load_periods_map(db, [volunteer.id])
+    return volunteers_service.to_volunteer_out(volunteer, periods_map.get(volunteer.id, []))
 
 
 @router.put("/{volunteer_id}", response_model=VolunteerOut)
@@ -245,49 +111,10 @@ async def update_volunteer(
     db: AsyncSession = Depends(get_db),
     actor: str = Depends(get_actor_id),
 ) -> dict:
-    volunteer = await _get_volunteer_or_404(db, volunteer_id)
-
-    if "national_register_number" in body.model_fields_set and body.national_register_number is not None:
-        await _ensure_unique_fields(
-            db,
-            national_register_number=body.national_register_number,
-            exclude_id=volunteer_id,
-        )
-    if "eid_document_number" in body.model_fields_set and body.eid_document_number is not None:
-        await _ensure_unique_fields(
-            db,
-            eid_document_number=body.eid_document_number,
-            exclude_id=volunteer_id,
-        )
-
-    for field in (
-        "name",
-        "address",
-        "national_register_number",
-        "eid_document_number",
-        "active",
-    ):
-        if field in body.model_fields_set:
-            setattr(volunteer, field, getattr(body, field))
-
-    if "help_periods" in body.model_fields_set and body.help_periods is not None:
-        await _replace_help_periods(db, volunteer_id, body.help_periods)
-
-    _ensure_volunteer_role(volunteer)
-
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="volunteer_updated",
-        resource_type="person",
-        resource_id=volunteer.id,
-        request_id=getattr(request.state, "request_id", None),
-        details={"fields_changed": sorted(body.model_fields_set)},
+    volunteer = await volunteers_service.get_volunteer_or_404(db, volunteer_id)
+    return await volunteers_service.apply_volunteer_update(
+        db, volunteer, body, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    await db.commit()
-    await db.refresh(volunteer)
-    periods_map = await _load_periods_map(db, [volunteer.id])
-    return _to_volunteer_out(volunteer, periods_map.get(volunteer.id, []))
 
 
 @router.delete("/{volunteer_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -299,49 +126,10 @@ async def delete_volunteer(
 ) -> None:
     """Remove the volunteer role from a person (soft archive).
 
-    The underlying Person record is kept intact so that reservations,
-    membership data, and audit history are preserved.  Only the 'volunteer'
-    role and associated help periods are removed.
+    See ``app.services.volunteers_service.delete_volunteer`` for the exact
+    semantics.
     """
-    volunteer = await _get_volunteer_or_404(db, volunteer_id)
-    await db.execute(delete(VolunteerPeriod).where(VolunteerPeriod.volunteer_id == volunteer_id))
-    _remove_volunteer_role(volunteer)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="volunteer_role_removed",
-        resource_type="person",
-        resource_id=volunteer_id,
-        request_id=getattr(request.state, "request_id", None),
-        details={},
+    volunteer = await volunteers_service.get_volunteer_or_404(db, volunteer_id)
+    await volunteers_service.delete_volunteer(
+        db, volunteer, actor=actor, request_id=getattr(request.state, "request_id", None)
     )
-    await db.commit()
-
-
-async def _get_volunteer_or_404(db: AsyncSession, volunteer_id: str) -> Person:
-    volunteer = await get_or_404(db, Person, volunteer_id, "Volunteer not found.")
-    if "volunteer" not in volunteer.roles:
-        raise HTTPException(status_code=404, detail="Volunteer not found.")
-    return volunteer
-
-
-def _to_volunteer_out(person: Person, help_periods: list[VolunteerPeriod]) -> dict:
-    d = person_to_dict(person)
-    return {
-        "id": d["id"],
-        "name": d["name"],
-        "address": d["address"],
-        "national_register_number": d["national_register_number"],
-        "eid_document_number": d["eid_document_number"],
-        "active": d["active"],
-        "help_periods": [
-            {
-                "id": period.id,
-                "first_help_day": period.first_help_day,
-                "last_help_day": period.last_help_day,
-            }
-            for period in help_periods
-        ],
-        "created_at": d["created_at"],
-        "updated_at": d["updated_at"],
-    }

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -62,7 +62,7 @@ class OrderItemRequest(BaseModel):
 
     Only `product_id` and `quantity` are client-supplied; `name`/`price`/`category`
     are resolved server-side against the event's real products (see
-    `_resolve_order_items` in routers/registrations.py) so a client can never set an
+    `app.services.registrations_service.resolve_order_items`) so a client can never set an
     arbitrary or zero price, or order a product that doesn't exist.
     """
 

--- a/backend/app/services/editions_service.py
+++ b/backend/app/services/editions_service.py
@@ -166,7 +166,11 @@ async def validate_exhibitor_ids(db: AsyncSession, exhibitor_ids: list[int]) -> 
     # Lock the referenced exhibitor rows so a concurrent retype-to-vendor (see
     # exhibitors.update_exhibitor, which locks the same rows) can't interleave
     # with this check and leave a vendor exhibitor linked to an edition lineup.
-    await db.execute(select(Exhibitor.id).where(Exhibitor.id.in_(exhibitor_ids)).with_for_update())
+    # Ordered by id so two overlapping requests always acquire locks in the same
+    # sequence and can't deadlock against each other.
+    await db.execute(
+        select(Exhibitor.id).where(Exhibitor.id.in_(exhibitor_ids)).order_by(Exhibitor.id).with_for_update()
+    )
     exhibitor_map = await _load_exhibitors_by_ids(db, set(exhibitor_ids))
     invalid = [eid for eid in exhibitor_ids if eid not in exhibitor_map]
     if invalid:
@@ -416,3 +420,19 @@ async def apply_edition_update(
     await commit_or_conflict(db)
     edition = await get_edition_or_404(db, edition.id)
     return await edition_payload(db, edition, active_only=False)
+
+
+async def delete_edition(db: AsyncSession, edition: Edition, *, actor: str, request_id: str | None = None) -> dict:
+    edition_id = edition.id
+    await db.delete(edition)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="edition_deleted",
+        resource_type="edition",
+        resource_id=edition_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": edition_id}

--- a/backend/app/services/editions_service.py
+++ b/backend/app/services/editions_service.py
@@ -1,0 +1,418 @@
+"""Shared application-service operations for editions.
+
+Used by both ``app.routers.editions`` (REST) and ``app.mcp.admin.editions``
+(MCP) so the deferred ``active``/``edition_type`` application, target-value
+computation, implicit exhibitor clearing, the ``deactivate_conflicting_editions``
+call, and audit-detail assembly for ``create_edition``/``apply_edition_update``
+live in exactly one place instead of two near-identical copies (#860, following
+on from #832 and #855). The payload-building and lookup helpers below back
+several other edition endpoints too, so they live here rather than in the
+router, following the pattern already used by ``app/services/rooms_service.py``
+and ``app/services/layouts_service.py``.
+
+Unlike those two modules, edition endpoints raise ``HTTPException`` directly
+(matching the pre-existing helpers this module consolidates) rather than the
+``ServiceError`` hierarchy in ``app/services/errors.py``: the REST router can
+therefore call these functions unwrapped, while the MCP adapter is
+responsible for translating ``HTTPException`` into ``MCPToolError`` at its own
+boundary (see ``app.mcp.utils.as_value_error``).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.audit import write_audit_entry
+from app.models import Edition, Event, Exhibitor, Venue
+from app.schemas import EditionCreate, EditionType, EditionUpdate
+from app.utils import edition_to_dict, event_to_summary_dict, get_or_404, venue_to_dict
+
+logger = logging.getLogger(__name__)
+
+
+async def load_editions(
+    db: AsyncSession,
+    include_inactive: bool,
+    edition_type: EditionType | None = None,
+) -> list[Edition]:
+    stmt = select(Edition).options(selectinload(Edition.events).selectinload(Event.products))
+    if not include_inactive:
+        stmt = stmt.where(Edition.active.is_(True))
+    if edition_type is not None:
+        stmt = stmt.where(Edition.edition_type == edition_type)
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def get_edition_or_404(db: AsyncSession, edition_id: str) -> Edition:
+    return await get_or_404(
+        db,
+        Edition,
+        edition_id,
+        "Edition not found.",
+        options=[selectinload(Edition.events).selectinload(Event.products)],
+    )
+
+
+async def deactivate_conflicting_editions(
+    db: AsyncSession,
+    *,
+    edition_type: str,
+    exclude_id: str | None,
+    actor: str,
+    request_id: str | None,
+) -> list[str]:
+    """Deactivate any other active edition of the same type in the same transaction.
+
+    Backs the "at most one active edition per type" invariant (#832) on the normal
+    single-request path: activating an edition transparently supersedes whichever
+    edition of that type was active before, rather than requiring the caller to
+    deactivate it first. Rows are locked with ``FOR UPDATE`` before being flipped so a
+    concurrent activation targeting one of them can't interleave. That still leaves one
+    race unresolved — two brand-new editions of the same type activated at once, with no
+    existing active row for either to lock — which is why this alone isn't the
+    invariant's backstop: the ``uq_editions_active_type`` partial unique index
+    (migration 009) is, and ``commit_or_conflict`` turns its violation into a 409.
+    """
+    stmt = select(Edition).where(Edition.edition_type == edition_type, Edition.active.is_(True))
+    if exclude_id is not None:
+        stmt = stmt.where(Edition.id != exclude_id)
+    conflicting = list((await db.execute(stmt.with_for_update())).scalars().all())
+    for other in conflicting:
+        other.active = False
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="edition_deactivated",
+            resource_type="edition",
+            resource_id=other.id,
+            request_id=request_id,
+            details={"reason": "superseded_by_activation", "edition_type": edition_type},
+        )
+    if conflicting:
+        await db.flush()
+    return [other.id for other in conflicting]
+
+
+async def commit_or_conflict(db: AsyncSession) -> None:
+    """Commit, translating a ``uq_editions_active_type`` violation into a 409.
+
+    A concurrent activation of two editions of the same type can race past
+    `deactivate_conflicting_editions` with nothing to lock; see that function's
+    docstring. Other integrity violations reaching this commit — a duplicate id
+    slipping past `create_edition`'s existence check, or a venue/co-organizer
+    deleted concurrently with this request — are re-raised as-is for
+    ``app.main.integrity_error_handler`` to report accurately instead of being
+    misreported as this specific conflict.
+    """
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        # SQLAlchemy's asyncpg dialect wraps the driver error in a fresh exception
+        # that only copies pgcode/sqlstate, not asyncpg's richer diagnostics — but
+        # it chains the original via `raise ... from error`, so the real
+        # `asyncpg.exceptions.UniqueViolationError` (with `constraint_name`) is
+        # reachable through `__cause__`.
+        constraint = getattr(getattr(exc.orig, "__cause__", None), "constraint_name", None)
+        if constraint != "uq_editions_active_type":
+            raise
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Another edition of this type was activated concurrently. Please retry.",
+        ) from exc
+
+
+async def load_venue(db: AsyncSession, venue_id: str) -> dict:
+    result = await db.execute(select(Venue).where(Venue.id == venue_id))
+    venue = result.scalar_one_or_none()
+    if venue is None:
+        raise HTTPException(status_code=404, detail=f"Venue '{venue_id}' not found.")
+    return venue_to_dict(venue)
+
+
+async def _load_venues_by_ids(db: AsyncSession, ids: set[str]) -> dict[str, dict]:
+    if not ids:
+        return {}
+    result = await db.execute(select(Venue).where(Venue.id.in_(ids)))
+    return {venue.id: venue_to_dict(venue) for venue in result.scalars().all()}
+
+
+async def _load_exhibitors_by_ids(db: AsyncSession, ids: set[int]) -> dict[int, dict]:
+    if not ids:
+        return {}
+    result = await db.execute(select(Exhibitor).where(Exhibitor.id.in_(ids), Exhibitor.active.is_(True)))
+    return {
+        exhibitor.id: {
+            "id": exhibitor.id,
+            "name": exhibitor.name,
+            "image": exhibitor.image,
+            "website": exhibitor.website,
+            "type": exhibitor.type,
+        }
+        for exhibitor in result.scalars().all()
+    }
+
+
+async def validate_exhibitor_ids(db: AsyncSession, exhibitor_ids: list[int]) -> None:
+    if not exhibitor_ids:
+        return
+    # Lock the referenced exhibitor rows so a concurrent retype-to-vendor (see
+    # exhibitors.update_exhibitor, which locks the same rows) can't interleave
+    # with this check and leave a vendor exhibitor linked to an edition lineup.
+    await db.execute(select(Exhibitor.id).where(Exhibitor.id.in_(exhibitor_ids)).with_for_update())
+    exhibitor_map = await _load_exhibitors_by_ids(db, set(exhibitor_ids))
+    invalid = [eid for eid in exhibitor_ids if eid not in exhibitor_map]
+    if invalid:
+        raise HTTPException(status_code=400, detail=f"Invalid or inactive exhibitor IDs: {invalid}")
+    vendor_ids = [eid for eid in exhibitor_ids if exhibitor_map[eid]["type"] == "vendor"]
+    if vendor_ids:
+        raise HTTPException(
+            status_code=400, detail=f"Vendor-type exhibitors may not be linked to editions: {vendor_ids}"
+        )
+
+
+async def validate_co_organizer(db: AsyncSession, exhibitor_id: int | None) -> None:
+    """A co-organizer must be an existing, active exhibitor.
+
+    Unlike the lineup, any exhibitor type is acceptable and any edition type may
+    have one — co-organizing says who ran the event with the vzw, not who was
+    programmed at it.
+    """
+    if exhibitor_id is None:
+        return
+    exhibitor = (
+        await db.execute(select(Exhibitor).where(Exhibitor.id == exhibitor_id, Exhibitor.active.is_(True)))
+    ).scalar_one_or_none()
+    if exhibitor is None:
+        raise HTTPException(status_code=400, detail=f"Invalid or inactive co-organizer exhibitor id: {exhibitor_id}")
+
+
+def validate_exhibitors_allowed(edition_type: EditionType, exhibitors: list[int]) -> None:
+    if edition_type != "festival" and exhibitors:
+        raise HTTPException(
+            status_code=400,
+            detail="Exhibitors are only supported on festival editions.",
+        )
+
+
+def active_events(edition: Edition) -> list[Event]:
+    return [event for event in edition.events if event.active]
+
+
+def _edition_dates(events: list[Event]) -> list[date]:
+    """Unique event dates in chronological order (relies on `events` being pre-sorted by date)."""
+    return list(dict.fromkeys(event.date for event in events))
+
+
+def edition_start_date(events: list[Event]) -> date | None:
+    return events[0].date if events else None
+
+
+def edition_end_date(events: list[Event]) -> date | None:
+    return events[-1].date if events else None
+
+
+def sorted_editions(editions: list[Edition], *, active_only: bool) -> list[Edition]:
+    def sort_key(edition: Edition) -> tuple:
+        events = active_events(edition) if active_only else edition.events
+        return (
+            edition_start_date(events) or date.max,
+            edition_end_date(events) or date.max,
+            edition.year,
+            edition.month,
+            edition.created_at,
+        )
+
+    return sorted(editions, key=sort_key)
+
+
+def _resolve_exhibitors(edition: Edition, exhibitor_map: dict[int, dict]) -> tuple[list[dict], list[dict], list[dict]]:
+    producers: list[dict] = []
+    sponsors: list[dict] = []
+    vendors: list[dict] = []
+    for exhibitor_id in edition.exhibitors:
+        item = exhibitor_map.get(exhibitor_id)
+        if item is None:
+            continue
+        if item["type"] == "producer":
+            producers.append(item)
+        elif item["type"] == "sponsor":
+            sponsors.append(item)
+        elif item["type"] == "vendor":
+            vendors.append(item)
+    return producers, sponsors, vendors
+
+
+async def edition_payloads(db: AsyncSession, editions: list[Edition], *, active_only: bool) -> list[dict]:
+    """Build edition response payloads.
+
+    `active_only` controls whether inactive events are dropped from the serialized
+    `events`/`dates` fields. Public endpoints (`/active`, `/upcoming`) pass `True` so
+    inactive (draft/cancelled) events never appear in unauthenticated responses;
+    admin endpoints pass `False` so event management keeps seeing everything.
+    """
+    venues = await _load_venues_by_ids(db, {edition.venue_id for edition in editions})
+    exhibitor_map = await _load_exhibitors_by_ids(
+        db,
+        {eid for edition in editions for eid in edition.exhibitors}
+        | {edition.co_organizer_exhibitor_id for edition in editions if edition.co_organizer_exhibitor_id},
+    )
+    payloads = []
+    for edition in editions:
+        if edition.venue_id not in venues:
+            logger.warning(
+                "Skipping edition payload because venue is missing. edition_id=%s venue_id=%s",
+                edition.id,
+                edition.venue_id,
+            )
+            continue
+        producers, sponsors, vendors = _resolve_exhibitors(edition, exhibitor_map)
+        # `Edition.events` is loaded pre-ordered by (date, start_time, created_at); filtering
+        # to active events preserves that order, so no re-sort is needed here.
+        events = active_events(edition) if active_only else edition.events
+        payloads.append(
+            edition_to_dict(
+                edition,
+                venue=venues[edition.venue_id],
+                dates=_edition_dates(events),
+                events=[event_to_summary_dict(event) for event in events],
+                producers=producers,
+                sponsors=sponsors,
+                vendors=vendors,
+                co_organizer=exhibitor_map.get(edition.co_organizer_exhibitor_id)
+                if edition.co_organizer_exhibitor_id
+                else None,
+            )
+        )
+    return payloads
+
+
+async def edition_payload(db: AsyncSession, edition: Edition, *, active_only: bool) -> dict:
+    payloads = await edition_payloads(db, [edition], active_only=active_only)
+    if not payloads:
+        raise HTTPException(status_code=404, detail="Edition not found.")
+    return payloads[0]
+
+
+async def create_edition(db: AsyncSession, *, body: EditionCreate, actor: str, request_id: str | None = None) -> dict:
+    if (await db.execute(select(Edition).where(Edition.id == body.id))).scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Edition '{body.id}' already exists.",
+        )
+    await load_venue(db, body.venue_id)
+    validate_exhibitors_allowed(body.edition_type, body.exhibitors)
+
+    edition = Edition(
+        id=body.id,
+        year=body.year,
+        month=body.month,
+        venue_id=body.venue_id,
+        edition_type=body.edition_type,
+        exhibitors=list(body.exhibitors),
+        co_organizer_exhibitor_id=body.co_organizer_exhibitor_id,
+        active=body.active,
+    )
+    await validate_exhibitor_ids(db, edition.exhibitors)
+    await validate_co_organizer(db, edition.co_organizer_exhibitor_id)
+
+    deactivated: list[str] = []
+    if edition.active:
+        deactivated = await deactivate_conflicting_editions(
+            db, edition_type=edition.edition_type, exclude_id=None, actor=actor, request_id=request_id
+        )
+
+    db.add(edition)
+    details: dict = {"year": edition.year, "month": edition.month, "edition_type": edition.edition_type}
+    if deactivated:
+        details["deactivated_conflicting_editions"] = deactivated
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="edition_created",
+        resource_type="edition",
+        resource_id=edition.id,
+        request_id=request_id,
+        details=details,
+    )
+    await commit_or_conflict(db)
+    edition = await get_edition_or_404(db, edition.id)
+    return await edition_payload(db, edition, active_only=False)
+
+
+async def apply_edition_update(
+    db: AsyncSession, edition: Edition, body: EditionUpdate, *, actor: str, request_id: str | None = None
+) -> dict:
+    if "co_organizer_exhibitor_id" in body.model_fields_set:
+        await validate_co_organizer(db, body.co_organizer_exhibitor_id)
+        edition.co_organizer_exhibitor_id = body.co_organizer_exhibitor_id
+
+    for field in ["year", "month"]:
+        if field in body.model_fields_set:
+            setattr(edition, field, getattr(body, field))
+
+    if "venue_id" in body.model_fields_set and body.venue_id is not None:
+        await load_venue(db, body.venue_id)
+        edition.venue_id = body.venue_id
+
+    # `active`/`edition_type` are deliberately not applied to `edition` yet: doing so
+    # here would dirty the object before `deactivate_conflicting_editions` runs below,
+    # and any autoflush in between (the exhibitor/co-organizer validations above already
+    # ran, but `validate_exhibitor_ids` below issues one too) could flush this row into
+    # an (edition_type, active) state that collides with the still-active conflicting
+    # row — the exact violation the deactivation step exists to avoid causing.
+    target_edition_type: str = body.edition_type if "edition_type" in body.model_fields_set else edition.edition_type  # ty: ignore[invalid-assignment]
+    target_active: bool = body.active if "active" in body.model_fields_set else edition.active  # ty: ignore[invalid-assignment]
+
+    exhibitors_implicitly_cleared = False
+    if "exhibitors" in body.model_fields_set and body.exhibitors is not None:
+        validate_exhibitors_allowed(target_edition_type, body.exhibitors)  # ty: ignore[invalid-argument-type]
+        await validate_exhibitor_ids(db, body.exhibitors)
+        edition.exhibitors = list(body.exhibitors)
+    elif target_edition_type != "festival" and edition.exhibitors:
+        # The edition type changed away from festival without an explicit exhibitors
+        # payload — either just now (edition_type in this update) or on an edition
+        # already non-festival before this update. Off-festival editions can't carry
+        # exhibitors, so clear the now-invalid associations as part of the same atomic
+        # transition instead of rejecting the update.
+        edition.exhibitors = []
+        exhibitors_implicitly_cleared = True
+
+    validate_exhibitors_allowed(target_edition_type, edition.exhibitors)  # ty: ignore[invalid-argument-type]
+
+    deactivated: list[str] = []
+    if target_active:
+        deactivated = await deactivate_conflicting_editions(
+            db, edition_type=target_edition_type, exclude_id=edition.id, actor=actor, request_id=request_id
+        )
+
+    # Safe to apply now: any conflicting active row of `target_edition_type` has
+    # already been deactivated and flushed above.
+    for field in ("active", "edition_type"):
+        if field in body.model_fields_set:
+            setattr(edition, field, getattr(body, field))
+
+    details: dict = {"fields_changed": sorted(body.model_fields_set)}
+    if exhibitors_implicitly_cleared:
+        details["exhibitors_cleared"] = True
+    if deactivated:
+        details["deactivated_conflicting_editions"] = deactivated
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="edition_updated",
+        resource_type="edition",
+        resource_id=edition.id,
+        request_id=request_id,
+        details=details,
+    )
+    await commit_or_conflict(db)
+    edition = await get_edition_or_404(db, edition.id)
+    return await edition_payload(db, edition, active_only=False)

--- a/backend/app/services/events_service.py
+++ b/backend/app/services/events_service.py
@@ -1,0 +1,220 @@
+"""Shared application-service operations for events.
+
+Used by both ``app.routers.events`` (REST) and ``app.mcp.admin.events`` (MCP)
+so the off-festival edition date-cardinality check, registration-settings
+validation, the registration-cascade delete guard, and audit-detail assembly
+for create/update/delete live in exactly one place instead of two copies
+(#860). Events raise ``HTTPException`` directly (matching the pre-existing
+shared helpers this consolidates, following the same convention as
+``app/services/editions_service.py``) rather than the ``ServiceError``
+hierarchy in ``app/services/errors.py``; the REST router can therefore call
+these functions unwrapped, while the MCP adapter translates ``HTTPException``
+into ``MCPToolError`` at its own boundary (see ``app.mcp.utils.as_value_error``).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.audit import write_audit_entry
+from app.models import Edition, Event, Registration
+from app.schemas import EventCreate, EventUpdate
+from app.utils import event_to_summary_dict, get_or_404, make_id
+
+
+async def get_event_or_404(db: AsyncSession, event_id: str) -> Event:
+    return await get_or_404(
+        db,
+        Event,
+        event_id,
+        "Event not found.",
+        options=[selectinload(Event.edition), selectinload(Event.products)],
+    )
+
+
+async def ensure_edition_exists(db: AsyncSession, edition_id: str) -> Edition:
+    result = await db.execute(select(Edition).where(Edition.id == edition_id))
+    edition = result.scalar_one_or_none()
+    if edition is None:
+        raise HTTPException(status_code=404, detail=f"Edition '{edition_id}' not found.")
+    return edition
+
+
+async def validate_standalone_event_date(
+    db: AsyncSession,
+    edition: Edition,
+    event_date: date,
+    exclude_event_id: str | None = None,
+) -> None:
+    """Enforce the off-festival edition event cardinality contract.
+
+    Off-festival editions (`bourse`, `capsule_exchange`) may contain any number of events
+    (e.g. separate opening, tasting, and auction entries), but every event on such an
+    edition must share the same calendar date. Festival editions are unrestricted since
+    they legitimately span multiple days. The public UI and admin UI both render every
+    active event for an edition, so this is the only cardinality constraint enforced.
+    """
+    if edition.edition_type == "festival":
+        return
+    stmt = select(Event.date).where(Event.edition_id == edition.id)
+    if exclude_event_id is not None:
+        stmt = stmt.where(Event.id != exclude_event_id)
+    existing_dates = {row[0] for row in (await db.execute(stmt)).all()}
+    resulting_dates = existing_dates | {event_date}
+    if len(resulting_dates) > 1:
+        raise HTTPException(
+            status_code=400,
+            detail="Standalone editions may only contain events on a single date.",
+        )
+
+
+def validate_registration_settings(
+    *,
+    registration_required: bool,
+    registrations_open_from: datetime | None,
+    max_capacity: int | None,
+) -> None:
+    if registration_required:
+        return
+    if registrations_open_from is not None or max_capacity is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=("registrations_open_from and max_capacity may only be set when registration_required is true."),
+        )
+
+
+async def reject_if_registrations_exist(db: AsyncSession, event_id: str) -> None:
+    """Block event deletion while registrations still reference it.
+
+    ``registrations.event_id`` is non-nullable and the ORM relationship has no
+    delete cascade configured (registrations carry payment/attendance/order
+    history, so silently orphaning or cascading them is unsafe). Without this
+    check, ``db.delete(event)`` reaches the database, which raises a raw
+    ``NotNullViolationError`` that would otherwise surface driver/SQL details
+    and registration row contents to the caller.
+    """
+    count = (
+        await db.execute(select(func.count()).select_from(Registration).where(Registration.event_id == event_id))
+    ).scalar_one()
+    if count:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Cannot delete event: {count} registration(s) are still linked to it. Delete or reassign them first."
+            ),
+        )
+
+
+async def create_event(db: AsyncSession, *, body: EventCreate, actor: str, request_id: str | None = None) -> dict:
+    edition = await ensure_edition_exists(db, body.edition_id)
+    await validate_standalone_event_date(db, edition, body.date)
+    validate_registration_settings(
+        registration_required=body.registration_required,
+        registrations_open_from=body.registrations_open_from,
+        max_capacity=body.max_capacity,
+    )
+    event = Event(
+        id=make_id("evt"),
+        edition_id=body.edition_id,
+        title=body.title,
+        description=body.description,
+        date=body.date,
+        start_time=body.start_time,
+        end_time=body.end_time,
+        category=body.category,
+        registration_required=body.registration_required,
+        registrations_open_from=body.registrations_open_from,
+        max_capacity=body.max_capacity,
+        active=body.active,
+    )
+    db.add(event)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="event_created",
+        resource_type="event",
+        resource_id=event.id,
+        request_id=request_id,
+        details={"title": event.title, "edition_id": event.edition_id},
+    )
+    await db.commit()
+    event = await get_event_or_404(db, event.id)
+    return event_to_summary_dict(event, include_edition=True)
+
+
+async def apply_event_update(
+    db: AsyncSession, event: Event, body: EventUpdate, *, actor: str, request_id: str | None = None
+) -> dict:
+    edition = event.edition
+
+    if "edition_id" in body.model_fields_set and body.edition_id is not None:
+        edition = await ensure_edition_exists(db, body.edition_id)
+        event.edition_id = body.edition_id
+
+    fields_set = body.model_fields_set
+    candidate_date = body.date if "date" in fields_set and body.date is not None else event.date
+    candidate_registration_required = (
+        body.registration_required
+        if "registration_required" in fields_set and body.registration_required is not None
+        else event.registration_required
+    )
+    candidate_registrations_open_from = (
+        body.registrations_open_from if "registrations_open_from" in fields_set else event.registrations_open_from
+    )
+    candidate_max_capacity = body.max_capacity if "max_capacity" in fields_set else event.max_capacity
+    await validate_standalone_event_date(db, edition, candidate_date, exclude_event_id=event.id)
+    validate_registration_settings(
+        registration_required=candidate_registration_required,
+        registrations_open_from=candidate_registrations_open_from,
+        max_capacity=candidate_max_capacity,
+    )
+
+    for field in (
+        "title",
+        "description",
+        "date",
+        "start_time",
+        "end_time",
+        "category",
+        "registration_required",
+        "registrations_open_from",
+        "max_capacity",
+        "active",
+    ):
+        if field in fields_set:
+            setattr(event, field, getattr(body, field))
+
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="event_updated",
+        resource_type="event",
+        resource_id=event.id,
+        request_id=request_id,
+        details={"fields_changed": sorted(body.model_fields_set)},
+    )
+    await db.commit()
+    event = await get_event_or_404(db, event.id)
+    return event_to_summary_dict(event, include_edition=True)
+
+
+async def delete_event(db: AsyncSession, event: Event, *, actor: str, request_id: str | None = None) -> dict:
+    event_id = event.id
+    await reject_if_registrations_exist(db, event_id)
+    await db.delete(event)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="event_deleted",
+        resource_type="event",
+        resource_id=event_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": event_id}

--- a/backend/app/services/exhibitors_service.py
+++ b/backend/app/services/exhibitors_service.py
@@ -1,0 +1,160 @@
+"""Shared application-service operations for exhibitors.
+
+Used by both ``app.routers.exhibitors`` (REST) and ``app.mcp.admin.exhibitors``
+(MCP) so contact-person resolution, the vendor-retype-vs-linked-editions guard,
+and audit-detail assembly live in exactly one place instead of two copies
+(#860). Follows the ``ServiceError`` convention in ``app/services/errors.py``:
+each adapter fetches the row with its own idiomatic 404 helper (``get_or_404``
+for REST, ``get_or_error`` for MCP) and passes it in, then translates a raised
+``ServiceError`` at its own boundary.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.models import Edition, Exhibitor, Person
+from app.schemas import ExhibitorCreate, ExhibitorUpdate
+from app.services.errors import ConflictError, NotFoundError
+from app.utils import exhibitor_to_dict
+
+
+async def editions_linking(db: AsyncSession, exhibitor_id: int) -> list[str]:
+    """Ids of editions whose exhibitor list still contains this exhibitor."""
+    result = await db.execute(select(Edition))
+    return sorted(edition.id for edition in result.scalars().all() if exhibitor_id in edition.exhibitors)
+
+
+async def load_contact(db: AsyncSession, person_id: str | None) -> Person | None:
+    if not person_id:
+        return None
+    result = await db.execute(select(Person).where(Person.id == person_id))
+    return result.scalar_one_or_none()
+
+
+async def load_contacts_by_ids(db: AsyncSession, ids: list[str]) -> dict[str, Person]:
+    if not ids:
+        return {}
+    result = await db.execute(select(Person).where(Person.id.in_(ids)))
+    return {p.id: p for p in result.scalars().all()}
+
+
+async def create_exhibitor(
+    db: AsyncSession, *, body: ExhibitorCreate, actor: str, request_id: str | None = None
+) -> dict:
+    contact = await load_contact(db, body.contact_person_id)
+    if body.contact_person_id and contact is None:
+        raise NotFoundError("Person not found.")
+    e = Exhibitor(
+        name=body.name,
+        image=body.image,
+        website=body.website,
+        active=body.active,
+        type=body.type,
+        contact_person_id=body.contact_person_id,
+    )
+    db.add(e)
+    await db.flush()
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="exhibitor_created",
+        resource_type="exhibitor",
+        resource_id=str(e.id),
+        request_id=request_id,
+        details={"name": e.name, "type": e.type},
+    )
+    await db.commit()
+    await db.refresh(e)
+    return exhibitor_to_dict(e, contact)
+
+
+async def apply_exhibitor_update(
+    db: AsyncSession,
+    e: Exhibitor,
+    body: ExhibitorUpdate,
+    *,
+    actor: str,
+    request_id: str | None = None,
+    clear_contact_person: bool = False,
+) -> dict:
+    """Apply a partial exhibitor update and return the refreshed payload.
+
+    ``clear_contact_person`` exists for the MCP adapter, whose kwargs can't
+    distinguish "omitted" from "explicitly null" — REST expresses the same
+    intent via an explicit ``null`` in the JSON body, which already lands in
+    ``body.model_fields_set`` and so never needs the flag (it always passes
+    ``False``).
+    """
+    if body.name is not None:
+        e.name = body.name
+    if body.image is not None:
+        e.image = body.image
+    if body.website is not None:
+        e.website = body.website
+    if body.active is not None:
+        e.active = body.active
+    if body.type is not None:
+        if body.type == "vendor" and e.type != "vendor":
+            # Lock this exhibitor row so a concurrent edition update that's about
+            # to link it to a lineup (see validate_exhibitor_ids in
+            # editions_service, which locks the same row) can't interleave with
+            # this retype and leave a vendor exhibitor linked to an edition.
+            await db.execute(select(Exhibitor.id).where(Exhibitor.id == e.id).with_for_update())
+            # Editions reject vendor ids (see validate_exhibitor_ids in
+            # editions_service), so retyping an exhibitor that editions still link
+            # to would strand them in a state their own update endpoint refuses.
+            linked = await editions_linking(db, e.id)
+            if linked:
+                raise ConflictError(
+                    "Cannot change this exhibitor to a vendor while editions still link to it: "
+                    f"{', '.join(linked)}. Remove it from those editions first."
+                )
+        e.type = body.type
+
+    fields_changed = set(body.model_fields_set)
+    if clear_contact_person:
+        e.contact_person_id = None
+        fields_changed.add("contact_person_id")
+    elif "contact_person_id" in body.model_fields_set:
+        if body.contact_person_id is not None:
+            contact_check = await load_contact(db, body.contact_person_id)
+            if contact_check is None:
+                raise NotFoundError("Person not found.")
+        e.contact_person_id = body.contact_person_id
+
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="exhibitor_updated",
+        resource_type="exhibitor",
+        resource_id=str(e.id),
+        request_id=request_id,
+        details={"fields_changed": sorted(fields_changed)},
+    )
+    await db.commit()
+    await db.refresh(e)
+    contact = await load_contact(db, e.contact_person_id)
+    return exhibitor_to_dict(e, contact)
+
+
+async def delete_exhibitor(db: AsyncSession, e: Exhibitor, *, actor: str, request_id: str | None = None) -> dict:
+    exhibitor_id = e.id
+    editions_result = await db.execute(select(Edition))
+    for edition in editions_result.scalars().all():
+        if exhibitor_id in edition.exhibitors:
+            edition.exhibitors = [eid for eid in edition.exhibitors if eid != exhibitor_id]
+    await db.delete(e)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="exhibitor_deleted",
+        resource_type="exhibitor",
+        resource_id=str(exhibitor_id),
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": exhibitor_id}

--- a/backend/app/services/members_service.py
+++ b/backend/app/services/members_service.py
@@ -1,0 +1,229 @@
+"""Shared application-service operations for members.
+
+Used by both ``app.routers.members`` (REST) and ``app.mcp.admin.members``
+(MCP). Members are ``Person`` rows tagged with the ``member`` role — see
+``app.services.volunteers_service``/``app.services.people_service`` for the
+other ``Person``-backed services. Raises ``HTTPException`` directly (matching
+the pre-existing shared helpers this consolidates, same convention as
+``app/services/editions_service.py``) rather than the ``ServiceError``
+hierarchy in ``app/services/errors.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.audit import write_audit_entry
+from app.live import live_bus
+from app.live import mapping as live_mapping
+from app.models import Person, Registration
+from app.schemas import PersonCreate, PersonUpdate
+from app.services.people_service import parse_phone
+from app.utils import get_or_404, make_id, person_to_dict, roles_contains
+
+logger = logging.getLogger(__name__)
+
+
+def normalise_roles(roles: list[str]) -> list[str]:
+    return sorted({r.strip().lower() for r in roles if r and r.strip()})
+
+
+def normalise_optional_identity(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def ensure_member_role(person: Person) -> None:
+    roles = set(person.roles or [])
+    roles.add("member")
+    person.roles = sorted(roles)
+
+
+def has_member_role(person: Person) -> bool:
+    return "member" in (person.roles or [])
+
+
+async def ensure_unique_fields(
+    db: AsyncSession,
+    national_register_number: str | None = None,
+    eid_document_number: str | None = None,
+    exclude_id: str | None = None,
+) -> None:
+    if national_register_number is not None:
+        stmt = select(Person).where(Person.national_register_number == national_register_number)
+        if exclude_id:
+            stmt = stmt.where(Person.id != exclude_id)
+        existing = (await db.execute(stmt)).scalar_one_or_none()
+        if existing is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="Person with this national register number already exists.",
+            )
+
+    if eid_document_number is not None:
+        stmt = select(Person).where(Person.eid_document_number == eid_document_number)
+        if exclude_id:
+            stmt = stmt.where(Person.id != exclude_id)
+        existing = (await db.execute(stmt)).scalar_one_or_none()
+        if existing is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="Person with this eID document number already exists.",
+            )
+
+
+async def get_member_or_404(db: AsyncSession, person_id: str) -> Person:
+    person = await get_or_404(db, Person, person_id, "Member not found.")
+    if not has_member_role(person):
+        raise HTTPException(status_code=404, detail="Member not found.")
+    return person
+
+
+async def create_member(db: AsyncSession, *, body: PersonCreate, actor: str, request_id: str | None = None) -> dict:
+    nrr = normalise_optional_identity(body.national_register_number)
+    eid = normalise_optional_identity(body.eid_document_number)
+    await ensure_unique_fields(db, national_register_number=nrr, eid_document_number=eid)
+
+    person = Person(
+        id=make_id("per"),
+        name=body.name,
+        email=str(body.email).lower().strip() if body.email else "",
+        phone=parse_phone(body.phone),
+        address=body.address,
+        national_register_number=nrr,
+        eid_document_number=eid,
+        visits_per_month=body.visits_per_month,
+        club_name=body.club_name,
+        notes=body.notes,
+        active=body.active,
+    )
+    person.roles = normalise_roles(body.roles)
+    ensure_member_role(person)
+
+    db.add(person)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="member_created",
+        resource_type="person",
+        resource_id=person.id,
+        request_id=request_id,
+        details={"roles": person.roles},
+    )
+    await db.commit()
+    await db.refresh(person)
+    return person_to_dict(person)
+
+
+def search_members_stmt(*, q: str | None = None, active: bool | None = None) -> Any:
+    stmt = select(Person).where(roles_contains("member"))
+
+    if active is not None:
+        stmt = stmt.where(Person.active == active)
+
+    if q:
+        q_escaped = q.strip().replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+        q_like = f"%{q_escaped}%"
+        stmt = stmt.where(
+            or_(
+                Person.name.ilike(q_like, escape="\\"),
+                Person.email.ilike(q_like, escape="\\"),
+                Person.phone.ilike(q_like, escape="\\"),
+                Person.address.ilike(q_like, escape="\\"),
+                Person.club_name.ilike(q_like, escape="\\"),
+                Person.notes.ilike(q_like, escape="\\"),
+            )
+        )
+
+    return stmt.order_by(Person.created_at.desc(), Person.id.desc())
+
+
+async def apply_member_update(
+    db: AsyncSession, person: Person, body: PersonUpdate, *, actor: str, request_id: str | None = None
+) -> dict:
+    for field in ("name", "address", "visits_per_month", "club_name", "notes", "active"):
+        if field in body.model_fields_set:
+            setattr(person, field, getattr(body, field))
+
+    if "phone" in body.model_fields_set:
+        person.phone = parse_phone(body.phone)
+
+    if "email" in body.model_fields_set:
+        person.email = str(body.email).lower().strip() if body.email else ""
+
+    nrr_in_set = "national_register_number" in body.model_fields_set
+    eid_in_set = "eid_document_number" in body.model_fields_set
+    nrr = normalise_optional_identity(body.national_register_number) if nrr_in_set else None
+    eid = normalise_optional_identity(body.eid_document_number) if eid_in_set else None
+
+    if nrr_in_set and nrr is not None:
+        await ensure_unique_fields(db, national_register_number=nrr, exclude_id=person.id)
+    if eid_in_set and eid is not None:
+        await ensure_unique_fields(db, eid_document_number=eid, exclude_id=person.id)
+
+    if nrr_in_set:
+        person.national_register_number = nrr
+    if eid_in_set:
+        person.eid_document_number = eid
+
+    if body.roles is not None:
+        person.roles = normalise_roles(body.roles)
+    ensure_member_role(person)
+
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="member_updated",
+        resource_type="person",
+        resource_id=person.id,
+        request_id=request_id,
+        details={"fields_changed": sorted(body.model_fields_set)},
+    )
+    await db.commit()
+    await db.refresh(person)
+    return person_to_dict(person)
+
+
+async def delete_member(db: AsyncSession, person: Person, *, actor: str, request_id: str | None = None) -> dict:
+    person_id = person.id
+    result = await db.execute(
+        select(Registration).options(selectinload(Registration.event)).where(Registration.person_id == person_id)
+    )
+    registrations = result.scalars().all()
+    registration_scopes = [
+        {
+            "registration_id": registration.id,
+            "event_id": registration.event_id,
+            "edition_id": registration.event.edition_id,
+        }
+        for registration in registrations
+    ]
+    for registration in registrations:
+        await db.delete(registration)
+    await db.delete(person)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="member_deleted",
+        resource_type="person",
+        resource_id=person_id,
+        request_id=request_id,
+        details={"deleted_registration_count": len(registrations)},
+    )
+    await db.commit()
+    for scope in registration_scopes:
+        try:
+            await live_bus.publish(live_mapping.registration_changed(action="deleted", **scope))
+        except Exception:
+            logger.warning(
+                "live_bus.publish failed for deleted registration %s", scope["registration_id"], exc_info=True
+            )
+    return {"deleted": True, "id": person_id}

--- a/backend/app/services/members_service.py
+++ b/backend/app/services/members_service.py
@@ -11,27 +11,19 @@ hierarchy in ``app/services/errors.py``.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastapi import HTTPException
 from sqlalchemy import or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from app.audit import write_audit_entry
-from app.live import live_bus
-from app.live import mapping as live_mapping
-from app.models import Person, Registration
+from app.models import Person
 from app.schemas import PersonCreate, PersonUpdate
-from app.services.people_service import parse_phone
+from app.services import people_service
+from app.services.people_service import normalise_roles, parse_phone
 from app.utils import get_or_404, make_id, person_to_dict, roles_contains
-
-logger = logging.getLogger(__name__)
-
-
-def normalise_roles(roles: list[str]) -> list[str]:
-    return sorted({r.strip().lower() for r in roles if r and r.strip()})
 
 
 def normalise_optional_identity(value: str | None) -> str | None:
@@ -118,7 +110,14 @@ async def create_member(db: AsyncSession, *, body: PersonCreate, actor: str, req
         request_id=request_id,
         details={"roles": person.roles},
     )
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="Person with this national register number or eID document number already exists.",
+        ) from exc
     await db.refresh(person)
     return person_to_dict(person)
 
@@ -187,43 +186,23 @@ async def apply_member_update(
         request_id=request_id,
         details={"fields_changed": sorted(body.model_fields_set)},
     )
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="Person with this national register number or eID document number already exists.",
+        ) from exc
     await db.refresh(person)
     return person_to_dict(person)
 
 
 async def delete_member(db: AsyncSession, person: Person, *, actor: str, request_id: str | None = None) -> dict:
-    person_id = person.id
-    result = await db.execute(
-        select(Registration).options(selectinload(Registration.event)).where(Registration.person_id == person_id)
-    )
-    registrations = result.scalars().all()
-    registration_scopes = [
-        {
-            "registration_id": registration.id,
-            "event_id": registration.event_id,
-            "edition_id": registration.event.edition_id,
-        }
-        for registration in registrations
-    ]
-    for registration in registrations:
-        await db.delete(registration)
-    await db.delete(person)
-    await write_audit_entry(
-        db,
-        actor=actor,
-        action="member_deleted",
-        resource_type="person",
-        resource_id=person_id,
-        request_id=request_id,
-        details={"deleted_registration_count": len(registrations)},
-    )
-    await db.commit()
-    for scope in registration_scopes:
-        try:
-            await live_bus.publish(live_mapping.registration_changed(action="deleted", **scope))
-        except Exception:
-            logger.warning(
-                "live_bus.publish failed for deleted registration %s", scope["registration_id"], exc_info=True
-            )
-    return {"deleted": True, "id": person_id}
+    """Remove a member (and cascade-delete their registrations).
+
+    Delegates the shared cascade-delete/audit/live-publish routine to
+    ``people_service.delete_person``, tagged with the ``member_deleted`` audit
+    action instead of ``person_deleted``.
+    """
+    return await people_service.delete_person(db, person, actor=actor, request_id=request_id, action="member_deleted")

--- a/backend/app/services/members_service.py
+++ b/backend/app/services/members_service.py
@@ -7,6 +7,11 @@ other ``Person``-backed services. Raises ``HTTPException`` directly (matching
 the pre-existing shared helpers this consolidates, same convention as
 ``app/services/editions_service.py``) rather than the ``ServiceError``
 hierarchy in ``app/services/errors.py``.
+
+Identity fields are normalised via ``people_service.normalise_optional_identity``
+before both the uniqueness check and persistence, matching ``people_service``/
+``volunteers_service`` exactly (alembic revision 014 renormalised pre-existing
+rows so the unique constraint stays valid under the stricter rule).
 """
 
 from __future__ import annotations
@@ -22,15 +27,8 @@ from app.audit import write_audit_entry
 from app.models import Person
 from app.schemas import PersonCreate, PersonUpdate
 from app.services import people_service
-from app.services.people_service import normalise_roles, parse_phone
+from app.services.people_service import normalise_optional_identity, normalise_roles, parse_phone
 from app.utils import get_or_404, make_id, person_to_dict, roles_contains
-
-
-def normalise_optional_identity(value: str | None) -> str | None:
-    if value is None:
-        return None
-    value = value.strip()
-    return value or None
 
 
 def ensure_member_role(person: Person) -> None:

--- a/backend/app/services/people_service.py
+++ b/backend/app/services/people_service.py
@@ -2,11 +2,18 @@
 
 Used by both ``app.routers.people`` (REST) and ``app.mcp.admin.people`` (MCP).
 Members and volunteers are also ``Person`` rows (see
-``app.services.members_service`` / a future ``volunteers_service``) but each
-has its own rules layered on top, so they get their own service module too
-rather than being folded into this one — ``parse_phone``/``normalise_roles``/
-``normalise_optional_identity`` are reused from here though, since identity
-normalisation and phone parsing are identical across all three.
+``app.services.members_service`` / ``app.services.volunteers_service``) but
+each has its own rules layered on top, so they get their own service module
+too rather than being folded into this one. ``parse_phone``/``normalise_roles``
+are reused from here since phone parsing and role normalisation are identical
+across all three; ``normalise_optional_identity`` is *not* — members/volunteers
+only strip surrounding whitespace rather than this module's fuller separator
+stripping + lowercasing, a pre-existing inconsistency across the three
+domains' unique national-register/eID checks that predates this module split
+and isn't addressed here (unifying it would need a data migration to
+renormalise already-stored values, not just a code change) — also
+``delete_person``'s cascade is reused by ``members_service.delete_member`` via
+its ``action`` parameter.
 
 Raises ``HTTPException`` directly (matching the pre-existing shared helpers
 this consolidates, same convention as ``app/services/editions_service.py``)
@@ -18,6 +25,7 @@ for REST, ``get_or_error`` for MCP) and passes it in for update/delete/merge.
 from __future__ import annotations
 
 import logging
+from typing import NoReturn
 
 import phonenumbers
 from fastapi import HTTPException, status
@@ -85,7 +93,7 @@ def parse_phone(raw: str | None) -> str:
     return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
 
 
-def raise_identity_conflict() -> None:
+def raise_identity_conflict() -> NoReturn:
     raise HTTPException(
         status_code=409,
         detail="Person with this national register number or eID document number already exists.",
@@ -211,7 +219,15 @@ async def apply_person_update(
     return person_to_dict(person)
 
 
-async def delete_person(db: AsyncSession, person: Person, *, actor: str, request_id: str | None = None) -> dict:
+async def delete_person(
+    db: AsyncSession, person: Person, *, actor: str, request_id: str | None = None, action: str = "person_deleted"
+) -> dict:
+    """Delete a person and cascade-delete their registrations.
+
+    ``action`` lets ``app.services.members_service.delete_member`` reuse this
+    routine verbatim with its own audit action name (``"member_deleted"``)
+    instead of keeping a byte-for-byte duplicate.
+    """
     person_id = person.id
     result = await db.execute(
         select(Registration).options(selectinload(Registration.event)).where(Registration.person_id == person_id)
@@ -231,7 +247,7 @@ async def delete_person(db: AsyncSession, person: Person, *, actor: str, request
     await write_audit_entry(
         db,
         actor=actor,
-        action="person_deleted",
+        action=action,
         resource_type="person",
         resource_id=person_id,
         request_id=request_id,

--- a/backend/app/services/people_service.py
+++ b/backend/app/services/people_service.py
@@ -1,0 +1,352 @@
+"""Shared application-service operations for people.
+
+Used by both ``app.routers.people`` (REST) and ``app.mcp.admin.people`` (MCP).
+Members and volunteers are also ``Person`` rows (see
+``app.services.members_service`` / a future ``volunteers_service``) but each
+has its own rules layered on top, so they get their own service module too
+rather than being folded into this one — ``parse_phone``/``normalise_roles``/
+``normalise_optional_identity`` are reused from here though, since identity
+normalisation and phone parsing are identical across all three.
+
+Raises ``HTTPException`` directly (matching the pre-existing shared helpers
+this consolidates, same convention as ``app/services/editions_service.py``)
+rather than the ``ServiceError`` hierarchy in ``app/services/errors.py``.
+Each adapter fetches the row with its own idiomatic 404 helper (``get_or_404``
+for REST, ``get_or_error`` for MCP) and passes it in for update/delete/merge.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import phonenumbers
+from fastapi import HTTPException, status
+from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.audit import write_audit_entry
+from app.live import live_bus
+from app.live import mapping as live_mapping
+from app.models import Exhibitor, Person, Registration, VolunteerPeriod
+from app.schemas import PersonCreate, PersonUpdate
+from app.utils import get_or_404, make_id, person_to_dict
+
+logger = logging.getLogger(__name__)
+
+
+def normalise_roles(roles: list[str]) -> list[str]:
+    normalised: set[str] = set()
+    for role in roles:
+        if not role or not role.strip():
+            continue
+        r = role.strip().lower()
+        normalised.add(r)
+    return sorted(normalised)
+
+
+def normalise_optional_identity(value: str | None) -> str | None:
+    """Strip separators and normalise case so that e.g. '93.05.18-223.61' and
+    '93051822361' are treated as the same value for uniqueness checks."""
+    if value is None:
+        return None
+    for ch in (" ", ".", "-", "/"):
+        value = value.replace(ch, "")
+    value = value.strip().lower()
+    return value or None
+
+
+def parse_phone(raw: str | None) -> str:
+    """Parse and normalise a phone number to E.164 format.
+
+    Uses the ``phonenumbers`` library (Google libphonenumber binding) with
+    ``"BE"`` as the default region for numbers that lack a country code prefix.
+    Numbers that already carry a ``+`` or ``00`` IDD prefix are parsed
+    regardless of the default region.
+
+    Returns ``""`` for empty/None input.
+    Raises :class:`fastapi.HTTPException` (422) for unparseable or invalid input.
+    """
+    if not raw or not raw.strip():
+        return ""
+    try:
+        parsed = phonenumbers.parse(raw, "BE")
+    except phonenumbers.NumberParseException as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Invalid phone number: {exc}",
+        ) from exc
+    if not phonenumbers.is_valid_number(parsed):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Invalid phone number.",
+        )
+    return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
+
+
+def raise_identity_conflict() -> None:
+    raise HTTPException(
+        status_code=409,
+        detail="Person with this national register number or eID document number already exists.",
+    )
+
+
+async def ensure_unique_identity_fields(
+    db: AsyncSession,
+    national_register_number: str | None = None,
+    eid_document_number: str | None = None,
+    exclude_id: str | None = None,
+) -> None:
+    if national_register_number is not None:
+        stmt = select(Person).where(Person.national_register_number == national_register_number)
+        if exclude_id:
+            stmt = stmt.where(Person.id != exclude_id)
+        existing = (await db.execute(stmt)).scalar_one_or_none()
+        if existing is not None:
+            raise_identity_conflict()
+
+    if eid_document_number is not None:
+        stmt = select(Person).where(Person.eid_document_number == eid_document_number)
+        if exclude_id:
+            stmt = stmt.where(Person.id != exclude_id)
+        existing = (await db.execute(stmt)).scalar_one_or_none()
+        if existing is not None:
+            raise_identity_conflict()
+
+
+async def get_person_or_404(db: AsyncSession, person_id: str) -> Person:
+    return await get_or_404(db, Person, person_id, "Person not found.")
+
+
+async def create_person(db: AsyncSession, *, body: PersonCreate, actor: str, request_id: str | None = None) -> dict:
+    national_register_number = normalise_optional_identity(body.national_register_number)
+    eid_document_number = normalise_optional_identity(body.eid_document_number)
+    await ensure_unique_identity_fields(
+        db,
+        national_register_number=national_register_number,
+        eid_document_number=eid_document_number,
+    )
+
+    person = Person(
+        id=make_id("per"),
+        name=body.name,
+        email=str(body.email).lower().strip() if body.email else "",
+        phone=parse_phone(body.phone),
+        address=body.address,
+        national_register_number=national_register_number,
+        eid_document_number=eid_document_number,
+        visits_per_month=body.visits_per_month,
+        club_name=body.club_name,
+        notes=body.notes,
+        active=body.active,
+    )
+    person.roles = normalise_roles(body.roles)
+
+    db.add(person)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="person_created",
+        resource_type="person",
+        resource_id=person.id,
+        request_id=request_id,
+        details={"roles": person.roles},
+    )
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise_identity_conflict()
+    await db.refresh(person)
+    return person_to_dict(person)
+
+
+async def apply_person_update(
+    db: AsyncSession, person: Person, body: PersonUpdate, *, actor: str, request_id: str | None = None
+) -> dict:
+    for field in ("name", "address", "visits_per_month", "club_name", "notes", "active"):
+        if field in body.model_fields_set:
+            setattr(person, field, getattr(body, field))
+
+    if "phone" in body.model_fields_set:
+        person.phone = parse_phone(body.phone)
+
+    if "email" in body.model_fields_set:
+        person.email = str(body.email).lower().strip() if body.email else ""
+
+    nrr_in_set = "national_register_number" in body.model_fields_set
+    eid_in_set = "eid_document_number" in body.model_fields_set
+    nrr = normalise_optional_identity(body.national_register_number) if nrr_in_set else None
+    eid = normalise_optional_identity(body.eid_document_number) if eid_in_set else None
+
+    if nrr_in_set and nrr is not None:
+        await ensure_unique_identity_fields(db, national_register_number=nrr, exclude_id=person.id)
+    if eid_in_set and eid is not None:
+        await ensure_unique_identity_fields(db, eid_document_number=eid, exclude_id=person.id)
+
+    if nrr_in_set:
+        person.national_register_number = nrr
+    if eid_in_set:
+        person.eid_document_number = eid
+
+    if body.roles is not None:
+        person.roles = normalise_roles(body.roles)
+
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="person_updated",
+        resource_type="person",
+        resource_id=person.id,
+        request_id=request_id,
+        details={"fields_changed": sorted(body.model_fields_set)},
+    )
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise_identity_conflict()
+    await db.refresh(person)
+    return person_to_dict(person)
+
+
+async def delete_person(db: AsyncSession, person: Person, *, actor: str, request_id: str | None = None) -> dict:
+    person_id = person.id
+    result = await db.execute(
+        select(Registration).options(selectinload(Registration.event)).where(Registration.person_id == person_id)
+    )
+    registrations = result.scalars().all()
+    registration_scopes = [
+        {
+            "registration_id": registration.id,
+            "event_id": registration.event_id,
+            "edition_id": registration.event.edition_id,
+        }
+        for registration in registrations
+    ]
+    for registration in registrations:
+        await db.delete(registration)
+    await db.delete(person)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="person_deleted",
+        resource_type="person",
+        resource_id=person_id,
+        request_id=request_id,
+        details={"deleted_registration_count": len(registrations)},
+    )
+    await db.commit()
+    for scope in registration_scopes:
+        try:
+            await live_bus.publish(live_mapping.registration_changed(action="deleted", **scope))
+        except Exception:
+            logger.warning(
+                "live_bus.publish failed for deleted registration %s", scope["registration_id"], exc_info=True
+            )
+    return {"deleted": True, "id": person_id}
+
+
+async def merge_people(
+    db: AsyncSession, canonical: Person, duplicate: Person, *, actor: str, request_id: str | None = None
+) -> dict:
+    """Merge ``duplicate`` into ``canonical``.
+
+    - All reservations and exhibitor contacts linked to the duplicate are
+      re-pointed to the canonical person.
+    - Blank string fields on the canonical person are filled from the duplicate.
+    - Roles are merged (union).
+    - Unique identity fields (national_register_number, eid_document_number)
+      are adopted from the duplicate only if the canonical person lacks them;
+      if both carry conflicting values a 409 is raised.
+    - The duplicate person record is deleted.
+    """
+    duplicate_id = duplicate.id
+
+    # Guard unique identity fields before making any changes.
+    # Normalise values with the same routine used by create/update so that
+    # equivalent but differently-formatted IDs are not treated as conflicts.
+    field_labels = {
+        "national_register_number": "national register number",
+        "eid_document_number": "eID document number",
+    }
+    for field in ("national_register_number", "eid_document_number"):
+        canon_val = normalise_optional_identity(getattr(canonical, field))
+        dup_val = normalise_optional_identity(getattr(duplicate, field))
+        if canon_val and dup_val and canon_val != dup_val:
+            label = field_labels[field]
+            raise HTTPException(
+                status_code=409,
+                detail=f"Both persons have a different {label}; resolve manually before merging.",
+            )
+
+    # Normalise canonical's own existing identity fields in-place so the
+    # surviving record is always in canonical form, consistent with
+    # create/update_person.
+    for field in ("national_register_number", "eid_document_number"):
+        existing = getattr(canonical, field)
+        normalised = normalise_optional_identity(existing)
+        if normalised != existing:
+            setattr(canonical, field, normalised or None)
+
+    # Fill blank string fields on canonical from duplicate.
+    for field in ("email", "phone", "address", "club_name", "notes"):
+        if not getattr(canonical, field) and getattr(duplicate, field):
+            setattr(canonical, field, getattr(duplicate, field))
+
+    # Fill blank nullable fields on canonical from duplicate.
+    for field in ("visits_per_month",):
+        if getattr(canonical, field) is None and getattr(duplicate, field) is not None:
+            setattr(canonical, field, getattr(duplicate, field))
+
+    # Merge roles (union).
+    canonical.roles = sorted(set(canonical.roles) | set(duplicate.roles))
+
+    # Adopt unique identity fields from duplicate if canonical lacks them.
+    # Normalise the value from the duplicate before storing so the canonical
+    # ends up with the same canonical form used by create/update_person.
+    adopted = {
+        field: normalise_optional_identity(getattr(duplicate, field))
+        for field in ("national_register_number", "eid_document_number")
+        if not getattr(canonical, field) and getattr(duplicate, field)
+    }
+    if adopted:
+        # These columns are UNIQUE, so the duplicate has to release its value
+        # before the canonical can take it. A single flush does not guarantee
+        # that order — SQLAlchemy batches same-mapper UPDATEs by primary key, so
+        # whenever the canonical's id sorts first it would write the value while
+        # the duplicate still holds it. Clear and flush separately.
+        for field in adopted:
+            setattr(duplicate, field, None)
+        await db.flush()
+        for field, value in adopted.items():
+            setattr(canonical, field, value)
+
+    await db.flush()
+
+    # Re-point everything that references the duplicate. VolunteerPeriod matters
+    # most: its FK cascades on delete, so a period left pointing at the duplicate
+    # is destroyed below rather than transferred, leaving a person carrying the
+    # volunteer role with no help periods.
+    await db.execute(update(Registration).where(Registration.person_id == duplicate_id).values(person_id=canonical.id))
+    await db.execute(
+        update(Exhibitor).where(Exhibitor.contact_person_id == duplicate_id).values(contact_person_id=canonical.id)
+    )
+    await db.execute(
+        update(VolunteerPeriod).where(VolunteerPeriod.volunteer_id == duplicate_id).values(volunteer_id=canonical.id)
+    )
+
+    await db.delete(duplicate)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="person_merged",
+        resource_type="person",
+        resource_id=canonical.id,
+        request_id=request_id,
+        details={"duplicate_id": duplicate_id},
+    )
+    await db.commit()
+    await db.refresh(canonical)
+    return person_to_dict(canonical)

--- a/backend/app/services/people_service.py
+++ b/backend/app/services/people_service.py
@@ -4,14 +4,15 @@ Used by both ``app.routers.people`` (REST) and ``app.mcp.admin.people`` (MCP).
 Members and volunteers are also ``Person`` rows (see
 ``app.services.members_service`` / ``app.services.volunteers_service``) but
 each has its own rules layered on top, so they get their own service module
-too rather than being folded into this one. ``parse_phone``/``normalise_roles``
-are reused from here since phone parsing and role normalisation are identical
-across all three; ``normalise_optional_identity`` is *not* — members/volunteers
-only strip surrounding whitespace rather than this module's fuller separator
-stripping + lowercasing, a pre-existing inconsistency across the three
-domains' unique national-register/eID checks that predates this module split
-and isn't addressed here (unifying it would need a data migration to
-renormalise already-stored values, not just a code change) — also
+too rather than being folded into this one. ``parse_phone``/``normalise_roles``/
+``normalise_optional_identity`` are all reused from here — identity
+normalisation, role normalisation, and phone parsing are identical across all
+three now. This wasn't always true: members/volunteers used to only strip
+surrounding whitespace instead of this module's fuller separator-stripping +
+lowercasing, a pre-existing inconsistency across the three domains' unique
+national-register/eID checks that predated #860's module split.
+Unifying it required renormalising already-stored rows so the unique
+constraint stayed valid under the stricter rule — see alembic revision 014.
 ``delete_person``'s cascade is reused by ``members_service.delete_member`` via
 its ``action`` parameter.
 

--- a/backend/app/services/registrations_service.py
+++ b/backend/app/services/registrations_service.py
@@ -1,0 +1,380 @@
+"""Shared application-service operations for admin registration management.
+
+Used by both ``app.routers.registrations`` (REST, admin-only endpoints) and
+``app.mcp.admin.registrations`` (MCP) so order-item resolution, the
+table/edition consistency guard, and the update/create/delete transitions
+(with their audit-detail assembly and live-bus publication) live in exactly
+one place instead of two copies (#860). The public self-service endpoints
+(guest-facing creation with spam/rate-limit checks, the email-token "my
+registrations" lookup flow, CSV export) have no MCP equivalent and stay in
+the router.
+
+Raises ``HTTPException`` directly (matching the pre-existing shared helpers
+this consolidates, same convention as ``app/services/editions_service.py``)
+rather than the ``ServiceError`` hierarchy in ``app/services/errors.py``.
+Person/event lookups reuse ``app.services.people_service.get_person_or_404``
+and ``app.services.events_service.get_event_or_404`` directly rather than
+keeping a third copy of each.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import UTC, datetime
+from typing import cast
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.audit import write_audit_entry
+from app.live import live_bus
+from app.live import mapping as live_mapping
+from app.models import Event, Layout, Person, Product, Registration, Table
+from app.schemas import OrderItemBase, OrderItemCategory, OrderItemRequest, RegistrationAdminCreate, RegistrationUpdate
+from app.services import events_service, people_service
+from app.utils import make_id, registration_to_dict
+
+logger = logging.getLogger(__name__)
+
+
+async def get_registration_or_404(db: AsyncSession, registration_id: str) -> Registration:
+    result = await db.execute(
+        select(Registration)
+        .options(
+            selectinload(Registration.event).selectinload(Event.edition),
+            selectinload(Registration.event).selectinload(Event.products),
+        )
+        .where(Registration.id == registration_id)
+    )
+    registration = result.scalar_one_or_none()
+    if registration is None:
+        raise HTTPException(status_code=404, detail="Registration not found.")
+    return registration
+
+
+def sum_delivered(order_items: list[dict] | None) -> int:
+    if not order_items:
+        return 0
+    return sum(int(item.get("delivered_quantity") or 0) for item in order_items)
+
+
+async def fetch_person_map(db: AsyncSession, rows: list[Registration]) -> dict[str, Person]:
+    if not rows:
+        return {}
+    person_ids = {row.person_id for row in rows}
+    people = (await db.execute(select(Person).where(Person.id.in_(person_ids)))).scalars().all()
+    return {person.id: person for person in people}
+
+
+async def assert_table_matches_edition(db: AsyncSession, table_id: str, edition_id: str | None) -> None:
+    """Reject seating a registration at a table belonging to another edition.
+
+    Layouts are per-edition, so a table only makes sense for registrations of the
+    edition its layout was drawn for. Layouts predating the edition link carry a
+    null edition_id and are left alone.
+    """
+    row = (
+        await db.execute(
+            select(Layout.edition_id).join(Table, Table.layout_id == Layout.id).where(Table.id == table_id)
+        )
+    ).first()
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Table '{table_id}' not found.")
+    table_edition_id = row[0]
+    if table_edition_id is not None and edition_id is not None and table_edition_id != edition_id:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Table '{table_id}' belongs to edition '{table_edition_id}', "
+                f"but this registration is for edition '{edition_id}'."
+            ),
+        )
+
+
+def resolve_order_items(event: Event, requests: list[OrderItemRequest], guest_count: int) -> list[dict]:
+    """Resolve client-supplied product_id/quantity pairs against the event's real,
+    active products, snapshotting name/price/category server-side (see Product's
+    docstring). Rejects any product_id that isn't an active product on this event,
+    so a client can never set an arbitrary price or order a nonexistent product.
+
+    Also enforces that a required product (e.g. an entry ticket) is present
+    whenever an optional one is ordered — an event with required products
+    configured rejects an order for optional add-ons alone — and applies each
+    ordered product's bundle (Product.included_product_id/included_per_guests):
+    a free quantity of the bundled product, scaled to guest_count, is merged
+    into that product's line item on top of anything explicitly requested.
+    """
+    products_by_id: dict[str, Product] = {p.id: p for p in event.products if p.active}
+
+    # product_id -> (quantity, included_quantity)
+    line_items: dict[str, tuple[int, int]] = {}
+    ordered_ids: set[str] = set()
+    for req in requests:
+        product = products_by_id.get(req.product_id)
+        if product is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Product '{req.product_id}' is not available for this event.",
+            )
+        ordered_ids.add(product.id)
+        quantity, included_quantity = line_items.get(product.id, (0, 0))
+        line_items[product.id] = (quantity + req.quantity, included_quantity)
+
+    required_ids = {p.id for p in products_by_id.values() if p.required}
+    if required_ids and (ordered_ids - required_ids) and not (ordered_ids & required_ids):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This event requires a required product (e.g. an entry ticket) before any optional products can be ordered.",
+        )
+
+    for product_id in list(ordered_ids):
+        product = products_by_id[product_id]
+        if product.included_product_id is None or product.included_per_guests is None:
+            continue
+        target = products_by_id.get(product.included_product_id)
+        if target is None:
+            continue  # bundled product archived since — inclusion silently no longer applies
+        included_qty = guest_count // product.included_per_guests
+        if included_qty <= 0:
+            continue
+        quantity, included_quantity = line_items.get(target.id, (0, 0))
+        line_items[target.id] = (quantity + included_qty, included_quantity + included_qty)
+
+    resolved: list[dict] = []
+    for product_id, (quantity, included_quantity) in line_items.items():
+        product = products_by_id[product_id]
+        resolved.append(
+            OrderItemBase(
+                product_id=product.id,
+                name=product.name,
+                quantity=quantity,
+                price=float(product.price),
+                category=cast(OrderItemCategory, product.category),
+                included_quantity=included_quantity,
+            ).model_dump()
+        )
+    return resolved
+
+
+async def admin_create_registration(
+    db: AsyncSession, *, body: RegistrationAdminCreate, actor: str, request_id: str | None = None
+) -> dict:
+    person = await people_service.get_person_or_404(db, body.person_id)
+    event = await events_service.get_event_or_404(db, body.event_id)
+    resolved_order_items = resolve_order_items(event, body.order_items, body.guest_count)
+
+    registration = Registration(
+        id=make_id("reg"),
+        event_id=event.id,
+        guest_count=body.guest_count,
+        notes=body.notes,
+        accessibility_note=body.accessibility_note,
+        status=body.status,
+        person_id=person.id,
+        check_in_token=secrets.token_urlsafe(32),
+    )
+    registration.order_items = resolved_order_items
+    db.add(registration)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="registration_created",
+        resource_type="registration",
+        resource_id=registration.id,
+        request_id=request_id,
+        details={"event_id": event.id, "person_id": person.id},
+    )
+    await db.commit()
+
+    registration = await get_registration_or_404(db, registration.id)
+    try:
+        await live_bus.publish(
+            live_mapping.registration_changed(
+                action="created",
+                registration_id=registration.id,
+                event_id=registration.event_id,
+                edition_id=registration.event.edition_id,
+            )
+        )
+    except Exception:
+        logger.warning("live_bus.publish failed for registration %s", registration.id, exc_info=True)
+    return registration_to_dict(registration, person, event)
+
+
+async def apply_registration_update(
+    db: AsyncSession,
+    registration: Registration,
+    body: RegistrationUpdate,
+    *,
+    actor: str,
+    request_id: str | None = None,
+    clear_amount_due: bool = False,
+    clear_table: bool = False,
+) -> dict:
+    """Apply a partial registration update and return the refreshed payload.
+
+    ``clear_amount_due``/``clear_table`` exist for the MCP adapter, whose
+    kwargs can't distinguish "omitted" from "explicitly null" for these two
+    nullable fields — REST expresses the same intent via an explicit ``null``
+    in the JSON body, which already lands in ``body.model_fields_set`` and so
+    never needs the flags (it always passes ``False``).
+    """
+    pre_table_id = registration.table_id
+    pre_order_items = list(registration.order_items) if registration.order_items else []
+    pre_delivery_sum = sum_delivered(registration.order_items)
+    pre_checked_in = registration.checked_in
+    pre_strap_issued = registration.strap_issued
+    pre_status = registration.status
+    pre_payment_status = registration.payment_status
+    pre_amount_due = registration.amount_due
+    event_id = registration.event_id
+    edition_id = registration.event.edition_id
+
+    if body.status is not None:
+        registration.status = body.status
+    if body.payment_status is not None:
+        registration.payment_status = body.payment_status
+    if clear_amount_due:
+        registration.amount_due = None
+    elif "amount_due" in body.model_fields_set:
+        registration.amount_due = body.amount_due
+
+    table_id_targeted = clear_table or "table_id" in body.model_fields_set
+    if clear_table:
+        registration.table_id = None
+    elif "table_id" in body.model_fields_set:
+        if body.table_id is not None:
+            await assert_table_matches_edition(db, body.table_id, edition_id)
+        registration.table_id = body.table_id
+
+    if body.notes is not None:
+        registration.notes = body.notes
+    if body.accessibility_note is not None:
+        registration.accessibility_note = body.accessibility_note
+    if "person_id" in body.model_fields_set:
+        if body.person_id is None:
+            raise HTTPException(
+                status_code=400, detail="person_id cannot be removed; every registration requires a person."
+            )
+        await people_service.get_person_or_404(db, body.person_id)
+        registration.person_id = body.person_id
+    if body.order_items is not None:
+        registration.order_items = [item.model_dump() for item in body.order_items]
+    if body.checked_in is not None:
+        if body.checked_in and not registration.checked_in:
+            registration.checked_in_at = datetime.now(UTC)
+        if not body.checked_in:
+            registration.checked_in_at = None
+        registration.checked_in = body.checked_in
+    if body.strap_issued is not None:
+        registration.strap_issued = body.strap_issued
+
+    audit_base = {"resource_type": "registration", "resource_id": registration.id, "request_id": request_id}
+    if table_id_targeted and registration.table_id != pre_table_id:
+        action = "table_unassigned" if registration.table_id is None else "table_assigned"
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action=action,
+            details={"table_id": registration.table_id, "previous_table_id": pre_table_id},
+            **audit_base,
+        )
+    if body.order_items is not None and registration.order_items != pre_order_items:
+        action = "delivery_updated" if sum_delivered(registration.order_items) != pre_delivery_sum else "order_updated"
+        await write_audit_entry(db, actor=actor, action=action, details={}, **audit_base)
+    if body.checked_in is not None and registration.checked_in != pre_checked_in:
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="check_in",
+            details={"checked_in": registration.checked_in},
+            **audit_base,
+        )
+    if body.strap_issued is not None and registration.strap_issued != pre_strap_issued:
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="strap_issued",
+            details={"strap_issued": registration.strap_issued},
+            **audit_base,
+        )
+    if registration.status != pre_status or registration.payment_status != pre_payment_status:
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="registration_status_changed",
+            details={
+                "status": registration.status,
+                "payment_status": registration.payment_status,
+            },
+            **audit_base,
+        )
+    if registration.amount_due != pre_amount_due:
+        await write_audit_entry(
+            db,
+            actor=actor,
+            action="amount_due_updated",
+            details={
+                "amount_due": float(registration.amount_due) if registration.amount_due is not None else None,
+                "previous_amount_due": float(pre_amount_due) if pre_amount_due is not None else None,
+            },
+            **audit_base,
+        )
+
+    await db.commit()
+    registration = await get_registration_or_404(db, registration.id)
+    person_map = await fetch_person_map(db, [registration])
+
+    # Publish live-update events; bus errors must never break write responses.
+    try:
+        scope = {"registration_id": registration.id, "event_id": event_id, "edition_id": edition_id}
+        if registration.table_id != pre_table_id:
+            await live_bus.publish(live_mapping.seating_changed(table_id=registration.table_id, **scope))
+        if body.order_items is not None and registration.order_items != pre_order_items:
+            if sum_delivered(registration.order_items) != pre_delivery_sum:
+                await live_bus.publish(live_mapping.delivery_changed(**scope))
+            else:
+                await live_bus.publish(live_mapping.order_changed(**scope))
+        if registration.checked_in != pre_checked_in or registration.strap_issued != pre_strap_issued:
+            await live_bus.publish(live_mapping.check_in_changed(**scope))
+        metadata_fields = {"status", "payment_status", "amount_due", "notes", "accessibility_note", "person_id"}
+        if any(f in body.model_fields_set for f in metadata_fields) or clear_amount_due:
+            await live_bus.publish(live_mapping.registration_changed(action="updated", **scope))
+    except Exception:
+        logger.warning("live_bus.publish failed for registration %s", registration.id, exc_info=True)
+
+    return registration_to_dict(registration, person_map[registration.person_id], registration.event)
+
+
+async def delete_registration(
+    db: AsyncSession, registration: Registration, *, actor: str, request_id: str | None = None
+) -> dict:
+    reg_id = registration.id
+    event_id = registration.event_id
+    edition_id = registration.event.edition_id
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="registration_deleted",
+        resource_type="registration",
+        resource_id=reg_id,
+        request_id=request_id,
+        details={"event_id": event_id},
+    )
+    await db.delete(registration)
+    await db.commit()
+    try:
+        await live_bus.publish(
+            live_mapping.registration_changed(
+                action="deleted",
+                registration_id=reg_id,
+                event_id=event_id,
+                edition_id=edition_id,
+            )
+        )
+    except Exception:
+        logger.warning("live_bus.publish failed for deleted registration %s", reg_id, exc_info=True)
+    return {"deleted": True, "id": reg_id}

--- a/backend/app/services/registrations_service.py
+++ b/backend/app/services/registrations_service.py
@@ -132,7 +132,10 @@ def resolve_order_items(event: Event, requests: list[OrderItemRequest], guest_co
 
     for product_id in list(ordered_ids):
         product = products_by_id[product_id]
-        if product.included_product_id is None or product.included_per_guests is None:
+        # A zero/negative included_per_guests can't happen through the REST/MCP
+        # schemas (which require >= 1), but guard the division defensively
+        # against a row that reached the database some other way.
+        if product.included_product_id is None or not product.included_per_guests or product.included_per_guests < 1:
             continue
         target = products_by_id.get(product.included_product_id)
         if target is None:

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -1,0 +1,77 @@
+"""Shared application-service operations for site-wide settings.
+
+Used by both ``app.routers.settings`` (REST) and ``app.mcp.admin.settings``
+(MCP) so the lazy-row-creation race handling and audit-detail assembly live
+in exactly one place instead of two copies (#860). Settings endpoints raise
+plain exceptions rather than the ``ServiceError`` hierarchy in
+``app/services/errors.py`` since there's currently no user-facing failure mode
+to translate — see ``app/services/editions_service.py`` for the sibling
+convention this follows when one is needed.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.models import AppSettings
+from app.schemas import AppSettingsUpdate
+from app.utils import app_settings_to_dict
+
+_SETTINGS_ID = "app_settings"
+
+
+async def get_or_create_settings(db: AsyncSession) -> AppSettings:
+    settings = await db.get(AppSettings, _SETTINGS_ID)
+    if settings is not None:
+        return settings
+
+    # Two concurrent first requests can both see no row and both try to insert
+    # the fixed id; the loser's flush raises IntegrityError rather than a
+    # second row. Roll back and re-fetch instead of erroring out — either
+    # request landing on the same row is a correct outcome here.
+    #
+    # Flushes rather than commits, so the caller controls the transaction
+    # boundary — update_settings folds the row creation, the mutation, and the
+    # audit entry into one atomic commit instead of two separate ones.
+    settings = AppSettings(id=_SETTINGS_ID)
+    db.add(settings)
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        settings = await db.get(AppSettings, _SETTINGS_ID)
+        if settings is None:
+            # The conflicting insert guarantees a row now — assert would do here,
+            # but assertions are stripped under `-O`, silently returning None and
+            # turning this into an AttributeError deep in the caller instead.
+            raise RuntimeError("Application settings row could not be created or reloaded.") from None
+        return settings
+    return settings
+
+
+async def get_settings(db: AsyncSession) -> dict:
+    settings = await get_or_create_settings(db)
+    await db.commit()  # persist a freshly-created default row; a no-op otherwise
+    return app_settings_to_dict(settings)
+
+
+async def update_settings(
+    db: AsyncSession, *, actor: str, body: AppSettingsUpdate, request_id: str | None = None
+) -> dict:
+    settings = await get_or_create_settings(db)
+    if body.maintenance_mode is not None:
+        settings.maintenance_mode = body.maintenance_mode
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="settings_updated",
+        resource_type="app_settings",
+        resource_id=_SETTINGS_ID,
+        request_id=request_id,
+        details={"fields_changed": sorted(body.model_fields_set)},
+    )
+    await db.commit()
+    await db.refresh(settings)
+    return app_settings_to_dict(settings)

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -29,25 +29,36 @@ async def get_or_create_settings(db: AsyncSession) -> AppSettings:
 
     # Two concurrent first requests can both see no row and both try to insert
     # the fixed id; the loser's flush raises IntegrityError rather than a
-    # second row. Roll back and re-fetch instead of erroring out — either
-    # request landing on the same row is a correct outcome here.
+    # second row. The insert runs inside a SAVEPOINT (db.begin_nested()) rather
+    # than the caller's outer transaction, so losing the race only unwinds
+    # this one insert — any other work the caller already queued on `db`
+    # survives instead of being silently discarded by a plain db.rollback().
     #
     # Flushes rather than commits, so the caller controls the transaction
     # boundary — update_settings folds the row creation, the mutation, and the
     # audit entry into one atomic commit instead of two separate ones.
     settings = AppSettings(id=_SETTINGS_ID)
-    db.add(settings)
     try:
-        await db.flush()
-    except IntegrityError:
-        await db.rollback()
+        async with db.begin_nested():
+            db.add(settings)
+            await db.flush()
+    except IntegrityError as exc:
+        # begin_nested() flushes any already-pending work before establishing
+        # the savepoint, so an IntegrityError here could in principle come
+        # from that pre-existing state rather than this insert. Only treat it
+        # as the expected app_settings race if it's actually that constraint —
+        # mirrors editions_service.commit_or_conflict's constraint-name check
+        # for the same reason: anything else must propagate as-is rather than
+        # being misreported as a settings-row race.
+        constraint = getattr(getattr(exc.orig, "__cause__", None), "constraint_name", None)
+        if constraint != "app_settings_pkey":
+            raise
         settings = await db.get(AppSettings, _SETTINGS_ID)
         if settings is None:
             # The conflicting insert guarantees a row now — assert would do here,
             # but assertions are stripped under `-O`, silently returning None and
             # turning this into an AttributeError deep in the caller instead.
             raise RuntimeError("Application settings row could not be created or reloaded.") from None
-        return settings
     return settings
 
 

--- a/backend/app/services/volunteers_service.py
+++ b/backend/app/services/volunteers_service.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from fastapi import HTTPException
 from sqlalchemy import delete, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.audit import write_audit_entry
@@ -190,7 +191,14 @@ async def create_volunteer(
         request_id=request_id,
         details={"help_period_count": len(body.help_periods)},
     )
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="Person with this national register number or eID document number already exists.",
+        ) from exc
     await db.refresh(person)
     periods_map = await load_periods_map(db, [person.id])
     return to_volunteer_out(person, periods_map.get(person.id, []))
@@ -238,7 +246,14 @@ async def apply_volunteer_update(
         request_id=request_id,
         details={"fields_changed": sorted(body.model_fields_set)},
     )
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="Person with this national register number or eID document number already exists.",
+        ) from exc
     await db.refresh(volunteer)
     periods_map = await load_periods_map(db, [volunteer.id])
     return to_volunteer_out(volunteer, periods_map.get(volunteer.id, []))

--- a/backend/app/services/volunteers_service.py
+++ b/backend/app/services/volunteers_service.py
@@ -8,6 +8,11 @@ other ``Person``-backed services. Raises ``HTTPException`` directly (matching
 the pre-existing shared helpers this consolidates, same convention as
 ``app/services/editions_service.py``) rather than the ``ServiceError``
 hierarchy in ``app/services/errors.py``.
+
+Identity fields are normalised via ``people_service.normalise_optional_identity``
+before both the uniqueness check and persistence, matching ``people_service``/
+``members_service`` exactly (alembic revision 014 renormalised pre-existing
+rows so the unique constraint stays valid under the stricter rule).
 """
 
 from __future__ import annotations
@@ -23,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.audit import write_audit_entry
 from app.models import Person, VolunteerPeriod
 from app.schemas import VolunteerCreate, VolunteerHelpPeriodIn, VolunteerUpdate
+from app.services.people_service import normalise_optional_identity
 from app.utils import get_or_404, make_id, person_to_dict, roles_contains
 
 
@@ -42,11 +48,9 @@ async def ensure_unique_fields(
     eid_document_number: str | None = None,
     exclude_id: str | None = None,
 ) -> None:
-    if national_register_number is not None:
-        national_register_number = national_register_number.strip() or None
-    if eid_document_number is not None:
-        eid_document_number = eid_document_number.strip() or None
-
+    """Check for a conflicting row. Callers are expected to have already run
+    values through ``normalise_optional_identity`` (see ``create_volunteer``/
+    ``apply_volunteer_update``) — this only queries with what it's given."""
     if national_register_number is not None:
         stmt = select(Person).where(Person.national_register_number == national_register_number)
         if exclude_id:
@@ -163,18 +167,16 @@ def search_volunteers_stmt(*, q: str | None = None, active: bool | None = None) 
 async def create_volunteer(
     db: AsyncSession, *, body: VolunteerCreate, actor: str, request_id: str | None = None
 ) -> dict:
-    await ensure_unique_fields(
-        db,
-        national_register_number=body.national_register_number,
-        eid_document_number=body.eid_document_number,
-    )
+    nrr = normalise_optional_identity(body.national_register_number)
+    eid = normalise_optional_identity(body.eid_document_number)
+    await ensure_unique_fields(db, national_register_number=nrr, eid_document_number=eid)
 
     person = Person(
         id=make_id("per"),
         name=body.name,
         address=body.address,
-        national_register_number=body.national_register_number,
-        eid_document_number=body.eid_document_number,
+        national_register_number=nrr,
+        eid_document_number=eid,
         active=body.active,
     )
     ensure_volunteer_role(person)
@@ -209,28 +211,24 @@ async def apply_volunteer_update(
 ) -> dict:
     volunteer_id = volunteer.id
 
-    if "national_register_number" in body.model_fields_set and body.national_register_number is not None:
-        await ensure_unique_fields(
-            db,
-            national_register_number=body.national_register_number,
-            exclude_id=volunteer_id,
-        )
-    if "eid_document_number" in body.model_fields_set and body.eid_document_number is not None:
-        await ensure_unique_fields(
-            db,
-            eid_document_number=body.eid_document_number,
-            exclude_id=volunteer_id,
-        )
+    nrr_in_set = "national_register_number" in body.model_fields_set
+    eid_in_set = "eid_document_number" in body.model_fields_set
+    nrr = normalise_optional_identity(body.national_register_number) if nrr_in_set else None
+    eid = normalise_optional_identity(body.eid_document_number) if eid_in_set else None
 
-    for field in (
-        "name",
-        "address",
-        "national_register_number",
-        "eid_document_number",
-        "active",
-    ):
+    if nrr_in_set and nrr is not None:
+        await ensure_unique_fields(db, national_register_number=nrr, exclude_id=volunteer_id)
+    if eid_in_set and eid is not None:
+        await ensure_unique_fields(db, eid_document_number=eid, exclude_id=volunteer_id)
+
+    for field in ("name", "address", "active"):
         if field in body.model_fields_set:
             setattr(volunteer, field, getattr(body, field))
+
+    if nrr_in_set:
+        volunteer.national_register_number = nrr
+    if eid_in_set:
+        volunteer.eid_document_number = eid
 
     if "help_periods" in body.model_fields_set and body.help_periods is not None:
         await replace_help_periods(db, volunteer_id, body.help_periods)

--- a/backend/app/services/volunteers_service.py
+++ b/backend/app/services/volunteers_service.py
@@ -1,0 +1,267 @@
+"""Shared application-service operations for volunteers.
+
+Used by both ``app.routers.volunteers`` (REST) and ``app.mcp.admin.volunteers``
+(MCP). Volunteers are ``Person`` rows tagged with the ``volunteer`` role, with
+help periods stored separately in ``VolunteerPeriod`` — see
+``app.services.people_service``/``app.services.members_service`` for the
+other ``Person``-backed services. Raises ``HTTPException`` directly (matching
+the pre-existing shared helpers this consolidates, same convention as
+``app/services/editions_service.py``) rather than the ``ServiceError``
+hierarchy in ``app/services/errors.py``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import delete, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit import write_audit_entry
+from app.models import Person, VolunteerPeriod
+from app.schemas import VolunteerCreate, VolunteerHelpPeriodIn, VolunteerUpdate
+from app.utils import get_or_404, make_id, person_to_dict, roles_contains
+
+
+def ensure_volunteer_role(person: Person) -> None:
+    roles = set(person.roles or [])
+    roles.add("volunteer")
+    person.roles = sorted(roles)
+
+
+def remove_volunteer_role(person: Person) -> None:
+    person.roles = sorted(role for role in (person.roles or []) if role != "volunteer")
+
+
+async def ensure_unique_fields(
+    db: AsyncSession,
+    national_register_number: str | None = None,
+    eid_document_number: str | None = None,
+    exclude_id: str | None = None,
+) -> None:
+    if national_register_number is not None:
+        national_register_number = national_register_number.strip() or None
+    if eid_document_number is not None:
+        eid_document_number = eid_document_number.strip() or None
+
+    if national_register_number is not None:
+        stmt = select(Person).where(Person.national_register_number == national_register_number)
+        if exclude_id:
+            stmt = stmt.where(Person.id != exclude_id)
+        existing = (await db.execute(stmt)).scalar_one_or_none()
+        if existing is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="Person with this national register number already exists.",
+            )
+
+    if eid_document_number is not None:
+        stmt = select(Person).where(Person.eid_document_number == eid_document_number)
+        if exclude_id:
+            stmt = stmt.where(Person.id != exclude_id)
+        existing = (await db.execute(stmt)).scalar_one_or_none()
+        if existing is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="Person with this eID document number already exists.",
+            )
+
+
+async def replace_help_periods(
+    db: AsyncSession,
+    volunteer_id: str,
+    help_periods: list[VolunteerHelpPeriodIn],
+) -> None:
+    await db.execute(delete(VolunteerPeriod).where(VolunteerPeriod.volunteer_id == volunteer_id))
+    for period in help_periods:
+        db.add(
+            VolunteerPeriod(
+                volunteer_id=volunteer_id,
+                first_help_day=period.first_help_day,
+                last_help_day=period.last_help_day,
+            )
+        )
+
+
+async def load_periods_map(db: AsyncSession, volunteer_ids: list[str]) -> dict[str, list[VolunteerPeriod]]:
+    if not volunteer_ids:
+        return {}
+    rows = (
+        (
+            await db.execute(
+                select(VolunteerPeriod)
+                .where(VolunteerPeriod.volunteer_id.in_(volunteer_ids))
+                .order_by(
+                    VolunteerPeriod.volunteer_id,
+                    VolunteerPeriod.first_help_day,
+                    VolunteerPeriod.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    grouped: dict[str, list[VolunteerPeriod]] = defaultdict(list)
+    for row in rows:
+        grouped[row.volunteer_id].append(row)
+    return grouped
+
+
+async def get_volunteer_or_404(db: AsyncSession, volunteer_id: str) -> Person:
+    volunteer = await get_or_404(db, Person, volunteer_id, "Volunteer not found.")
+    if "volunteer" not in volunteer.roles:
+        raise HTTPException(status_code=404, detail="Volunteer not found.")
+    return volunteer
+
+
+def to_volunteer_out(person: Person, help_periods: list[VolunteerPeriod]) -> dict:
+    d = person_to_dict(person)
+    return {
+        "id": d["id"],
+        "name": d["name"],
+        "address": d["address"],
+        "national_register_number": d["national_register_number"],
+        "eid_document_number": d["eid_document_number"],
+        "active": d["active"],
+        "help_periods": [
+            {
+                "id": period.id,
+                "first_help_day": period.first_help_day,
+                "last_help_day": period.last_help_day,
+            }
+            for period in help_periods
+        ],
+        "created_at": d["created_at"],
+        "updated_at": d["updated_at"],
+    }
+
+
+def search_volunteers_stmt(*, q: str | None = None, active: bool | None = None) -> Any:
+    stmt = select(Person).where(roles_contains("volunteer"))
+
+    if active is not None:
+        stmt = stmt.where(Person.active == active)
+
+    if q:
+        q_escaped = q.strip().replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+        q_like = f"%{q_escaped}%"
+        stmt = stmt.where(
+            or_(
+                Person.name.ilike(q_like, escape="\\"),
+                Person.address.ilike(q_like, escape="\\"),
+                Person.national_register_number.ilike(q_like, escape="\\"),
+                Person.eid_document_number.ilike(q_like, escape="\\"),
+            )
+        )
+
+    return stmt.order_by(Person.created_at.desc(), Person.id.desc())
+
+
+async def create_volunteer(
+    db: AsyncSession, *, body: VolunteerCreate, actor: str, request_id: str | None = None
+) -> dict:
+    await ensure_unique_fields(
+        db,
+        national_register_number=body.national_register_number,
+        eid_document_number=body.eid_document_number,
+    )
+
+    person = Person(
+        id=make_id("per"),
+        name=body.name,
+        address=body.address,
+        national_register_number=body.national_register_number,
+        eid_document_number=body.eid_document_number,
+        active=body.active,
+    )
+    ensure_volunteer_role(person)
+
+    db.add(person)
+    await db.flush()
+    await replace_help_periods(db, person.id, body.help_periods)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="volunteer_created",
+        resource_type="person",
+        resource_id=person.id,
+        request_id=request_id,
+        details={"help_period_count": len(body.help_periods)},
+    )
+    await db.commit()
+    await db.refresh(person)
+    periods_map = await load_periods_map(db, [person.id])
+    return to_volunteer_out(person, periods_map.get(person.id, []))
+
+
+async def apply_volunteer_update(
+    db: AsyncSession, volunteer: Person, body: VolunteerUpdate, *, actor: str, request_id: str | None = None
+) -> dict:
+    volunteer_id = volunteer.id
+
+    if "national_register_number" in body.model_fields_set and body.national_register_number is not None:
+        await ensure_unique_fields(
+            db,
+            national_register_number=body.national_register_number,
+            exclude_id=volunteer_id,
+        )
+    if "eid_document_number" in body.model_fields_set and body.eid_document_number is not None:
+        await ensure_unique_fields(
+            db,
+            eid_document_number=body.eid_document_number,
+            exclude_id=volunteer_id,
+        )
+
+    for field in (
+        "name",
+        "address",
+        "national_register_number",
+        "eid_document_number",
+        "active",
+    ):
+        if field in body.model_fields_set:
+            setattr(volunteer, field, getattr(body, field))
+
+    if "help_periods" in body.model_fields_set and body.help_periods is not None:
+        await replace_help_periods(db, volunteer_id, body.help_periods)
+
+    ensure_volunteer_role(volunteer)
+
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="volunteer_updated",
+        resource_type="person",
+        resource_id=volunteer.id,
+        request_id=request_id,
+        details={"fields_changed": sorted(body.model_fields_set)},
+    )
+    await db.commit()
+    await db.refresh(volunteer)
+    periods_map = await load_periods_map(db, [volunteer.id])
+    return to_volunteer_out(volunteer, periods_map.get(volunteer.id, []))
+
+
+async def delete_volunteer(db: AsyncSession, volunteer: Person, *, actor: str, request_id: str | None = None) -> dict:
+    """Remove the volunteer role from a person (soft archive).
+
+    The underlying ``Person`` record is kept intact so that reservations,
+    membership data, and audit history are preserved. Only the ``volunteer``
+    role and associated help periods are removed.
+    """
+    volunteer_id = volunteer.id
+    await db.execute(delete(VolunteerPeriod).where(VolunteerPeriod.volunteer_id == volunteer_id))
+    remove_volunteer_role(volunteer)
+    await write_audit_entry(
+        db,
+        actor=actor,
+        action="volunteer_role_removed",
+        resource_type="person",
+        resource_id=volunteer_id,
+        request_id=request_id,
+        details={},
+    )
+    await db.commit()
+    return {"deleted": True, "id": volunteer_id}

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -60,7 +60,7 @@ VALID_RESERVATION = {
     "event_title": "Vrijdagavond",
     "guest_count": 2,
     # Registration creation now resolves order_items against the event's real
-    # products server-side (see _resolve_order_items in routers/registrations.py),
+    # products server-side (see app.services.registrations_service.resolve_order_items),
     # so a fixture product_id with no matching Product would be rejected. Tests
     # that care about order contents on creation create a real product first
     # and override this field; everyone else gets an order-free registration.

--- a/backend/tests/test_editions.py
+++ b/backend/tests/test_editions.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.models import AuditEntry, Edition
-from app.routers.editions import _commit_or_conflict
+from app.services.editions_service import commit_or_conflict
 from tests.helpers import ADMIN_HEADERS, VENUE_PAYLOAD, _create_event, _post_registration
 
 
@@ -1322,7 +1322,7 @@ async def test_supersede_is_recorded_in_audit_trail(client, db_session):
 
 @pytest.mark.anyio
 async def test_activation_conflict_that_slips_past_the_dedup_check_returns_409(client, monkeypatch):
-    """If a concurrent request races past `_deactivate_conflicting_editions` (it finds
+    """If a concurrent request races past `deactivate_conflicting_editions` (it finds
     nothing to lock when neither of two brand-new editions is active yet — see that
     function's docstring), the database's partial unique index is the real backstop.
     Simulated here by neutralising the dedup check so the conflict only surfaces at
@@ -1344,12 +1344,12 @@ async def test_activation_conflict_that_slips_past_the_dedup_check_returns_409(c
     )
     assert r.status_code == 201
 
-    from app.routers import editions as editions_router
+    from app.services import editions_service
 
     async def _noop_deactivate(*args, **kwargs):
         return []
 
-    monkeypatch.setattr(editions_router, "_deactivate_conflicting_editions", _noop_deactivate)
+    monkeypatch.setattr(editions_service, "deactivate_conflicting_editions", _noop_deactivate)
 
     r = await client.post(
         "/api/editions",
@@ -1373,7 +1373,7 @@ async def test_activation_conflict_that_slips_past_the_dedup_check_returns_409(c
 
 @pytest.mark.anyio
 async def test_commit_or_conflict_does_not_mislabel_unrelated_integrity_errors(db_session):
-    """`_commit_or_conflict` must only translate the `uq_editions_active_type`
+    """`commit_or_conflict` must only translate the `uq_editions_active_type`
     violation into the activation-conflict 409 — an unrelated IntegrityError (e.g. a
     foreign key violation from a concurrently deleted venue) must propagate as-is for
     `app.main.integrity_error_handler` to report accurately, not get mislabeled as an
@@ -1389,7 +1389,7 @@ async def test_commit_or_conflict_does_not_mislabel_unrelated_integrity_errors(d
         )
     )
     with pytest.raises(IntegrityError):
-        await _commit_or_conflict(db_session)
+        await commit_or_conflict(db_session)
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_exhibitor_retype.py
+++ b/backend/tests/test_exhibitor_retype.py
@@ -78,7 +78,7 @@ async def test_other_retypes_are_unaffected(client):
 
 @pytest.mark.anyio
 async def test_retyping_an_exhibitor_locks_it_against_concurrent_edition_linking(client, engine):
-    """update_exhibitor and _validate_exhibitor_ids both take a row lock on the
+    """update_exhibitor and validate_exhibitor_ids both take a row lock on the
     exhibitor, so a retype-to-vendor and an edition linking that same exhibitor
     into its lineup can't interleave — otherwise a vendor could end up linked to
     an edition despite both endpoints individually refusing that state."""
@@ -99,7 +99,7 @@ async def test_retyping_an_exhibitor_locks_it_against_concurrent_edition_linking
         await holder.execute(select(Exhibitor.id).where(Exhibitor.id == producer_id).with_for_update())
 
         async with factory() as contender:
-            # Simulate _validate_exhibitor_ids's lock attempt for an edition update
+            # Simulate validate_exhibitor_ids's lock attempt for an edition update
             # that's about to link the same exhibitor: it must block.
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(

--- a/backend/tests/test_people.py
+++ b/backend/tests/test_people.py
@@ -662,6 +662,26 @@ async def test_member_invalid_phone_rejected(client):
 
 
 @pytest.mark.anyio
+async def test_member_duplicate_national_register_number_detected_despite_formatting(client):
+    """'93.05.18-223.61' and '93051822361' are the same identity — members_service
+    normalises the same way people_service does (#866), so the second create is
+    rejected as a 409 even though the raw strings differ."""
+    r = await client.post(
+        "/api/members",
+        json={"name": "First Member", "national_register_number": "93.05.18-223.61"},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+
+    r = await client.post(
+        "/api/members",
+        json={"name": "Second Member", "national_register_number": "93051822361"},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code == 409
+
+
+@pytest.mark.anyio
 async def test_delete_member_removes_existing_registrations(client):
     """Deleting a member with existing registrations must not hit the registrations FK RESTRICT."""
     member = await client.post(

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -12,7 +12,10 @@ with a single row) — see the PR description.
 from __future__ import annotations
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
+from app.models import Edition
+from app.services import settings_service
 from tests.helpers import ADMIN_HEADERS
 
 
@@ -55,3 +58,29 @@ async def test_put_settings_toggles_maintenance_mode(client):
     r = await client.put("/api/settings", json={"maintenance_mode": False}, headers=ADMIN_HEADERS)
     assert r.status_code == 200
     assert r.json()["maintenance_mode"] is False
+
+
+@pytest.mark.anyio
+async def test_get_or_create_settings_does_not_mislabel_unrelated_integrity_errors(db_session):
+    """`get_or_create_settings` runs its insert inside a SAVEPOINT
+    (`db.begin_nested()`), but that savepoint flushes any *other* pending work
+    already queued on the session before it's established — so an
+    IntegrityError here can come from that unrelated work rather than the
+    settings-row race. It must only treat an `app_settings_pkey` violation as
+    the expected concurrent-first-request race (mirrors
+    `editions_service.commit_or_conflict`'s constraint-name check) — an
+    unrelated violation (here: an edition referencing a nonexistent venue)
+    must propagate as-is, not get silently swallowed as a settings race and
+    leave the caller's real error masked with a phantom settings row."""
+    db_session.add(
+        Edition(
+            id="edition-fk-race-settings",
+            year=2099,
+            month="march",
+            venue_id="venue-does-not-exist",
+            edition_type="bourse",
+            active=False,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await settings_service.get_or_create_settings(db_session)

--- a/backend/tests/test_volunteers.py
+++ b/backend/tests/test_volunteers.py
@@ -119,6 +119,30 @@ async def test_volunteer_crud_and_constraints(client):
 
 
 @pytest.mark.anyio
+async def test_volunteer_duplicate_national_register_number_detected_despite_formatting(client):
+    """'93.05.18-223.61' and '93051822361' are the same identity — volunteers_service
+    normalises the same way people_service does (#866), so the second create is
+    rejected as a 409 even though the raw strings differ."""
+    payload = {
+        "name": "First Volunteer",
+        "national_register_number": "93.05.18-223.61",
+        "eid_document_number": "BEX000001",
+        "help_periods": [{"first_help_day": "2026-03-15", "last_help_day": "2026-03-17"}],
+    }
+    r = await client.post("/api/volunteers", json=payload, headers=ADMIN_HEADERS)
+    assert r.status_code == 201
+
+    payload = {
+        "name": "Second Volunteer",
+        "national_register_number": "93051822361",
+        "eid_document_number": "BEX000002",
+        "help_periods": [{"first_help_day": "2026-03-15", "last_help_day": "2026-03-17"}],
+    }
+    r = await client.post("/api/volunteers", json=payload, headers=ADMIN_HEADERS)
+    assert r.status_code == 409
+
+
+@pytest.mark.anyio
 async def test_volunteers_support_limit_and_page(client):
     created_ids: set[str] = set()
     for i, name in enumerate(("Vol Alpha", "Vol Bravo", "Vol Charlie")):


### PR DESCRIPTION
## Summary

`app.mcp.admin.editions.create_edition`/`update_edition` duplicated `app.routers.editions.create_edition`/`update_edition` almost line for line. Since the single-active-edition-per-type invariant (#832) depends on both copies staying identical, a future change to one path could silently diverge from the other.

That same shape of problem — MCP admin tools importing private helpers straight out of the REST router module, with the actual CRUD transaction bodies duplicated in both places — turned out to exist across most of the admin surface. PR #827 (closing #807) had proven the shared-service pattern on `areas`/`layouts`/`rooms`/`table_types`/`tables`/`venues` (plus `faq`/`integration_clients` via other PRs), but #807 was closed as completed without migrating the rest. This PR finishes that migration for every remaining domain, not just `editions`.

- Added `app/services/{editions,events,exhibitors,members,people,registrations,settings,volunteers}_service.py`, each holding the create/update/delete transitions, validation, and payload-building logic previously duplicated between the REST router and the MCP admin module.
- `editions`/`events`/`members`/`people`/`registrations`/`settings`/`volunteers` keep the `HTTPException` convention already used by the pre-existing shared helpers they consolidate (REST calls the service unwrapped; MCP translates `HTTPException` → `MCPToolError` via `as_value_error`).
- `exhibitors` had no pre-existing shared-helper convention to preserve, so it's a fresh extraction using the `ServiceError`/`to_http_exception` convention from `app/services/rooms_service.py`/`app/services/layouts_service.py` instead.
- `registrations_service` also collapses two independent-but-identical `get_person_or_404`/`get_event_or_404` copies into direct reuse of `people_service`/`events_service`.
- Each router is now a thin REST adapter; each MCP admin module now imports from the shared service instead of reaching into the router module.
- Updated comments/docstrings across `app/models.py`, `app/routers/exhibitors.py`, `app/schemas.py`, `tests/helpers.py`, and affected tests that referenced the old function locations.
- Updated #860 to track this broadened scope.

Closes #860.

## Test plan

- [x] `uv run ruff check app tests`
- [x] `uv run ty check app`
- [x] `uv run pytest` (871 passed)
